### PR TITLE
Cause Mac APP target to prompt for mic input permission with a dialog

### DIFF
--- a/Examples/IPlugEffect/resources/IPlugEffect-macOS-Info.plist
+++ b/Examples/IPlugEffect/resources/IPlugEffect-macOS-Info.plist
@@ -32,6 +32,8 @@
 	<string>10.11.0</string>
 	<key>NSMainNibFile</key>
 	<string>IPlugEffect-macOS-MainMenu</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs mic access to proecss audio.</string>
 	<key>NSPrincipalClass</key>
 	<string>SWELLApplication</string>
 </dict>


### PR DESCRIPTION
Added NSMicrophoneUsageDescription key to Mac plist as described at https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos