### PR TITLE
[BREAKING] Text entry calls / Popup menus

### DIFF
--- a/Examples/IPlugControls/IPlugControls.cpp
+++ b/Examples/IPlugControls/IPlugControls.cpp
@@ -50,7 +50,7 @@ public:
   {
     SetUpMenu();
     
-    GetUI()->CreatePopupMenu(mMainMenu, x, y, this);
+    GetUI()->CreatePopupMenu(*this, mMainMenu, x, y);
   }
   
   void OnPopupMenuSelection(IPopupMenu* pSelectedMenu) override

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -369,18 +369,15 @@ void IPopupMenuControl::DrawSeparator(IGraphics& g, const IRECT& bounds, IBlend*
     g.FillRect(COLOR_MID_GRAY, bounds, &BLEND_25);
 }
 
-IPopupMenu* IPopupMenuControl::CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller)
+void IPopupMenuControl::CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds)
 {
   mMenu = &menu;
-  mCaller = pCaller;
   
   if(mMaxBounds.W() == 0)
     mMaxBounds = GetUI()->GetBounds();
     
   if(GetState() == kCollapsed)
     Expand(bounds);
-  
-  return mMenu;
 }
 
 IRECT IPopupMenuControl::GetLargestCellRectForMenu(IPopupMenu& menu, float x, float y) const
@@ -559,20 +556,7 @@ void IPopupMenuControl::CollapseEverything()
   if(pClickedMenu->GetFunction())
     pClickedMenu->ExecFunction();
   
-  if(mCaller)
-  {
-    if(mIsContextMenu)
-      mCaller->OnContextSelection(pClickedMenu->GetChosenItemIdx());
-    else
-    {
-      if(pClickedMenu->GetChosenItemIdx() == -1)
-        mCaller->OnPopupMenuSelection(nullptr);
-      else
-        mCaller->OnPopupMenuSelection(pClickedMenu);
-    }
-    
-    mIsContextMenu = false;
-  }
+  GetUI()->SetControlValueAfterPopupMenu(pClickedMenu);
     
   mActiveMenuPanel = nullptr;
 

--- a/IGraphics/Controls/IPopupMenuControl.h
+++ b/IGraphics/Controls/IPopupMenuControl.h
@@ -96,18 +96,14 @@ public:
   /** Call this to create a pop-up menu
    @param menu Reference to a menu from which to populate this user interface control. NOTE: this object should not be a temporary, otherwise when the menu returns asynchronously, it may not exist.
    @param bounds \todo
-   @param pCaller The IControl that called this method, and will receive the call back after menu selection
-   @return the menu */
-  IPopupMenu* CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller);
+   @param pCaller The IControl that called this method, and will receive the call back after menu selection */
+  void CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds);
 
   /** @return \true if the pop-up is fully expanded */
   bool GetExpanded() const { return mState == kExpanded; }
 
   /** @return EPopupState indicating the state of the pop-up */
   EPopupState GetState() const { return mState; }
-
-  /** This is called by the IGraphics class when a context menu is being created (a special popup that certain plug-in formats (e.g. VST3) may append to)  */
-  void SetMenuIsContextMenu(bool isContextMenu) { mIsContextMenu = isContextMenu; }
 
   /** Force the menu to open with a specific bounds - useful on small screens for making it modal.*/
   void SetExpandedBounds(const IRECT& bounds) { mSpecifiedExpandedBounds = bounds; }
@@ -181,8 +177,6 @@ private:
   EPopupState mState = kCollapsed; // The state of the pop-up, mainly used for animation
   IRECT* mMouseCellBounds = nullptr;
   IRECT* mPrevMouseCellBounds = nullptr;
-  IControl* mCaller = nullptr; // Pointer to the IControl that created this pop-up menu, for callback
-  bool mIsContextMenu = false;
   IPopupMenu* mMenu = nullptr; // Pointer to the main IPopupMenu, that this control is visualising. This control does not own the menu.
     
   int mMaxColumnItems = 0; // How long the list can get before adding a new column - 0 equals no limit

--- a/IGraphics/Controls/Test/TestDirBrowseControl.h
+++ b/IGraphics/Controls/Test/TestDirBrowseControl.h
@@ -75,7 +75,7 @@ public:
   {
     if(but.Contains(x, y))
     {
-      GetUI()->CreatePopupMenu(mMainMenu, x, y, this);
+      GetUI()->CreatePopupMenu(*this, mMainMenu, x, y);
     }
     else if(useplatbut.Contains(x, y))
     {

--- a/IGraphics/Controls/Test/TestMPSControl.h
+++ b/IGraphics/Controls/Test/TestMPSControl.h
@@ -42,7 +42,7 @@ public:
   void OnMouseDown(float x, float y, const IMouseMod& mod) override
   {
     if(mod.R)
-      GetUI()->CreatePopupMenu(mMenu, x, y, this);
+      GetUI()->CreatePopupMenu(*this, mMenu, x, y);
     
     SetDirty(false);
   }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -150,7 +150,11 @@ void IGraphics::RemoveControls(int fromIdx)
     {
       mInTextEdit = nullptr;
     }
-    
+    if (pControl == mInPopupMenu)
+    {
+      mInPopupMenu = nullptr;
+    }
+
     mControls.Delete(idx--, true);
   }
   
@@ -196,12 +200,15 @@ void IGraphics::SetControlValueAfterTextEdit(const char* str)
 
 void IGraphics::SetControlValueAfterPopupMenu(IPopupMenu* pMenu)
 {
-  if (mIsContextMenu)
-    mInPopUpMenu->OnContextSelection(pMenu->GetChosenItemIdx());
-  else
-    mInPopUpMenu->OnPopupMenuSelection(pMenu->GetChosenItemIdx() == -1 ? nullptr : pMenu);
+  if (!mInPopupMenu)
+    return;
     
-  mInPopUpMenu = nullptr;
+  if (mIsContextMenu)
+    mInPopupMenu->OnContextSelection(pMenu->GetChosenItemIdx());
+  else
+    mInPopupMenu->OnPopupMenuSelection(pMenu->GetChosenItemIdx() == -1 ? nullptr : pMenu);
+    
+  mInPopupMenu = nullptr;
 }
 
 void IGraphics::AttachBackground(const char* name)
@@ -1453,7 +1460,7 @@ void IGraphics::CreateSupportedPopupMenu(IControl& control, IPopupMenu& menu, co
 {
   ReleaseMouseCapture();
     
-  mInPopUpMenu = &control;
+  mInPopupMenu = &control;
   mIsContextMenu = isContext;
     
   if(mPopupControl) // if we are not using platform pop-up menus

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1454,10 +1454,7 @@ void IGraphics::CreateTextEntry(IControl& control, const IText& text, const IREC
   mInTextEdit = &control;
     
   if (mTextEntryControl)
-  {
     mTextEntryControl->CreateTextEntry(bounds, text, str);
-    return;
-  }
   else
     CreatePlatformTextEntry(control.ParamIdx(), text, bounds, control.GetTextEntryLength(), str);
 }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1168,17 +1168,7 @@ void IGraphics::PopupHostContextMenuForParam(IControl* pControl, int paramIdx, f
     if(!contextMenu.NItems())
       return;
 
-    if(mPopupControl) // if we are not using platform popup menus, IPopupMenuControl will not block
-    {
-      mInPopUpMenu = pControl;
-      mIsContextMenu = true;
-      mPopupControl->CreatePopupMenu(contextMenu, IRECT(x, y, x, y));
-    }
-    else
-    {
-      CreatePlatformPopupMenu(contextMenu, IRECT(x, y, x, y)); 
-      pControl->OnContextSelection(contextMenu.GetChosenItemIdx());
-    }
+    CreateSupportedPopupMenu(*pControl, contextMenu, IRECT(x, y, x, y), true);
 #endif
   }
 }
@@ -1459,21 +1449,27 @@ void IGraphics::CreateTextEntry(IControl& control, const IText& text, const IREC
     CreatePlatformTextEntry(control.ParamIdx(), text, bounds, control.GetTextEntryLength(), str);
 }
 
-void IGraphics::CreatePopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds)
+void IGraphics::CreateSupportedPopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds, bool isContext)
 {
   ReleaseMouseCapture();
-
+    
+  mInPopUpMenu = &control;
+  mIsContextMenu = isContext;
+    
   if(mPopupControl) // if we are not using platform pop-up menus
   {
-    mInPopUpMenu = &control;
-    mIsContextMenu = false;
     mPopupControl->CreatePopupMenu(menu, bounds);
   }
   else
   {
     IPopupMenu* pReturnMenu = CreatePlatformPopupMenu(menu, bounds);
-    control.OnPopupMenuSelection(pReturnMenu);
+    SetControlValueAfterPopupMenu(pReturnMenu);
   }
+}
+
+void IGraphics::CreatePopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds)
+{
+  CreateSupportedPopupMenu(control, menu, bounds, false);
 }
 
 void IGraphics::StartLayer(const IRECT& r)

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -174,7 +174,7 @@ void IGraphics::RemoveAllControls()
   mControls.Empty(true);
 }
 
-void IGraphics::SetControlValueFromStringAfterTextEdit(const char* str)
+void IGraphics::SetControlValueAfterTextEdit(const char* str)
 {
   if (!mInTextEdit)
     return;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1456,7 +1456,7 @@ private:
   IControl* mMouseCapture = nullptr;
   IControl* mMouseOver = nullptr;
   IControl* mInTextEdit = nullptr;
-  IControl* mInPopUpMenu = nullptr;
+  IControl* mInPopupMenu = nullptr;
   bool mIsContextMenu;
   int mMouseOverIdx = -1;
   float mMouseDownX = -1.f;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -855,7 +855,7 @@ protected:
    * @param text /todo
    * @param bounds /todo
    * @param str /todo */
-  virtual void CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str = "") = 0;
+  virtual void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) = 0;
   
   /** /todo
    * @param menu /todo
@@ -888,10 +888,9 @@ public:
    * @param bounds Rectangular region of the graphics context that the prompt (e.g. text entry box) should occupy */
   void PromptUserInput(IControl& control, const IRECT& bounds);
 
-  /** Called by the platform class after returning from a prompt (typically a text entry) in order to update a control with a new value
-   * @param control Reference to the control which the call relates to
+  /** Called by the platform class after returning from a text entry in order to update a control with a new value. the base class has a record of the control, so it is not needed here.
    * @param str The new value as a CString */
-  void SetControlValueFromStringAfterPrompt(IControl& control, const char* str);
+  void SetControlValueFromStringAfterTextEdit(const char* str);
 
   /** Shows a pop up/contextual menu in relation to a rectangular region of the graphics context
    * @param menu Reference to an IPopupMenu class populated with the items for the platform menu
@@ -1444,6 +1443,7 @@ private:
   int mIdleTicks = 0;
   IControl* mMouseCapture = nullptr;
   IControl* mMouseOver = nullptr;
+  IControl* mInTextEdit = nullptr;
   int mMouseOverIdx = -1;
   float mMouseDownX = -1.f;
   float mMouseDownY = -1.f;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -862,7 +862,7 @@ protected:
    * @param bounds /todo
    * @param pCaller /todo
    * @return IPopupMenu* /todo */
-  virtual IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller = nullptr) = 0;
+  virtual IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds) = 0;
 
 #pragma mark - Base implementation
 public:
@@ -888,23 +888,28 @@ public:
    * @param bounds Rectangular region of the graphics context that the prompt (e.g. text entry box) should occupy */
   void PromptUserInput(IControl& control, const IRECT& bounds);
 
-  /** Called by the platform class after returning from a text entry in order to update a control with a new value. the base class has a record of the control, so it is not needed here.
+  /** Called by the platform class after returning from a text entry in order to update a control with a new value. The base class has a record of the control, so it is not needed here.
    * @param str The new value as a CString */
   void SetControlValueFromStringAfterTextEdit(const char* str);
+    
+  /** Called by PopupMenuControl in order to update a control with a new value after returning from the non-blocking menu. The base class has a record of the control, so it is not needed here.
+   * @param pReturnMenu The new value as a CString */
+  void SetControlValueAfterPopupMenu(IPopupMenu* pMenu);
 
   /** Shows a pop up/contextual menu in relation to a rectangular region of the graphics context
+   * @param control A reference to the IControl creating this pop-up menu. If it exists IControl::OnPopupMenuSelection() will be called on successful selection
    * @param menu Reference to an IPopupMenu class populated with the items for the platform menu
-   * @param bounds The platform menu will popup at the bottom left hand corner of this rectangular region
-   * @param pCaller A pointed to the IControl creating this pop-up menu. If it exists IControl::OnPopupMenuSelection() will be called on successful selection
-   * @return Pointer to an IPopupMenu that represents the menu that user finally clicked on (might not be the same as menu if they clicked a submenu) */
-  IPopupMenu* CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller = nullptr);
+   * @param bounds The platform menu will popup at the bottom left hand corner of this rectangular region */
+  void CreatePopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds);
 
   /** Shows a pop up/contextual menu at point in the graphics context
+   * @param control A reference to the IControl creating this pop-up menu. If it exists IControl::OnPopupMenuSelection() will be called on successful selection
    * @param x The X coordinate in the graphics context at which to pop up the menu
-   * @param y The Y coordinate in the graphics context at which to pop up the menu
-   * @param pCaller A pointer to the IControl creating this pop-up menu. If it exists IControl::OnPopupMenuSelection() will be called on successful selection
-   * @return Pointer to an IPopupMenu that represents the menu that user finally clicked on (might not be the same as menu if they clicked a submenu) */
-  IPopupMenu* CreatePopupMenu(IPopupMenu& menu, float x, float y, IControl* pCaller = nullptr) { const IRECT bounds = IRECT(x,y,x,y); return CreatePopupMenu(menu, bounds, pCaller); }
+   * @param y The Y coordinate in the graphics context at which to pop up the menu */
+  void CreatePopupMenu(IControl& control, IPopupMenu& menu, float x, float y)
+  {
+    return CreatePopupMenu(control, menu, IRECT(x, y, x, y));
+  }
 
   /** /todo 
    * @param lo /todo
@@ -1444,6 +1449,8 @@ private:
   IControl* mMouseCapture = nullptr;
   IControl* mMouseOver = nullptr;
   IControl* mInTextEdit = nullptr;
+  IControl* mInPopUpMenu = nullptr;
+  bool mIsContextMenu;
   int mMouseOverIdx = -1;
   float mMouseDownX = -1.f;
   float mMouseDownY = -1.f;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -890,7 +890,7 @@ public:
 
   /** Called by the platform class after returning from a text entry in order to update a control with a new value. The base class has a record of the control, so it is not needed here.
    * @param str The new value as a CString */
-  void SetControlValueFromStringAfterTextEdit(const char* str);
+  void SetControlValueAfterTextEdit(const char* str);
     
   /** Called by PopupMenuControl in order to update a control with a new value after returning from the non-blocking menu. The base class has a record of the control, so it is not needed here.
    * @param pReturnMenu The new value as a CString */

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1051,6 +1051,13 @@ private:
    * @param scale /todo */
   void DrawControl(IControl* pControl, const IRECT& bounds, float scale);
   
+  /** Shows a pop up/contextual menu in relation to a rectangular region of the graphics context
+   * @param control A reference to the IControl creating this pop-up menu. If it exists IControl::OnPopupMenuSelection() will be called on successful selection
+   * @param menu Reference to an IPopupMenu class populated with the items for the platform menu
+   * @param bounds The platform menu will popup at the bottom left hand corner of this rectangular region
+   * @param isContext Determines if the menu is a contextual menu or not */
+  void CreateSupportedPopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds, bool isContext);
+    
 protected: // TODO: correct?
   /** /todo */
   void StartResizeGesture() { mResizingInProcess = true; };

--- a/IGraphics/Platforms/IGraphicsIOS.h
+++ b/IGraphics/Platforms/IGraphicsIOS.h
@@ -58,7 +58,7 @@ protected:
   void CachePlatformFont(const char* fontID, const PlatformFontPtr& font) override;
   
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
-  void CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str) override;
+  void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 
 private:
   void* mView = nullptr;

--- a/IGraphics/Platforms/IGraphicsIOS.h
+++ b/IGraphics/Platforms/IGraphicsIOS.h
@@ -57,7 +57,7 @@ protected:
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fontName, ETextStyle style) override;
   void CachePlatformFont(const char* fontID, const PlatformFontPtr& font) override;
   
-  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
+  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds) override;
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 
 private:

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -129,7 +129,7 @@ bool IGraphicsIOS::PromptForColor(IColor& color, const char* str)
   return false;
 }
 
-IPopupMenu* IGraphicsIOS::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller)
+IPopupMenu* IGraphicsIOS::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds)
 {
   IPopupMenu* pReturnMenu = nullptr;
   
@@ -143,9 +143,6 @@ IPopupMenu* IGraphicsIOS::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
   if(pReturnMenu && pReturnMenu->GetFunction())
     pReturnMenu->ExecFunction();
   
-  if(pCaller)
-    pCaller->OnPopupMenuSelection(pReturnMenu); // should fire even if pReturnMenu == nullptr
-
   return pReturnMenu;
 }
 

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -15,9 +15,6 @@
 
 #import "IGraphicsIOS_view.h"
 
-#include "IControl.h"
-#include "IPopupMenuControl.h"
-
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -149,7 +149,7 @@ IPopupMenu* IGraphicsIOS::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
   return pReturnMenu;
 }
 
-void IGraphicsIOS::CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str)
+void IGraphicsIOS::CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str)
 {
 }
 

--- a/IGraphics/Platforms/IGraphicsLinux.h
+++ b/IGraphics/Platforms/IGraphicsLinux.h
@@ -47,5 +47,5 @@ public:
 
 protected:
   IPopupMenu* CreatePlatformPopupMenu(const IPopupMenu& menu, IRECT& bounds) override;
-  void CreatePlatformTextEntry(IControl* pControl, const IText& text, const IRECT& bounds, const char* str) override;
+  void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 }

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -70,7 +70,7 @@ protected:
   void CreatePlatformImGui() override;
 
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
-  void CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str) override;
+  void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 private:
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fileNameOrResID) override;
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fontName, ETextStyle style) override;

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -69,7 +69,7 @@ public:
 protected:
   void CreatePlatformImGui() override;
 
-  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
+  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds) override;
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 private:
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fileNameOrResID) override;

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -510,7 +510,7 @@ bool IGraphicsMac::PromptForColor(IColor& color, const char* str)
   return false;
 }
 
-IPopupMenu* IGraphicsMac::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller)
+IPopupMenu* IGraphicsMac::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds)
 {
   IPopupMenu* pReturnMenu = nullptr;
 
@@ -523,9 +523,6 @@ IPopupMenu* IGraphicsMac::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
   //synchronous
   if(pReturnMenu && pReturnMenu->GetFunction())
     pReturnMenu->ExecFunction();
-
-  if(pCaller)
-    pCaller->OnPopupMenuSelection(pReturnMenu); // should fire even if pReturnMenu == nullptr
 
   return pReturnMenu;
 }

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -530,12 +530,12 @@ IPopupMenu* IGraphicsMac::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
   return pReturnMenu;
 }
 
-void IGraphicsMac::CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str)
+void IGraphicsMac::CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str)
 {
   if (mView)
   {
     NSRect areaRect = ToNSRect(this, bounds);
-    [(IGRAPHICS_VIEW*) mView createTextEntry: control : text: str: areaRect];
+    [(IGRAPHICS_VIEW*) mView createTextEntry: paramIdx : text: str: length: areaRect];
   }
 }
 

--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -89,7 +89,6 @@ inline NSColor* ToNSColor(const IColor& c)
   NSTimer* mTimer;
   IGRAPHICS_TEXTFIELD* mTextFieldView;
   NSCursor* mMoveCursor;
-  IControl* mEdControl; // the control linked to the open text edit
   float mPrevX, mPrevY;
   IRECTList mDirtyRects;
 @public
@@ -124,7 +123,7 @@ inline NSColor* ToNSColor(const IColor& c)
 //text entry
 - (void) removeFromSuperview;
 - (void) controlTextDidEndEditing: (NSNotification*) aNotification;
-- (void) createTextEntry: (IControl&) control : (const IText&) text : (const char*) str : (NSRect) areaRect;
+- (void) createTextEntry: (int) paramIdx : (const IText&) text : (const char*) str : (int) length : (NSRect) areaRect;
 - (void) endUserInput;
 //pop-up menu
 - (IPopupMenu*) createPopupMenu: (IPopupMenu&) menu : (NSRect) bounds;

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -974,7 +974,7 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 {
   char* txt = (char*)[[mTextFieldView stringValue] UTF8String];
 
-  mGraphics->SetControlValueFromStringAfterPrompt(*mEdControl, txt);
+  mGraphics->SetControlValueFromStringAfterTextEdit(txt);
   mGraphics->SetAllControlsDirty();
 
   [self endUserInput ];
@@ -1003,7 +1003,7 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
   else return nullptr;
 }
 
-- (void) createTextEntry: (IControl&) control : (const IText&) text : (const char*) str : (NSRect) areaRect;
+- (void) createTextEntry: (int) paramIdx : (const IText&) text : (const char*) str : (int) length : (NSRect) areaRect;
 {
   if (mTextFieldView)
     return;
@@ -1038,7 +1038,7 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
       break;
   }
 
-  const IParam* pParam = control.GetParam();
+  const IParam* pParam = paramIdx > kNoParameter ? mGraphics->GetDelegate()->GetParam(paramIdx) : nullptr;
 
   // set up formatter
   if (pParam)
@@ -1061,7 +1061,7 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 
     [mTextFieldView setFormatter:[[[IGRAPHICS_FORMATTER alloc] init] autorelease]];
     [[mTextFieldView formatter] setAcceptableCharacterSet:characterSet];
-    [[mTextFieldView formatter] setMaximumLength:control.GetTextEntryLength()];
+    [[mTextFieldView formatter] setMaximumLength:length];
     [characterSet release];
   }
 
@@ -1083,8 +1083,6 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
   NSWindow* pWindow = [self window];
   [pWindow makeKeyAndOrderFront:nil];
   [pWindow makeFirstResponder: mTextFieldView];
-
-  mEdControl = &control;
 }
 
 - (void) endUserInput
@@ -1096,7 +1094,6 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
   [pWindow makeFirstResponder: self];
 
   mTextFieldView = nullptr;
-  mEdControl = nullptr;
 }
 
 - (NSString*) view: (NSView*) pView stringForToolTip: (NSToolTipTag) tag point: (NSPoint) point userData: (void*) pData

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -974,7 +974,7 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 {
   char* txt = (char*)[[mTextFieldView stringValue] UTF8String];
 
-  mGraphics->SetControlValueFromStringAfterTextEdit(txt);
+  mGraphics->SetControlValueAfterTextEdit(txt);
   mGraphics->SetAllControlsDirty();
 
   [self endUserInput ];

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -601,7 +601,7 @@ void IGraphicsWeb::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
 //  input.call<void>("focus");
 }
 
-IPopupMenu* IGraphicsWeb::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller)
+IPopupMenu* IGraphicsWeb::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds)
 {
   return nullptr;
 }

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -554,7 +554,7 @@ void IGraphicsWeb::PromptForDirectory(WDL_String& path)
   inputEl.call<void>("click");
 }
 
-void IGraphicsWeb::CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str)
+void IGraphicsWeb::CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str)
 {
     ShowMessageBox("Warning", "Text entry not yet implemented", kMB_OK);
 //  val input = val::global("document").call<val>("createElement", std::string("input"));
@@ -573,9 +573,9 @@ void IGraphicsWeb::CreatePlatformTextEntry(IControl& control, const IText& text,
 //  dimstr.SetFormatted(32, "%fpx",  bounds.H());
 //  input["style"].set("height", std::string(dimstr.Get()));
 //  
-//  if (control.ParamIdx() > kNoParameter)
+//  if (paramIdx > kNoParameter)
 //  {
-//    const IParam* pParam = control.GetParam();
+//    const IParam* pParam = GetParam(paramIdx);
 //    
 //    switch ( pParam->Type() )
 //    {

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -13,8 +13,6 @@
 #include <emscripten/key_codes.h>
 
 #include "IGraphicsWeb.h"
-#include "IControl.h"
-#include "IPopupMenuControl.h"
 
 using namespace emscripten;
 

--- a/IGraphics/Platforms/IGraphicsWeb.h
+++ b/IGraphics/Platforms/IGraphicsWeb.h
@@ -71,7 +71,7 @@ public:
   
 protected:
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
-  void CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str) override;
+  void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
     
 private:
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fileNameOrResID) override;

--- a/IGraphics/Platforms/IGraphicsWeb.h
+++ b/IGraphics/Platforms/IGraphicsWeb.h
@@ -70,7 +70,7 @@ public:
   double mPrevY = 0.;
   
 protected:
-  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
+  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds) override;
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
     
 private:

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -226,7 +226,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
             case kCommit:
             {
               SendMessage(pGraphics->mParamEditWnd, WM_GETTEXT, MAX_WIN32_PARAM_LEN, (LPARAM) txt);
-              pGraphics->SetControlValueFromStringAfterTextEdit(txt);
+              pGraphics->SetControlValueAfterTextEdit(txt);
               pGraphics->DestroyEditWindow();
             }
             break;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -584,7 +584,6 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
       //  (normally single line edit boxes don't get sent return key messages)
       case WM_GETDLGCODE:
       {
-        if (pGraphics->mEdControl->GetParam()) break;
         LPARAM lres;
         // find out if the original control wants it
         lres = CallWindowProc(pGraphics->mDefEditProc, hWnd, WM_GETDLGCODE, wParam, lParam);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1162,7 +1162,7 @@ HMENU IGraphicsWin::CreateMenu(IPopupMenu& menu, long* pOffsetIdx)
   return hMenu;
 }
 
-IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller)
+IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds)
 {
   long offsetIdx = 0;
   HMENU hMenu = CreateMenu(menu, &offsetIdx);
@@ -1209,9 +1209,6 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
       RECT r = { 0, 0, WindowWidth(), WindowHeight() };
       InvalidateRect(mPlugWnd, &r, FALSE);
     }
-
-    if (pCaller)
-      pCaller->OnPopupMenuSelection(result);
 
     return result;
   }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -173,7 +173,6 @@ void IGraphicsWin::DestroyEditWindow()
    SetWindowLongPtr(mParamEditWnd, GWLP_WNDPROC, (LPARAM) mDefEditProc);
    DestroyWindow(mParamEditWnd);
    mParamEditWnd = nullptr;
-   mEdControl = nullptr;
    mDefEditProc = nullptr;
    DeleteObject(mEditFont);
    mEditFont = nullptr;
@@ -228,7 +227,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
             case kCommit:
             {
               SendMessage(pGraphics->mParamEditWnd, WM_GETTEXT, MAX_WIN32_PARAM_LEN, (LPARAM) txt);
-              pGraphics->SetControlValueFromStringAfterPrompt(*pGraphics->mEdControl, txt);
+              pGraphics->SetControlValueFromStringAfterTextEdit(txt);
               pGraphics->DestroyEditWindow();
             }
             break;
@@ -1221,7 +1220,7 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
   return nullptr;
 }
 
-void IGraphicsWin::CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str)
+void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str)
 {
   if (mParamEditWnd)
     return;
@@ -1260,8 +1259,6 @@ void IGraphicsWin::CreatePlatformTextEntry(IControl& control, const IText& text,
 
   mDefEditProc = (WNDPROC) SetWindowLongPtr(mParamEditWnd, GWLP_WNDPROC, (LONG_PTR) ParamEditProc);
   SetWindowLongPtr(mParamEditWnd, GWLP_USERDATA, 0xdeadf00b);
-
-  mEdControl = &control;
 }
 
 bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -16,7 +16,6 @@
 
 #include "IPlugParameter.h"
 #include "IGraphicsWin.h"
-#include "IControl.h"
 #include "IPopupMenuControl.h"
 #include "IPlugPaths.h"
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -73,7 +73,7 @@ public:
   bool GetTextFromClipboard(WDL_String& str) override;
   
 protected:
-  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
+  IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds) override;
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 
   void SetTooltip(const char* tooltip);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -74,7 +74,7 @@ public:
   
 protected:
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;
-  void CreatePlatformTextEntry(IControl& control, const IText& text, const IRECT& bounds, const char* str) override;
+  void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 
   void SetTooltip(const char* tooltip);
   void ShowTooltip();
@@ -122,7 +122,6 @@ private:
   HFONT mEditFont = nullptr;
   DWORD mPID = 0;
 
-  IControl* mEdControl = nullptr;
   EParamEditMsg mParamEditMsg = kNone;
   bool mShowingTooltip = false;
   float mHiddenCursorX;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -122,6 +122,10 @@ private:
   HFONT mEditFont = nullptr;
   DWORD mPID = 0;
 
+  const IParam* mEditParam = nullptr;
+  IText mEditText;
+  IRECT mEditRECT;
+
   EParamEditMsg mParamEditMsg = kNone;
   bool mShowingTooltip = false;
   float mHiddenCursorX;


### PR DESCRIPTION
This makes it clearer how the flow goes through IGraphics and control tracking is now in the base class - this also fixes some style bugs with windows text entries (which would derive values form the controls, and not the values sent to the methods).

It does change the signature for IGraphics::CreatePopupMenu() but In doing so it makes it consistent with IGraphics::CreateTextEntry()