### PR TITLE
BREAKING - pass IParam::Shape by const reference and not pointer

### DIFF
--- a/Examples/IPlugInstrument/IPlugInstrument.cpp
+++ b/Examples/IPlugInstrument/IPlugInstrument.cpp
@@ -7,8 +7,8 @@ IPlugInstrument::IPlugInstrument(IPlugInstanceInfo instanceInfo)
 {
   GetParam(kParamGain)->InitDouble("Gain", 100., 0., 100.0, 0.01, "%");
   GetParam(kParamNoteGlideTime)->InitSeconds("Note Glide Time", 0.1, 2.);
-  GetParam(kParamAttack)->InitDouble("Attack", 10., 1., 1000., 0.1, "ms", IParam::kFlagsNone, "ADSR", new IParam::ShapePowCurve(3.));
-  GetParam(kParamDecay)->InitDouble("Decay", 10., 1., 1000., 0.1, "ms", IParam::kFlagsNone, "ADSR", new IParam::ShapePowCurve(3.));
+  GetParam(kParamAttack)->InitDouble("Attack", 10., 1., 1000., 0.1, "ms", IParam::kFlagsNone, "ADSR", IParam::ShapePowCurve(3.));
+  GetParam(kParamDecay)->InitDouble("Decay", 10., 1., 1000., 0.1, "ms", IParam::kFlagsNone, "ADSR", IParam::ShapePowCurve(3.));
   GetParam(kParamSustain)->InitDouble("Sustain", 50., 0., 100., 1, "%", IParam::kFlagsNone, "ADSR");
   GetParam(kParamRelease)->InitDouble("Release", 10., 1., 1000., 0.1, "ms", IParam::kFlagsNone, "ADSR");
   

--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -84,7 +84,7 @@ double IParam::ShapeExp::ValueToNormalized(double value, const IParam& param) co
 
 IParam::IParam()
 {
-  mShape = new ShapeLinear;
+  mShape.reset(new ShapeLinear);
   memset(mName, 0, MAX_PARAM_NAME_LEN * sizeof(char));
   memset(mLabel, 0, MAX_PARAM_LABEL_LEN * sizeof(char));
   memset(mParamGroup, 0, MAX_PARAM_LABEL_LEN * sizeof(char));
@@ -125,7 +125,7 @@ void IParam::InitInt(const char* name, int defaultVal, int minVal, int maxVal, c
   InitDouble(name, (double) defaultVal, (double) minVal, (double) maxVal, 1.0, label, flags | kFlagStepped, group);
 }
 
-void IParam::InitDouble(const char* name, double defaultVal, double minVal, double maxVal, double step, const char* label, int flags, const char* group, Shape* shape, EParamUnit unit, DisplayFunc displayFunc)
+void IParam::InitDouble(const char* name, double defaultVal, double minVal, double maxVal, double step, const char* label, int flags, const char* group, const Shape& shape, EParamUnit unit, DisplayFunc displayFunc)
 {
   if (mType == kTypeNone) mType = kTypeDouble;
   
@@ -154,23 +154,18 @@ void IParam::InitDouble(const char* name, double defaultVal, double minVal, doub
     ;
   }
     
-  if (shape)
-  {
-    delete mShape;
-    mShape = shape;
-  }
-  
+  mShape.reset(shape.Clone());
   mShape->Init(*this);
 }
 
 void IParam::InitFrequency(const char *name, double defaultVal, double minVal, double maxVal, double step, int flags, const char *group)
 {
-  InitDouble(name, defaultVal, minVal, maxVal, step, "Hz", flags, group, new ShapeExp, kUnitFrequency);
+  InitDouble(name, defaultVal, minVal, maxVal, step, "Hz", flags, group, ShapeExp(), kUnitFrequency);
 }
 
 void IParam::InitSeconds(const char *name, double defaultVal, double minVal, double maxVal, double step, int flags, const char *group)
 {
-  InitDouble(name, defaultVal, minVal, maxVal, step, "Seconds", flags, group, nullptr, kUnitSeconds);
+  InitDouble(name, defaultVal, minVal, maxVal, step, "Seconds", flags, group, ShapeLinear(), kUnitSeconds);
 }
 
 void IParam::InitPitch(const char *name, int defaultVal, int minVal, int maxVal, int flags, const char *group)
@@ -186,17 +181,17 @@ void IParam::InitPitch(const char *name, int defaultVal, int minVal, int maxVal,
 
 void IParam::InitGain(const char *name, double defaultVal, double minVal, double maxVal, double step, int flags, const char *group)
 {
-  InitDouble(name, defaultVal, minVal, maxVal, step, "dB", flags, group, nullptr, kUnitDB);
+  InitDouble(name, defaultVal, minVal, maxVal, step, "dB", flags, group, ShapeLinear(), kUnitDB);
 }
 
 void IParam::InitPercentage(const char *name, double defaultVal, double minVal, double maxVal, int flags, const char *group)
 {
-  InitDouble(name, defaultVal, minVal, maxVal, 1, "%", flags, group, nullptr, kUnitPercentage);
+  InitDouble(name, defaultVal, minVal, maxVal, 1, "%", flags, group, ShapeLinear(), kUnitPercentage);
 }
 
 void IParam::InitAngleDegrees(const char *name, double defaultVal, double minVal, double maxVal, int flags, const char *group)
 {
-  InitDouble(name, defaultVal, minVal, maxVal, 1, "degrees", flags, group, nullptr, kUnitDegrees);
+  InitDouble(name, defaultVal, minVal, maxVal, 1, "degrees", flags, group, ShapeLinear(), kUnitDegrees);
 }
 
 void IParam::Init(const IParam& p, const char* searchStr, const char* replaceStr, const char* newGroup)
@@ -223,7 +218,7 @@ void IParam::Init(const IParam& p, const char* searchStr, const char* replaceStr
     group.Set(newGroup);
   }
   
-  InitDouble(str.Get(), p.mDefault, p.mMin, p.mMax, p.mStep, p.mLabel, p.mFlags, group.Get(), p.mShape->Clone(), p.mUnit, p.mDisplayFunction);
+  InitDouble(str.Get(), p.mDefault, p.mMin, p.mMax, p.mStep, p.mLabel, p.mFlags, group.Get(), *p.mShape, p.mUnit, p.mDisplayFunction);
   
   for (auto i=0; i<p.NDisplayTexts(); i++)
   {

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstring>
 #include <functional>
+#include <memory>
 
 #include "wdlstring.h"
 
@@ -97,15 +98,10 @@ public:
 
   IParam();
 
-  ~IParam()
-  {
-    delete mShape;
-  };
-
   void InitBool(const char* name, bool defaultValue, const char* label = "", int flags = 0, const char* group = "", const char* offText = "off", const char* onText = "on"); // // LABEL not used here TODO: so why have it?
   void InitEnum(const char* name, int defaultValue, int nEnums, const char* label = "", int flags = 0, const char* group = "", const char* listItems = 0, ...); // LABEL not used here TODO: so why have it?
   void InitInt(const char* name, int defaultValue, int minVal, int maxVal, const char* label = "", int flags = 0, const char* group = "");
-  void InitDouble(const char* name, double defaultVal, double minVal, double maxVal, double step, const char* label = "", int flags = 0, const char* group = "", Shape* shape = nullptr, EParamUnit unit = kUnitCustom, DisplayFunc displayFunc = nullptr);
+  void InitDouble(const char* name, double defaultVal, double minVal, double maxVal, double step, const char* label = "", int flags = 0, const char* group = "", const Shape& shape = ShapeLinear(), EParamUnit unit = kUnitCustom, DisplayFunc displayFunc = nullptr);
 
   void InitSeconds(const char* name, double defaultVal = 1., double minVal = 0., double maxVal = 10., double step = 0.1, int flags = 0, const char* group = "");
   void InitFrequency(const char* name, double defaultVal = 1000., double minVal = 0.1, double maxVal = 10000., double step = 0.1, int flags = 0, const char* group = "");
@@ -210,7 +206,7 @@ private:
   char mLabel[MAX_PARAM_LABEL_LEN];
   char mParamGroup[MAX_PARAM_GROUP_LEN];
   
-  Shape* mShape = nullptr;
+  std::unique_ptr<Shape> mShape;
   DisplayFunc mDisplayFunction = nullptr;
 
   WDL_TypedBuf<DisplayText> mDisplayTexts;

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -152,7 +152,7 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
   return pos;
 }
 
-void IPluginBase::InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char *label, int flags, const char *group, IParam::Shape *shape, IParam::EParamUnit unit, IParam::DisplayFunc displayFunc)
+void IPluginBase::InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char *label, int flags, const char *group, const IParam::Shape& shape, IParam::EParamUnit unit, IParam::DisplayFunc displayFunc)
 {
   WDL_String nameStr;
   for (auto p = startIdx; p <= endIdx; p++)

--- a/IPlug/IPlugPluginBase.h
+++ b/IPlug/IPlugPluginBase.h
@@ -271,7 +271,7 @@ public:
    * @param shape A IParam::Shape class to determine how the parameter shape should be skewed
    * @param unit An IParam::EParamUnit which can be used in audiounit plug-ins to specify certain kinds of parameter
    * @param displayFunc An IParam::DisplayFunc lambda function to specify a custom display function */
-  void InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char* label = "", int flags = 0, const char* group = "", IParam::Shape* shape = nullptr, IParam::EParamUnit unit = IParam::kUnitCustom, IParam::DisplayFunc displayFunc = nullptr);
+  void InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char* label = "", int flags = 0, const char* group = "", const IParam::Shape& shape = IParam::ShapeLinear(), IParam::EParamUnit unit = IParam::kUnitCustom, IParam::DisplayFunc displayFunc = nullptr);
   
   /** Clone a range of parameters, optionally doing a string substitution on the parameter name.
    * @param cloneStartIdx The index of the first parameter to clone


### PR DESCRIPTION
This set of commits removes the need to use new when creating shapes for parameters, as shapes are passed by const-reference and the Clone() function is used to copy the shape object, leading to nicer code.

@olilarkin  - I'm hoping you'll like this change, so I'm making a PR because of the breaking nature of the change only - I've tested - it works and most of the changes are simply to follow through the lower level change.