### PR TITLE
ITextEntryControl implemented for single-line text entry

### DIFF
--- a/Examples/IPlugControls/IPlugControls.cpp
+++ b/Examples/IPlugControls/IPlugControls.cpp
@@ -90,7 +90,7 @@ IPlugControls::IPlugControls(IPlugInstanceInfo instanceInfo)
     pGraphics->AttachCornerResizer(kUIResizerScale, true);
     pGraphics->AttachPanelBackground(COLOR_GRAY);
     pGraphics->EnableTooltips(true);
-//    pGraphics->AttachTextEntryControl();
+    pGraphics->AttachTextEntryControl();
     
     IRECT b = pGraphics->GetBounds().GetPadded(-5);
     

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -87,10 +87,16 @@ void ITextEntryControl::Draw(IGraphics& g)
   g.FillRect(mText.mTextEntryBGColor, mRECT);
   g.DrawText(mText, mEditString.Get(), mRECT);
   
-  //TODO: draw selection rect
-  
-  if(mDrawCursor)
-    g.DrawVerticalLine(mText.mTextEntryFGColor, mRECT.GetVPadded(-2.f), 0.4f);
+  if (mDrawCursor)
+  {
+    float cursorPos = 0.0f;
+    for (int i = 0; i < mCharWidths.GetSize() && i < mEditState.cursor; ++i)
+    {
+      cursorPos += mCharWidths.Get()[i];
+    }
+    cursorPos /= mRECT.W();
+    g.DrawVerticalLine(mText.mTextEntryFGColor, mRECT.GetVPadded(-2.f), cursorPos);
+  }
 }
 
 template<typename Proc>

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -399,13 +399,19 @@ void ITextEntryControl::OnStateChanged()
 
 void ITextEntryControl::OnTextChange()
 {
+  // rebuild the cache when the text changes
+  mCharWidths.Resize(0, false);
   FillCharWidthCache();
 }
 
 void ITextEntryControl::FillCharWidthCache()
 {
+  // only calculate when empty
+  if (mCharWidths.GetSize())
+    return;
+
   const int len = mEditString.GetLength();
-  mCharWidths.Resize(len);
+  mCharWidths.Resize(len, false);
   for (int i = 0; i < len; ++i)
   {
     char c = mEditString.Get()[i];

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -105,9 +105,8 @@ void ITextEntryControl::Draw(IGraphics& g)
 
       selectionEnd += mCharWidths.Get()[i];
     }
-    IRECT selectionRect = mRECT.GetVPadded(-2.f);
-    selectionRect.L = selectionStart;
-    selectionRect.R = selectionEnd;
+    IRECT selectionRect(selectionStart, mRECT.T + row.ymin, selectionEnd, mRECT.T + row.ymax);
+    selectionRect = selectionRect.GetVPadded(-mText.mSize*0.1f);
     IBlend blend(kBlendDefault, 0.2);
     g.FillRect(mText.mTextEntryFGColor, selectionRect, &blend);
   }
@@ -121,9 +120,8 @@ void ITextEntryControl::Draw(IGraphics& g)
     {
       cursorPos += mCharWidths.Get()[i];
     }
-    IRECT cursorRect = mRECT.GetVPadded(-2.f);
-    cursorRect.L = roundf(cursorPos);
-    cursorRect.R = cursorRect.L;
+    IRECT cursorRect(roundf(cursorPos), mRECT.T + row.ymin, roundf(cursorPos), mRECT.T + row.ymax);
+    cursorRect = cursorRect.GetVPadded(-mText.mSize*0.1f);
     g.FillRect(mText.mTextEntryFGColor, cursorRect);
   }
 }
@@ -353,8 +351,6 @@ void ITextEntryControl::Layout(StbTexteditRow* row, ITextEntryControl* _this, in
 
   row->num_chars = _this->mEditString.GetLength();
   row->baseline_y_delta = 1.25;
-  row->ymin = 0.f;
-  row->ymax = static_cast<float> (_this->GetText().mSize);
 
   switch (_this->GetText().mAlign)
   {
@@ -381,6 +377,35 @@ void ITextEntryControl::Layout(StbTexteditRow* row, ITextEntryControl* _this, in
       break;
     }
   }
+
+  switch (_this->GetText().mVAlign)
+  {
+    case IText::kVAlignTop:
+    {
+      row->ymin = 0;
+      break;
+    }
+
+    case IText::kVAlignMiddle:
+    {
+      row->ymin = _this->GetRECT().H()*0.5f - _this->GetText().mSize*0.5f;
+      break;
+    }
+
+    case IText::kVAlignBottom:
+    {
+      row->ymin = _this->GetRECT().H() - _this->GetText().mSize;
+      break;
+    }
+
+    default:
+    {
+      assert(false); // not implemented
+      break;
+    }
+  }
+
+  row->ymax = row->ymin + static_cast<float> (_this->GetText().mSize);
 }
 
 //static

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -360,8 +360,7 @@ void ITextEntryControl::Layout(StbTexteditRow* row, ITextEntryControl* _this, in
   {
     case IText::kAlignNear:
     {
-      // TODO: may want some kind of inset here because the cursor winds up a bit close to the text in Center and Far alignments
-      row->x0 = _this->GetRECT().L; 
+      row->x0 = _this->GetRECT().L + 1; 
       row->x1 = row->x0 + textWidth;
       break;
     }

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -57,6 +57,7 @@
 
 ITextEntryControl::ITextEntryControl()
 : IControl(IRECT())
+, mTargetControl(nullptr)
 {
   stb_textedit_initialize_state(&mEditState, true);
   
@@ -402,12 +403,14 @@ float ITextEntryControl::GetCharWidth(char c, char pc)
   return bounds.W();
 }
 
-void ITextEntryControl::CreateTextEntry(const IRECT& bounds, const IText& text, const char* str)
+void ITextEntryControl::CreateTextEntry(IControl& control, const IRECT& bounds, const IText& text, const char* str)
 {
   SetTargetAndDrawRECTs(bounds);
   SetText(text);
   mText.mFGColor = mText.mTextEntryFGColor;
+  mTargetControl = &control;
   mEditString.Set(str);
+  OnTextChange();
   SetDirty(false);
   mEditing = true;
 }
@@ -415,6 +418,7 @@ void ITextEntryControl::CreateTextEntry(const IRECT& bounds, const IText& text, 
 void ITextEntryControl::DismissEdit()
 {
   mEditing = false;
+  mTargetControl = nullptr;
   SetTargetAndDrawRECTs(IRECT());
   GetUI()->SetAllControlsDirty();
 }
@@ -422,6 +426,11 @@ void ITextEntryControl::DismissEdit()
 void ITextEntryControl::CommitEdit()
 {
   mEditing = false;
+  if (mTargetControl != nullptr)
+  {
+    mTargetControl->OnTextEntryCompletion(mEditString.Get());
+    mTargetControl = nullptr;
+  }
   SetTargetAndDrawRECTs(IRECT());
   GetUI()->SetAllControlsDirty();
 }

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -172,8 +172,10 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
   {
     case kVK_SPACE: stbKey = kVK_SPACE; break;
     case kVK_TAB: return false;
-    case kVK_DELETE: stbKey = kVK_DELETE; break;
-    case kVK_BACK: stbKey = kVK_BACK; break;
+    case kVK_DELETE: stbKey = STB_TEXTEDIT_K_DELETE; break;
+    case kVK_BACK: stbKey = STB_TEXTEDIT_K_BACKSPACE; break;
+    // #TODO: left, right, home, end: on windows will require modifying key handling in IGraphicsWin
+    // #TODO: up and down, once multi-line editing is supported
     case kVK_RETURN: CommitEdit(); break;
     case kVK_ESCAPE: DismissEdit(); break;
     default:

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -282,17 +282,27 @@ void ITextEntryControl::OnStateChanged()
 
 void ITextEntryControl::OnTextChange()
 {
-  //TODO:
+  //TODO: clear character cache here?
 }
 
 void ITextEntryControl::FillCharWidthCache()
 {
-  //TODO:
+  //TODO: should we only do this if the cache is empty?
+  // If so, we'll need to clear the cache when the string changes.
+  const int len = mEditString.GetLength();
+  mCharWidths.Resize(len);
+  char pc = 0;
+  for (int i = 0; i < len; ++i)
+  {
+    char c = mEditString.Get()[i];
+    mCharWidths.Get()[i] = GetCharWidth(c, pc);
+    pc = c;
+  }
 }
 
 void ITextEntryControl::CalcCursorSizes()
 {
-  //TODO:
+  //TODO: cache cursor size and location?
 }
 
 float ITextEntryControl::GetCharWidth(char c, char pc)

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -281,7 +281,7 @@ void ITextEntryControl::CopySelection()
 int ITextEntryControl::DeleteChars(ITextEntryControl* _this, size_t pos, size_t num)
 {
   _this->mEditString.DeleteSub((int) pos, (int) num);
-  
+  _this->OnTextChange();
   return true; // TODO: Error checking
 }
 
@@ -290,6 +290,7 @@ int ITextEntryControl::InsertChars(ITextEntryControl* _this, size_t pos, const c
 {
   WDL_String str = WDL_String(text, (int) num);
   _this->mEditString.Insert(&str, (int) pos);
+  _this->OnTextChange();
   return true; // TODO: Error checking
 }
 
@@ -358,13 +359,11 @@ void ITextEntryControl::OnStateChanged()
 
 void ITextEntryControl::OnTextChange()
 {
-  //TODO: clear character cache here?
+  FillCharWidthCache();
 }
 
 void ITextEntryControl::FillCharWidthCache()
 {
-  //TODO: should we only do this if the cache is empty?
-  // If so, we'll need to clear the cache when the string changes.
   const int len = mEditString.GetLength();
   mCharWidths.Resize(len);
   char pc = 0;

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -216,12 +216,10 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
   
   switch (key.VK)
   {
-    case kVK_SPACE: stbKey = kVK_SPACE; break;
+    case kVK_SPACE: stbKey = ' '; break;
     case kVK_TAB: return false;
     case kVK_DELETE: stbKey = STB_TEXTEDIT_K_DELETE; break;
     case kVK_BACK: stbKey = STB_TEXTEDIT_K_BACKSPACE; break;
-    // #TODO: left, right, home, end: on windows will require modifying key handling in IGraphicsWin
-    // #TODO: up and down, once multi-line editing is supported
     case kVK_RETURN: CommitEdit(); break;
     case kVK_ESCAPE: DismissEdit(); break;
     default:
@@ -233,8 +231,7 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
       if(key.VK >= 'A' && key.VK <= 'Z')
         break;
       else
-      // TODO: need to shift correct bits for VK
-//        stbKey = (key.VK) | VIRTUAL_KEY_BIT;
+        stbKey = (key.VK) | VIRTUAL_KEY_BIT;
       break;
     }
   }

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -450,8 +450,11 @@ void ITextEntryControl::CreateTextEntry(IControl& control, const IRECT& bounds, 
   const IParam* param = mTargetControl->GetParam();
   mParamType = param ? param->Type() : IParam::kTypeNone;
   mEditString.Set(str);
+  mEditState.select_start = 0;
+  mEditState.select_end = mEditString.GetLength();
+  mEditState.cursor = 0;
   OnTextChange();
-  SetDirty(false);
+  SetDirty(true);
   mEditing = true;
 }
 

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -48,7 +48,7 @@
 ((key & VIRTUAL_KEY_BIT) ? 0 : ((key & STB_TEXTEDIT_K_CONTROL) ? 0 : (key & (~0xF0000000))));
 #define STB_TEXTEDIT_GETCHAR(tc, i) ITextEntryControl::GetChar (tc, i)
 #define STB_TEXTEDIT_NEWLINE '\n'
-//#define STB_TEXTEDIT_IS_SPACE(ch) isSpace (ch)
+#define STB_TEXTEDIT_IS_SPACE(ch) isspace(ch)
 #define STB_TEXTEDIT_DELETECHARS ITextEntryControl::DeleteChars
 #define STB_TEXTEDIT_INSERTCHARS ITextEntryControl::InsertChars
 

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -86,7 +86,8 @@ void ITextEntryControl::Draw(IGraphics& g)
 {
   g.FillRect(mText.mTextEntryBGColor, mRECT);
 
-  if (mEditState.select_start != mEditState.select_end)
+  const bool hasSelection = mEditState.select_start != mEditState.select_end;
+  if (hasSelection)
   {
     float selectionStart = 0.0f, selectionEnd = 0.0f;
     const int start = std::min(mEditState.select_start, mEditState.select_end);
@@ -109,7 +110,7 @@ void ITextEntryControl::Draw(IGraphics& g)
 
   g.DrawText(mText, mEditString.Get(), mRECT);
   
-  if (mDrawCursor)
+  if (mDrawCursor && !hasSelection)
   {
     float cursorPos = 0.0f;
     for (int i = 0; i < mCharWidths.GetSize() && i < mEditState.cursor; ++i)
@@ -186,7 +187,10 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
     {
       case 'A':
       {
-        //TODO: Select All
+        CallSTB([&] {
+          mEditState.select_start = 0;
+          mEditState.select_end = mEditString.GetLength();
+        });
         return true;
       }
       case 'X':

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -120,7 +120,7 @@ void ITextEntryControl::Draw(IGraphics& g)
     {
       cursorPos += mCharWidths.Get()[i];
     }
-    IRECT cursorRect(roundf(cursorPos), mRECT.T + row.ymin, roundf(cursorPos), mRECT.T + row.ymax);
+    IRECT cursorRect(roundf(cursorPos-1), mRECT.T + row.ymin, roundf(cursorPos), mRECT.T + row.ymax);
     cursorRect = cursorRect.GetVPadded(-mText.mSize*0.1f);
     g.FillRect(mText.mTextEntryFGColor, cursorRect);
   }

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -221,6 +221,18 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
         }
         return true;
       }
+      case 'Z':
+      {
+        if (key.S)
+        {
+          CallSTB([&]() { stb_textedit_key(this, &mEditState, STB_TEXTEDIT_K_REDO); });
+        }
+        else
+        {
+          CallSTB([&]() { stb_textedit_key(this, &mEditState, STB_TEXTEDIT_K_UNDO); });
+        }
+        return true;
+      }
     
       default:
         break;

--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -195,18 +195,27 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
       }
       case 'X':
       {
-        //TODO: Cut
-        return false;
+        CopySelection();
+        CallSTB([&] {
+          stb_textedit_cut(this, &mEditState);
+        });
+        return true;
       }
       case 'C':
       {
-        //TODO: Copy
-        return false;
+        CopySelection();
+        return true;
       }
       case 'V':
       {
-        //TODO: Paste
-        return false;
+        WDL_String fromClipboard;
+        if (GetUI()->GetTextFromClipboard(fromClipboard))
+        {
+          CallSTB([&] {
+            stb_textedit_paste(this, &mEditState, fromClipboard.Get(), fromClipboard.GetLength());
+          });
+        }
+        return true;
       }
     
       default:
@@ -254,6 +263,18 @@ void ITextEntryControl::OnEndAnimation()
 {
   if(mEditing)
     SetDirty(true);
+}
+
+void ITextEntryControl::CopySelection()
+{
+  if (mEditState.select_start != mEditState.select_end)
+  {
+    const int start = std::min(mEditState.select_start, mEditState.select_end);
+    const int end = std::max(mEditState.select_start, mEditState.select_end);
+    WDL_String selection;
+    selection.Set(mEditString.Get() + start, end - start);
+    GetUI()->SetTextInClipboard(selection);
+  }
 }
 
 //static

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -50,7 +50,7 @@ public:
 //  void OnMouseWheel(float x, float y, const IMouseMod& mod, float d) override;
   void OnEndAnimation() override;
 
-  void CreateTextEntry(const IRECT& bounds, const IText& text, const char* str);
+  void CreateTextEntry(IControl& control, const IRECT& bounds, const IText& text, const char* str);
 
   static int DeleteChars(ITextEntryControl* _this, size_t pos, size_t num);
   static int InsertChars(ITextEntryControl* _this, size_t pos, const char* text, size_t num);
@@ -81,6 +81,7 @@ private:
   bool mCursorSizesValid = false;
   bool mNotifyTextChange = false;
 
+  IControl* mTargetControl;
   STB_TexteditState mEditState;
   WDL_String mEditString;
   WDL_TypedBuf<float> mCharWidths;

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -82,6 +82,7 @@ private:
   bool mNotifyTextChange = false;
 
   IControl* mTargetControl;
+  IParam::EParamType mParamType = IParam::kTypeNone;
   STB_TexteditState mEditState;
   WDL_String mEditString;
   WDL_TypedBuf<float> mCharWidths;

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -43,7 +43,8 @@ public:
 
   void OnMouseDown(float x, float y, const IMouseMod& mod) override;
   bool OnKeyDown(float x, float y, const IKeyPress& key) override;
-//  void OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod& mod) override;
+  void OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod& mod) override;
+  void OnMouseUp(float x, float y, const IMouseMod& mod) override;
 //  void OnMouseOver(float x, float y, const IMouseMod& mod) override;
 //  void OnMouseOut() override;
 //  void OnMouseWheel(float x, float y, const IMouseMod& mod, float d) override;

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -71,6 +71,7 @@ private:
   void FillCharWidthCache();
   void CalcCursorSizes();
   float GetCharWidth (char c, char pc);
+  void CopySelection();
 
   bool mDrawCursor = false;
 

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -70,7 +70,7 @@ private:
   void OnTextChange();
   void FillCharWidthCache();
   void CalcCursorSizes();
-  float GetCharWidth (char c, char pc);
+  float GetCharWidth (char c, char nc);
   void CopySelection();
 
   bool mDrawCursor = false;

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -213,6 +213,18 @@ void IControl::OnPopupMenuSelection(IPopupMenu* pSelectedMenu)
   }
 }
 
+void IControl::OnTextEntryCompletion(const char* str)
+{
+  const IParam* pParam = GetParam();
+
+  if (pParam)
+  {
+    const double v = pParam->StringToValue(str);
+    SetValueFromUserInput(pParam->ToNormalized(v));
+  }
+}
+
+
 void IControl::PromptUserInput()
 {
   if (mParamIdx >= 0 && !mDisablePrompt)

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -140,9 +140,10 @@ public:
    * @param pSelectedMenu If pSelectedMenu is invalid it means the user didn't select anything */
   virtual void OnPopupMenuSelection(IPopupMenu* pSelectedMenu);
 
-  /** Implement this method to hand text input after IGraphics::CreateTextEntry/IControl::PromptUserInput
+  /** Implement this method to handle text input after IGraphics::CreateTextEntry/IControl::PromptUserInput
+   * The default implementation will attempt to convert the string to an appropriate IParam value if this control has an IParam.
    * @param str A CString with the inputted text */
-  virtual void OnTextEntryCompletion(const char* str) {}
+  virtual void OnTextEntryCompletion(const char* str);
 
   /** Implement this to respond to a menu selection from CreateContextMenu(); @see CreateContextMenu() */
   virtual void OnContextSelection(int itemSelected) {}

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1433,7 +1433,7 @@ void IGraphics::CreateTextEntry(IControl& control, const IText& text, const IREC
 {
   if (mTextEntryControl)
   {
-    mTextEntryControl->CreateTextEntry(bounds, text, str);
+    mTextEntryControl->CreateTextEntry(control, bounds, text, str);
     return;
   }
   else

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -757,6 +757,11 @@ public:
    * @return /c true on success */
   virtual bool GetTextFromClipboard(WDL_String& str) = 0;
 
+  /** Set text in the clipboard
+   * @param str A WDL_String that will be used to set the current text in the clipboard
+   * @return /c true on success */
+  virtual bool SetTextInClipboard(const WDL_String& str) = 0;
+
   /** Call this if you modify control tool tips at runtime. \todo explain */
   virtual void UpdateTooltips() = 0;
 

--- a/IGraphics/Platforms/IGraphicsIOS.h
+++ b/IGraphics/Platforms/IGraphicsIOS.h
@@ -49,6 +49,7 @@ public:
   static int GetUserOSVersion();
   
   bool GetTextFromClipboard(WDL_String& str) override;
+  bool SetTextInClipboard(const WDL_String& str) override;
 
   void CreatePlatformImGui() override;
 

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -177,6 +177,11 @@ bool IGraphicsIOS::GetTextFromClipboard(WDL_String& str)
   return false;
 }
 
+bool SetTextInClipboard(const WDL_String& str)
+{
+  return false;
+}
+
 void IGraphicsIOS::CreatePlatformImGui()
 {
 #ifdef IGRAPHICS_IMGUI

--- a/IGraphics/Platforms/IGraphicsLinux.h
+++ b/IGraphics/Platforms/IGraphicsLinux.h
@@ -44,6 +44,7 @@ public:
 
   static int GetUserOSVersion();
   bool GetTextFromClipboard(WDL_String& str) override;
+  bool SetTextInClipboard(const WDL_String& str) override { return false; } // TODO
 
 protected:
   IPopupMenu* CreatePlatformPopupMenu(const IPopupMenu& menu, IRECT& bounds) override;

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -61,6 +61,7 @@ public:
   static int GetUserOSVersion();
 
   bool GetTextFromClipboard(WDL_String& str) override;
+  bool SetTextInClipboard(const WDL_String& str) override { return false; } // TODO
 
   void MeasureText(const IText& text, const char* str, IRECT& bounds) const override;
 

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -61,7 +61,7 @@ public:
   static int GetUserOSVersion();
 
   bool GetTextFromClipboard(WDL_String& str) override;
-  bool SetTextInClipboard(const WDL_String& str) override { return false; } // TODO
+  bool SetTextInClipboard(const WDL_String& str) override;
 
   void MeasureText(const IText& text, const char* str, IRECT& bounds) const override;
 

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -592,6 +592,13 @@ bool IGraphicsMac::GetTextFromClipboard(WDL_String& str)
   }
 }
 
+bool IGraphicsMac::SetTextInClipboard(const WDL_String& str)
+{
+  NSString* pTextForClipboard = [NSString stringWithUTF8String:str.Get()];
+  [[NSPasteboard generalPasteboard] clearContents];
+  return [[NSPasteboard generalPasteboard] setString:pTextForClipboard forType:NSStringPboardType];
+}
+
 void IGraphicsMac::CreatePlatformImGui()
 {
 #ifdef IGRAPHICS_IMGUI

--- a/IGraphics/Platforms/IGraphicsWeb.h
+++ b/IGraphics/Platforms/IGraphicsWeb.h
@@ -56,6 +56,7 @@ public:
   void* GetWindow() override { return nullptr; } // TODO:
   bool WindowIsOpen() override { return GetWindow(); } // TODO: ??
   bool GetTextFromClipboard(WDL_String& str) override;
+  bool SetTextInClipboard(const WDL_String& str) override { return false; } // TODO
   void UpdateTooltips() override {} // TODO:
   int ShowMessageBox(const char* str, const char* caption, EMessageBoxType type) override;
   

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -398,7 +398,8 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       // TODO: should get unicode?
       bool handle = false;
 
-      if (len == 1)
+      // send when len is 0 because wParam might be something like VK_LEFT or VK_HOME, etc.
+      if (len == 0 || len == 1)
       {
         char str[2];
         str[0] = static_cast<char>(character);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -71,6 +71,7 @@ public:
   const char* GetPlatformAPIStr() override { return "win32"; };
 
   bool GetTextFromClipboard(WDL_String& str) override;
+  bool SetTextInClipboard(const WDL_String& str) override;
   
 protected:
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT& bounds, IControl* pCaller) override;


### PR DESCRIPTION
Still needs to have SetTextInClipboard implemented for Web, but should otherwise be functional. I am not able to test a Web version, however.

Also, cut/copy/paste might be finicky in a DAW, depending on whether or not the DAW intercepts special keys, which I know Reaper will do unless you tell it not to.