### PR TITLE
Support for custom VST2 responses to effCanDo and VendorSpecifi callsc

### DIFF
--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -652,6 +652,8 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
         {
           return 1;
         }
+        
+        return _this->VSTCanDo((char *) ptr);
       }
       return 0;
     }
@@ -728,7 +730,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
           break;
         }
       }
-      return 0;
+      return _this->VSTVendorSpecific(idx, value, ptr, opt);
     }
     case effGetProgram:
     {

--- a/IPlug/VST2/IPlugVST2.h
+++ b/IPlug/VST2/IPlugVST2.h
@@ -55,6 +55,9 @@ public:
   void OutputSysexFromEditor();
 
 private:
+  virtual VstIntPtr VSTVendorSpecific(VstInt32 idx, VstIntPtr value, void* ptr, float opt) { return 0; }
+  virtual VstIntPtr VSTCanDo(const char* hostString) { return 0; }
+    
   /**
    Called prior to every ProcessBlock call in order to update certain properties and connect buffers if necessary
 


### PR DESCRIPTION
This allows developers to support custom vendor specific VST2 behaviour without affecting current plugins at all. I have used this for NKS support, for instance.