### PR TITLE
fix setting the background color in a native windows text entry

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -485,7 +485,8 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       SetBkColor(dc, RGB(text.mTextEntryBGColor.R, text.mTextEntryBGColor.G, text.mTextEntryBGColor.B));
       SetTextColor(dc, RGB(text.mTextEntryFGColor.R, text.mTextEntryFGColor.G, text.mTextEntryFGColor.B));
       SetBkMode(dc, OPAQUE);
-      return GetStockObject(DC_BRUSH) != 0;
+      SetDCBrushColor(dc, RGB(text.mTextEntryBGColor.R, text.mTextEntryBGColor.G, text.mTextEntryBGColor.B));
+      return (LRESULT)GetStockObject(DC_BRUSH);
     }
     case WM_DROPFILES:
     {


### PR DESCRIPTION
We need to SetDCBrushColor and then return the DC_BRUSH in order for the background color of parts of the text entry not behind actual text to be the correct color.

Docs for handling WM_CTLCOLOREDIT mention that if the message is handled, it must return the handle to a brush. See: https://docs.microsoft.com/en-us/windows/desktop/controls/wm-ctlcoloredit