### PR TITLE
Fix HostPath on Windows, add INIPath function

### DIFF
--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -132,6 +132,13 @@ void SandboxSafeAppSupportPath(WDL_String& path)
   AppSupportPath(path);
 }
 
+void INIPath(WDL_String& path, const char * pluginName)
+{
+  GetKnownFolder(path, CSIDL_LOCAL_APPDATA);
+
+  path.AppendFormatted(MAX_WIN32_PATH_LEN, "\\%s", pluginName);
+}
+
 #elif defined OS_WEB
 
 void AppSupportPath(WDL_String& path, bool isSystem)

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -79,7 +79,7 @@ static void GetModulePath(HMODULE hModule, WDL_String& path)
   }
 }
 
-void HostPath(WDL_String& path)
+void HostPath(WDL_String& path, const char* bundleID)
 {
   GetModulePath(0, path);
 }

--- a/IPlug/IPlugPaths.h
+++ b/IPlug/IPlugPaths.h
@@ -56,3 +56,8 @@ extern void SandboxSafeAppSupportPath(WDL_String& path);
  * @param pluginName CString to specify the plug-in name, which will be the sub folder (beneath mfrName) in which the .vstpreset files are located
  * @param isSystem Set \c true if you want to obtain the system-wide path, otherwise the path will be in the user's home folder */
 extern void VST3PresetsPath(WDL_String& path, const char* mfrName, const char* pluginName, bool isSystem = true);
+
+/** Get the path to the folder where the App's settings.ini file is stored
+ * @param path WDL_String reference where the path will be put on success or empty string on failure
+ * @param pluginName CString to specify the plug-in name (BUNDLE_NAME from config.h can be used here) */
+extern void INIPath(WDL_String& path, const char * pluginName);

--- a/IPlug/IPlugPaths.mm
+++ b/IPlug/IPlugPaths.mm
@@ -86,6 +86,12 @@ void VST3PresetsPath(WDL_String& path, const char* mfrName, const char* pluginNa
   path.SetFormatted(MAX_MACOS_PATH_LEN, "%s/Audio/Presets/%s/%s/", [pApplicationSupportDirectory UTF8String], mfrName, pluginName);
 }
 
+void INIPath(WDL_String& path, const char* pluginName)
+{
+  AppSupportPath(path, false);
+  path.AppendFormatted(MAX_MACOS_PATH_LEN, "/%s", pluginName);
+}
+
 void AppSupportPath(WDL_String& path, bool isSystem)
 {
   NSArray *pPaths;
@@ -122,6 +128,11 @@ void DesktopPath(WDL_String& path)
 }
 
 void VST3PresetsPath(WDL_String& path, const char* mfrName, const char* pluginName, bool isSystem)
+{
+  path.Set("");
+}
+
+void INIPath(WDL_String& path, const char* pluginName)
 {
   path.Set("");
 }


### PR DESCRIPTION
The INIPath implementation wound up being based on VST3PresetsPath but winds up generating the same folder path as the code in IPlugApp_host.cpp. I decided *not* to include the settings.ini filename in the path because IPlugAppHost::InitState wants the directory before it wants the filename so it can create the directory and file if they aren't there already. This way, if you decide to change InitState to use INIPath, it will look much the same as it does now.