### PR TITLE
IGraphics::PathArc winding parameter

### DIFF
--- a/IGraphics/Drawing/IGraphicsAGG.cpp
+++ b/IGraphics/Drawing/IGraphicsAGG.cpp
@@ -279,11 +279,11 @@ void IGraphicsAGG::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int srcX
   }
 }
 
-void IGraphicsAGG::PathArc(float cx, float cy, float r, float aMin, float aMax)
+void IGraphicsAGG::PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding)
 {
   agg::path_storage transformedPath;
     
-  agg::arc arc(cx, cy, r, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f));
+  agg::arc arc(cx, cy, r, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), winding == kWindingCCW);
   arc.approximation_scale(mTransform.scale());
     
   transformedPath.join_path(arc);

--- a/IGraphics/Drawing/IGraphicsAGG.cpp
+++ b/IGraphics/Drawing/IGraphicsAGG.cpp
@@ -283,7 +283,7 @@ void IGraphicsAGG::PathArc(float cx, float cy, float r, float aMin, float aMax, 
 {
   agg::path_storage transformedPath;
     
-  agg::arc arc(cx, cy, r, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), winding == kWindingCCW);
+  agg::arc arc(cx, cy, r, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), winding == kWindingCW);
   arc.approximation_scale(mTransform.scale());
     
   transformedPath.join_path(arc);

--- a/IGraphics/Drawing/IGraphicsAGG.h
+++ b/IGraphics/Drawing/IGraphicsAGG.h
@@ -257,7 +257,7 @@ public:
   void PathClear() override { mPath.remove_all(); }
   void PathClose() override { mPath.close_polygon(); }
 
-  void PathArc(float cx, float cy, float r, float aMin, float aMax) override;
+  void PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding) override;
 
   void PathMoveTo(float x, float y) override;
   void PathLineTo(float x, float y) override;

--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -286,9 +286,12 @@ void IGraphicsCairo::PathClose()
   cairo_close_path(mContext);
 }
 
-void IGraphicsCairo::PathArc(float cx, float cy, float r, float aMin, float aMax)
+void IGraphicsCairo::PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding)
 {
-  cairo_arc(mContext, cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f));
+  if (winding == kWindingCW)
+    cairo_arc(mContext, cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f));
+  else
+    cairo_arc_negative(mContext, cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f));
 }
 
 void IGraphicsCairo::PathMoveTo(float x, float y)

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -58,7 +58,7 @@ public:
       
   void PathClear() override;
   void PathClose() override;
-  void PathArc(float cx, float cy, float r, float aMin, float aMax) override;
+  void PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding) override;
   void PathMoveTo(float x, float y) override;
   void PathLineTo(float x, float y) override;
   void PathCurveTo(float x1, float y1, float x2, float y2, float x3, float y3) override;

--- a/IGraphics/Drawing/IGraphicsCanvas.cpp
+++ b/IGraphics/Drawing/IGraphicsCanvas.cpp
@@ -112,9 +112,9 @@ void IGraphicsCanvas::PathClose()
   GetContext().call<void>("closePath");
 }
 
-void IGraphicsCanvas::PathArc(float cx, float cy, float r, float aMin, float aMax)
+void IGraphicsCanvas::PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding)
 {
-  GetContext().call<void>("arc", cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f));
+  GetContext().call<void>("arc", cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), winding == kWindingCCW);
 }
 
 void IGraphicsCanvas::PathMoveTo(float x, float y)

--- a/IGraphics/Drawing/IGraphicsCanvas.h
+++ b/IGraphics/Drawing/IGraphicsCanvas.h
@@ -45,7 +45,7 @@ public:
 
   void PathClear() override;
   void PathClose() override;
-  void PathArc(float cx, float cy, float r, float aMin, float aMax) override;
+  void PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding) override;
   void PathMoveTo(float x, float y) override;
   void PathLineTo(float x, float y) override;
   void PathCurveTo(float x1, float y1, float x2, float y2, float x3, float y3) override;

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -505,9 +505,9 @@ void IGraphicsNanoVG::PathClose()
   nvgClosePath(mVG);
 }
 
-void IGraphicsNanoVG::PathArc(float cx, float cy, float r, float aMin, float aMax)
+void IGraphicsNanoVG::PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding)
 {
-  nvgArc(mVG, cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), NVG_CW);
+  nvgArc(mVG, cx, cy, r, DegToRad(aMin - 90.f), DegToRad(aMax - 90.f), winding == kWindingCW ? NVG_CW : NVG_CCW);
 }
 
 void IGraphicsNanoVG::PathMoveTo(float x, float y)

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -107,7 +107,7 @@ public:
 
   void PathClear() override;
   void PathClose() override;
-  void PathArc(float cx, float cy, float r, float aMin, float aMax) override;
+  void PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding) override;
   void PathMoveTo(float x, float y) override;
   void PathLineTo(float x, float y) override;
   void PathCurveTo(float x1, float y1, float x2, float y2, float x3, float y3) override;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -604,7 +604,7 @@ public:
    * @param r /todo
    * @param aMin /todo
    * @param aMax /todo */
-  virtual void PathArc(float cx, float cy, float r, float aMin, float aMax) {}
+  virtual void PathArc(float cx, float cy, float r, float aMin, float aMax, EWinding winding = kWindingCW) {}
 
   /** /todo 
    * @param cx /todo

--- a/IGraphics/IGraphicsConstants.h
+++ b/IGraphics/IGraphicsConstants.h
@@ -100,6 +100,12 @@ enum EVColor
   kNumDefaultVColors
 };
 
+enum EWinding
+{
+  kWindingCW,
+  kWindingCCW
+};
+
 enum EFillRule
 {
   kFillWinding,


### PR DESCRIPTION
Arc direction is needed when it is a part of combined path.