### PR TITLE
Simplify CloseWindow() logic and try to avoid re-entrancy issues

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -19,6 +19,8 @@ IGEditorDelegate::IGEditorDelegate(int nParams)
 
 IGEditorDelegate::~IGEditorDelegate()
 {
+  if (mGraphics)
+	DELETE_NULL(mGraphics);
 }
 
 void IGEditorDelegate::OnUIOpen()
@@ -59,12 +61,17 @@ void* IGEditorDelegate::OpenWindow(void* pParent)
 void IGEditorDelegate::CloseWindow()
 {
   IEditorDelegate::CloseWindow();
-  
-  if(mGraphics)
-    mGraphics->CloseWindow();
-  
-  if(mIGraphicsTransient)
-    DELETE_NULL(mGraphics);
+  IGraphics* pGraphics = mGraphics;
+	
+  mGraphics = nullptr;
+	
+  if (pGraphics)
+  {
+	pGraphics->CloseWindow();
+	  
+	if (mIGraphicsTransient)
+	  delete pGraphics;
+  }
 }
 
 void IGEditorDelegate::SendControlValueFromDelegate(int controlTag, double normalizedValue)

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -20,7 +20,7 @@ IGEditorDelegate::IGEditorDelegate(int nParams)
 IGEditorDelegate::~IGEditorDelegate()
 {
   if (mGraphics)
-	DELETE_NULL(mGraphics);
+    DELETE_NULL(mGraphics);
 }
 
 void IGEditorDelegate::OnUIOpen()
@@ -62,15 +62,14 @@ void IGEditorDelegate::CloseWindow()
 {
   IEditorDelegate::CloseWindow();
   IGraphics* pGraphics = mGraphics;
-	
   mGraphics = nullptr;
-	
+    
   if (pGraphics)
   {
-	pGraphics->CloseWindow();
-	  
-	if (mIGraphicsTransient)
-	  delete pGraphics;
+    pGraphics->CloseWindow();
+    
+    if (mIGraphicsTransient)
+      delete pGraphics;
   }
 }
 

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -229,14 +229,10 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* view = (IGRAPHICS_VIEW*) mView;
     [view removeAllToolTips];
     [view killTimer];
-    mView = nullptr;
-
-    if (view->mGraphics)
-    {
-      [view removeFromSuperview];
-    }
-    [view release];
-      
+	[view removeFromSuperview];
+	[view release];
+	  
+	mView = nullptr;
     OnViewDestroyed();
   }
 }

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -229,10 +229,10 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* view = (IGRAPHICS_VIEW*) mView;
     [view removeAllToolTips];
     [view killTimer];
-	[view removeFromSuperview];
-	[view release];
-	  
-	mView = nullptr;
+    [view removeFromSuperview];
+    [view release];
+      
+    mView = nullptr;
     OnViewDestroyed();
   }
 }

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -862,15 +862,10 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 //    mWebView = nullptr;
 //  }
   
-  if (mGraphics)
-  {
-    IGraphics* pGraphics = mGraphics;
-    mGraphics = nullptr;
-    pGraphics->SetPlatformContext(nullptr);
+  mGraphics->SetPlatformContext(nullptr);
     
-    //For some APIs (AUv2) this is where we know about the window being closed, close via delegate
-    pGraphics->GetDelegate()->CloseWindow();
-  }
+  //For some APIs (AUv2) this is where we know about the window being closed, close via delegate
+  mGraphics->GetDelegate()->CloseWindow();
   [super removeFromSuperview];
 }
 


### PR DESCRIPTION
This attempts to fix #160. I still don't understand exactly the conditions that cause the crash, but it seems to be re-entrancy related. I can't see any race conditions (there is only one thread involved), but I there is an outside chance it is memory corruption/stamping.

What I've done here is:

1 - stop IGEditorDelegate::CloseWindow from running code twice if it does re-enter to stop the crash
2 - fixed a memory leak where mGraphics wasn't deleted for non-transient graphics.

I was getting the crash intermittently with iPlugEffect. Now if I load 10-20 times in a row and quit I get no crash.