### PR TITLE
Static storage

### DIFF
--- a/IGraphics/Drawing/IGraphicsAGG.cpp
+++ b/IGraphics/Drawing/IGraphicsAGG.cpp
@@ -200,10 +200,15 @@ IGraphicsAGG::IGraphicsAGG(IGEditorDelegate& dlg, int w, int h, int fps, float s
 , mFontContour(mFontCurves)
 {
   DBGMSG("IGraphics AGG @ %i FPS\n", fps);
+    
+  StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
+  storage.Retain();
 }
 
 IGraphicsAGG::~IGraphicsAGG()
 {
+  StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
+  storage.Release();
 }
 
 void IGraphicsAGG::DrawResize()

--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -25,6 +25,8 @@ IGraphicsLice::IGraphicsLice(IGEditorDelegate& dlg, int w, int h, int fps, float
 : IGraphics(dlg, w, h, fps, scale)
 {
   DBGMSG("IGraphics Lice @ %i FPS\n", fps);
+  StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
+  storage.Retain();
 }
 
 IGraphicsLice::~IGraphicsLice() 
@@ -39,6 +41,9 @@ IGraphicsLice::~IGraphicsLice()
   
   DELETE_NULL(mDrawBitmap);
   DELETE_NULL(mTmpBitmap);
+    
+  StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
+  storage.Release()
 }
 
 void IGraphicsLice::DrawResize()

--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -43,7 +43,7 @@ IGraphicsLice::~IGraphicsLice()
   DELETE_NULL(mTmpBitmap);
     
   StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
-  storage.Release()
+  storage.Release();
 }
 
 void IGraphicsLice::DrawResize()

--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -402,10 +402,11 @@ void IGraphicsLice::UpdateLayer()
 
 LICE_IFont* IGraphicsLice::CacheFont(const IText& text, double scale)
 {
+  StaticStorage<LICE_IFont>::Accessor storage(s_fontCache);
   WDL_String hashStr(text.mFont);
   hashStr.AppendFormatted(50, "-%d-%d-%d", text.mSize, text.mOrientation, text.mStyle);
     
-  LICE_CachedFont* font = (LICE_CachedFont*)s_fontCache.Find(hashStr.Get(), scale);
+  LICE_CachedFont* font = (LICE_CachedFont*) storage.Find(hashStr.Get(), scale);
   if (!font)
   {
     font = new LICE_CachedFont;
@@ -448,7 +449,7 @@ LICE_IFont* IGraphicsLice::CacheFont(const IText& text, double scale)
       goto Resize;
     }
 #endif
-    s_fontCache.Add(font, hashStr.Get(), scale);
+    storage.Add(font, hashStr.Get(), scale);
   }
   text.mCached = font;
   text.mCachedScale = scale;

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -241,7 +241,8 @@ IBitmap IGraphicsNanoVG::LoadBitmap(const char* name, int nStates, bool framesAr
     targetScale = GetScreenScale();
 
   // NanoVG does not use the global static cache, since bitmaps are textures linked to a context
-  APIBitmap* pAPIBitmap = mBitmapCache.Find(name, targetScale);
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+  APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
   
   // If the bitmap is not already cached at the targetScale
   if (!pAPIBitmap)
@@ -261,7 +262,7 @@ IBitmap IGraphicsNanoVG::LoadBitmap(const char* name, int nStates, bool framesAr
 
     pAPIBitmap = LoadAPIBitmap(fullPathOrResourceID.Get(), sourceScale, resourceFound, ext);
     
-    mBitmapCache.Add(pAPIBitmap, name, sourceScale);
+    storage.Add(pAPIBitmap, name, sourceScale);
 
     assert(pAPIBitmap);
   }

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -169,7 +169,7 @@ private:
   void SetClipRegion(const IRECT& r) override;
   void UpdateLayer() override;
 
-  StaticStorage<APIBitmap> mBitmapCache; //not actually static
+  StaticStorage<APIBitmap> mBitmapCache; //not actually static (doesn't require retaining or releasing)
   NVGcontext* mVG = nullptr;
   NVGframebuffer* mMainFrameBuffer = nullptr;
     

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -70,11 +70,21 @@ IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 , mMaxHeight(h * 2)
 {
   mFPS = (fps > 0 ? fps : DEFAULT_FPS);
+    
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(s_bitmapCache);
+  bitmapStorage.Retain();
+  StaticStorage<SVGHolder>::Accessor svgStorage(s_SVGCache);
+  svgStorage.Retain();
 }
 
 IGraphics::~IGraphics()
 {
   RemoveAllControls();
+    
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(s_bitmapCache);
+  bitmapStorage.Release();
+  StaticStorage<SVGHolder>::Accessor svgStorage(s_SVGCache);
+  svgStorage.Release();
 }
 
 void IGraphics::SetScreenScale(int scale)

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1118,7 +1118,8 @@ void IGraphics::EnableLiveEdit(bool enable/*, const char* file, int gridsize*/)
 
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
-  SVGHolder* pHolder = s_SVGCache.Find(fileName);
+  StaticStorage<SVGHolder>::Accessor storage(s_SVGCache);
+  SVGHolder* pHolder = storage.Find(fileName);
 
   if(!pHolder)
   {
@@ -1157,7 +1158,7 @@ ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 
     pHolder = new SVGHolder(pImage);
     
-    s_SVGCache.Add(pHolder, path.Get());
+    storage.Add(pHolder, path.Get());
   }
 
   return ISVG(pHolder->mImage);
@@ -1168,7 +1169,8 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
   if (targetScale == 0)
     targetScale = GetScreenScale();
 
-  APIBitmap* pAPIBitmap = s_bitmapCache.Find(name, targetScale);
+  StaticStorage<APIBitmap>::Accessor storage(s_bitmapCache);
+  APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
 
   // If the bitmap is not already cached at the targetScale
   if (!pAPIBitmap)
@@ -1197,7 +1199,7 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
     {
       // Try again in cache for mismatched bitmaps, but load from disk if needed
       if (sourceScale != targetScale)
-        pAPIBitmap = s_bitmapCache.Find(name, sourceScale);
+        pAPIBitmap = storage.Find(name, sourceScale);
 
       if (!pAPIBitmap)
       {
@@ -1231,12 +1233,14 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
 
 void IGraphics::ReleaseBitmap(const IBitmap& bitmap)
 {
-  s_bitmapCache.Remove(bitmap.GetAPIBitmap());
+  StaticStorage<APIBitmap>::Accessor storage(s_bitmapCache);
+  storage.Remove(bitmap.GetAPIBitmap());
 }
 
 void IGraphics::RetainBitmap(const IBitmap& bitmap, const char* cacheName)
 {
-  s_bitmapCache.Add(bitmap.GetAPIBitmap(), cacheName, bitmap.GetScale());
+  StaticStorage<APIBitmap>::Accessor storage(s_bitmapCache);
+  storage.Add(bitmap.GetAPIBitmap(), cacheName, bitmap.GetScale());
 }
 
 IBitmap IGraphics::ScaleBitmap(const IBitmap& inBitmap, const char* name, int scale)
@@ -1284,10 +1288,12 @@ EResourceLocation IGraphics::SearchImageResource(const char* name, const char* t
 
 APIBitmap* IGraphics::SearchBitmapInCache(const char* name, int targetScale, int& sourceScale)
 {
+  StaticStorage<APIBitmap>::Accessor storage(s_bitmapCache);
+    
   // Search target scale, then descending
   for (sourceScale = targetScale; sourceScale > 0; SearchNextScale(sourceScale, targetScale))
   {
-    APIBitmap* pBitmap = s_bitmapCache.Find(name, sourceScale);
+    APIBitmap* pBitmap = storage.Find(name, sourceScale);
 
     if (pBitmap)
       return pBitmap;

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <random>
 #include <chrono>
+#include <string>
+
 
 #include "wdlstring.h"
 #include "ptrlist.h"
@@ -1459,7 +1461,9 @@ public:
     void Add(T* pData, const char* str, double scale = 1.)    { return mStorage.Add(pData, str, scale); }
     void Remove(T* pData)                                     { return mStorage.Remove(pData); }
     void Clear()                                              { return mStorage.Clear(); }
-    
+    void Retain()                                             { return mStorage.Retain(); }
+    void Release()                                            { return mStorage.Release(); }
+      
   private:
     
     StaticStorage& mStorage;
@@ -1538,6 +1542,18 @@ private:
     mDatas.Empty(true);
   };
 
+  void Retain()
+  {
+    mCount++;
+  }
+    
+  void Release()
+  {
+    if (--mCount == 0)
+      Clear();
+  }
+    
+  int mCount;
   WDL_Mutex mMutex;
   WDL_PtrList<DataKey> mDatas;
 };

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -1548,11 +1548,11 @@ private:
     int i, n = mDatas.GetSize();
     for (i = 0; i < n; ++i)
     {
-      // TODO: - this doesn't work - why not?
-      /*
+      // TODO: - this doesn't work - why not? (AH - it seems fine - need to check this)
+      
       DataKey* key = mDatas.Get(i);
       T* data = key->data;
-      delete data;*/
+      delete data;
     }
     mDatas.Empty(true);
   };


### PR DESCRIPTION
This makes static storage threadsafe, and adds reference counting so resources are freed from memory when there are no IGraphics objects for a plug in memory.