### PR TITLE
Editor state serialisation

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -116,7 +116,7 @@ void IGraphics::Resize(int w, int h, float scale)
   if (mCornerResizer)
     mCornerResizer->OnRescale();
 
-  bool parentHasResized = GetDelegate()->EditorPropertiesModified();
+  bool parentHasResized = GetDelegate()->EditorResize();
 
   PlatformResize(parentHasResized);
   ForAllControls(&IControl::OnResize);

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -25,22 +25,7 @@ void IGEditorDelegate::OnUIOpen()
 {
   IEditorDelegate::OnUIOpen();
   
-  int width = GetEditorWidth();
-  int height = GetEditorHeight();
-  float scale = 1.f;
-    
-  // Recall size data (if not present use the defaults above)
-    
-  const IByteChunk& data = GetEditorData();
-    
-  int pos = data.Get(&width, 0);
-  pos = data.Get(&height, pos);
-  pos = data.Get(&scale, pos);
-    
-  if (pos > 0)
-    GetUI()->Resize(width, height, scale);
-    
-  pos = UnSerializeEditorProperties(data, pos);
+  UpdateSizeAndData();
 }
 
 void* IGEditorDelegate::OpenWindow(void* pParent)
@@ -75,6 +60,11 @@ void IGEditorDelegate::CloseWindow()
     }
     mClosing = false;
   }
+}
+
+int IGEditorDelegate::SetEditorData(const IByteChunk& data, int startPos)
+{
+  return UpdateSizeAndData();
 }
 
 void IGEditorDelegate::SendControlValueFromDelegate(int controlTag, double normalizedValue)
@@ -184,4 +174,24 @@ bool IGEditorDelegate::EditorPropertiesModified()
   SerializeEditorProperties(data);
     
   return EditorPropertiesChangedFromUI(mGraphics->WindowWidth(), mGraphics->WindowHeight(), data);
+}
+
+int IGEditorDelegate::UpdateSizeAndData()
+{
+  int width = GetEditorWidth();
+  int height = GetEditorHeight();
+  float scale = 1.f;
+    
+  // Recall size data (if not present use the defaults above)
+    
+  const IByteChunk& data = GetEditorData();
+    
+  int pos = data.Get(&width, 0);
+  pos = data.Get(&height, pos);
+  pos = data.Get(&scale, pos);
+    
+  if (pos > 0)
+    GetUI()->Resize(width, height, scale);
+    
+  return UnSerializeEditorProperties(data, pos);
 }

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -24,7 +24,7 @@ IGEditorDelegate::~IGEditorDelegate()
 void IGEditorDelegate::OnUIOpen()
 {
   IEditorDelegate::OnUIOpen();
-  UpdateSizeAndData(GetEditorData(), 0);
+  UpdateData(GetEditorData(), 0);
 }
 
 void* IGEditorDelegate::OpenWindow(void* pParent)
@@ -63,7 +63,7 @@ void IGEditorDelegate::CloseWindow()
 
 int IGEditorDelegate::SetEditorData(const IByteChunk& data, int startPos)
 {
-  int endPos = UpdateSizeAndData(data, startPos);
+  int endPos = UpdateData(data, startPos);
 
   mEditorData.Clear();
     
@@ -165,7 +165,13 @@ void IGEditorDelegate::AttachGraphics(IGraphics* pGraphics)
   mIGraphicsTransient = false;
 }
 
-bool IGEditorDelegate::EditorPropertiesModified()
+bool IGEditorDelegate::EditorResize()
+{
+  EditorDataModified();
+  return EditorResizeFromUI(mGraphics->WindowWidth(), mGraphics->WindowHeight());
+}
+
+void IGEditorDelegate::EditorDataModified()
 {
   IByteChunk data;
     
@@ -177,12 +183,12 @@ bool IGEditorDelegate::EditorPropertiesModified()
   data.Put(&height);
   data.Put(&scale);
     
-  SerializeEditorProperties(data);
+  SerializeCustomEditorData(data);
     
-  return EditorPropertiesChangedFromUI(mGraphics->WindowWidth(), mGraphics->WindowHeight(), data);
+  EditorDataChangedFromUI(data);
 }
 
-int IGEditorDelegate::UpdateSizeAndData(const IByteChunk& data, int startPos)
+int IGEditorDelegate::UpdateData(const IByteChunk& data, int startPos)
 {
   int width = GetEditorWidth();
   int height = GetEditorHeight();
@@ -194,8 +200,10 @@ int IGEditorDelegate::UpdateSizeAndData(const IByteChunk& data, int startPos)
   startPos = data.Get(&height, startPos);
   startPos = data.Get(&scale, startPos);
     
+  // This may resize the editor
+    
   if (startPos > 0 && GetUI())
     GetUI()->Resize(width, height, scale);
     
-  return UnSerializeEditorProperties(data, startPos);
+  return UnserializeCustomEditorData(data, startPos);
 }

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -30,8 +30,8 @@ public:
   ~IGEditorDelegate();
 
   //IEditorDelegate
-  void* OpenWindow(void* pHandle) final override;
-  void CloseWindow() final override;
+  void* OpenWindow(void* pHandle) final;
+  void CloseWindow() final;
   //The rest should be final, but the WebSocketEditorDelegate needs to override them
   void SendControlValueFromDelegate(int controlTag, double normalizedValue) override;
   void SendControlMsgFromDelegate(int controlTag, int messageTag, int dataSize = 0, const void* pData = nullptr) override;

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -86,7 +86,7 @@ protected:
   std::function<void(IGraphics* pGraphics)> mLayoutFunc = nullptr;
 private:
     
-  int UpdateSizeAndData();
+  int UpdateSizeAndData(const IByteChunk& data, int startPos);
 
   std::unique_ptr<IGraphics> mGraphics;
   bool mIGraphicsTransient = false; // If creating IGraphics on demand this will be true

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -66,27 +66,31 @@ public:
   /** Get a pointer to the IGraphics context */
   IGraphics* GetUI() { return mGraphics.get(); };
 
-  /** Called when the IGraphics context properties are changed
+  /** Called from the UI to resize the editor via the plugin and store editor in the base.
+   & This calls through to EditorResizeFromUI after updating the data.
    * @return \c true if the base API resized the window */
-  bool EditorPropertiesModified();
+  bool EditorResize();
+        
+  /** Should be called when editor data changes*/
+  void EditorDataModified();
   
   /** Override this method to serialize custom editor state data.
   * @param chunk The output bytechunk where data can be serialized
   * @return \c true if serialization was successful*/
-  virtual bool SerializeEditorProperties(IByteChunk& chunk) const { TRACE; return true; }
+  virtual bool SerializeCustomEditorData(IByteChunk& chunk) const { TRACE; return true; }
     
   /** Override this method to unserialize custom editor state data
   * @param chunk The incoming chunk containing the state data.
   * @param startPos The position in the chunk where the data starts
   * @return The new chunk position (endPos)*/
-  virtual int UnSerializeEditorProperties(const IByteChunk& chunk, int startPos) { TRACE; return startPos; }
+  virtual int UnserializeCustomEditorData(const IByteChunk& chunk, int startPos) { TRACE; return startPos; }
     
 protected:
   std::function<IGraphics*()> mMakeGraphicsFunc = nullptr;
   std::function<void(IGraphics* pGraphics)> mLayoutFunc = nullptr;
 private:
     
-  int UpdateSizeAndData(const IByteChunk& data, int startPos);
+  int UpdateData(const IByteChunk& data, int startPos);
 
   std::unique_ptr<IGraphics> mGraphics;
   bool mIGraphicsTransient = false; // If creating IGraphics on demand this will be true

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -37,6 +37,7 @@ public:
   void SendControlMsgFromDelegate(int controlTag, int messageTag, int dataSize = 0, const void* pData = nullptr) override;
   void SendMidiMsgFromDelegate(const IMidiMsg& msg) override;
   void SendParameterValueFromDelegate(int paramIdx, double value, bool normalized) override;
+  int SetEditorData(const IByteChunk& data, int startPos) override;
 
   /** If you override this method you must call the parent! */
   void OnUIOpen() override;
@@ -84,6 +85,8 @@ protected:
   std::function<IGraphics*()> mMakeGraphicsFunc = nullptr;
   std::function<void(IGraphics* pGraphics)> mLayoutFunc = nullptr;
 private:
+    
+  int UpdateSizeAndData();
 
   std::unique_ptr<IGraphics> mGraphics;
   bool mIGraphicsTransient = false; // If creating IGraphics on demand this will be true

--- a/IPlug/AAX/IPlugAAX.cpp
+++ b/IPlug/AAX/IPlugAAX.cpp
@@ -511,7 +511,7 @@ void IPlugAAX::EndInformHostOfParamChange(int idx)
   ReleaseParameter(mParamIDs.Get(idx)->Get());
 }
 
-bool IPlugAAX::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data)
+bool IPlugAAX::EditorResizeFromDelegate(int viewWidth, int viewHeight)
 {
   if (HasUI())
   {
@@ -524,7 +524,7 @@ bool IPlugAAX::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight
     if (pViewInterface && (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight()))
       pViewInterface->GetViewContainer()->SetViewSize(oEffectViewSize);
 
-    IPlugAPIBase::EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data);
+    IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
   }
   
   return true;

--- a/IPlug/AAX/IPlugAAX.h
+++ b/IPlug/AAX/IPlugAAX.h
@@ -87,7 +87,7 @@ public:
   
   void InformHostOfProgramChange() override { }; //NA
   
-  bool EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data) override;
+  bool EditorResizeFromDelegate(int viewWidth, int viewHeight) override;
   
   //IPlug Processor Overrides
   void SetLatency(int samples) override;

--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -33,7 +33,7 @@ IPlugAPP::IPlugAPP(IPlugInstanceInfo instanceInfo, IPlugConfig c)
   CreateTimer();
 }
 
-bool IPlugAPP::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data)
+bool IPlugAPP::EditorResizeFromDelegate(int viewWidth, int viewHeight)
 {
   if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
   {
@@ -45,7 +45,7 @@ bool IPlugAPP::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight
     #endif
   }
   
-  return IPlugAPIBase::EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data);
+  return IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
 }
 
 bool IPlugAPP::SendMidiMsg(const IMidiMsg& msg)

--- a/IPlug/APP/IPlugAPP.h
+++ b/IPlug/APP/IPlugAPP.h
@@ -41,7 +41,7 @@ public:
   void InformHostOfParamChange(int idx, double normalizedValue) override {};
   void EndInformHostOfParamChange(int idx) override {};
   void InformHostOfProgramChange() override {};
-  bool EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data) override;
+  bool EditorResizeFromDelegate(int viewWidth, int viewHeight) override;
 
   //IEditorDelegate
   void SendSysexMsgFromUI(const ISysEx& msg) override;

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -84,11 +84,10 @@ bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) con
   return isEqual;
 }
 
-bool IPlugAPIBase::EditorPropertiesChangedFromDelegate(int width, int height, const IByteChunk& data)
+bool IPlugAPIBase::EditorResizeFromDelegate(int width, int height)
 {
   mEditorWidth = width;
   mEditorHeight = height;
-  mEditorData = data;
 
   return false;
 }

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -105,12 +105,17 @@ public:
   /** Helper method, used to print some info to the console in debug builds. Can be overridden in other IPlugAPIBases, for specific functionality, such as printing UI details. */
   virtual void PrintDebugInfo() const;
 
-  /** Call this method from a delegate, for example if you wish to store graphics dimensions in your plug-in state in order to notify the API of a graphics resize or other layout change.
-   * If calling from a UI interaction use EditorPropertiesChangedFromUI()
+  /** Call this method from a delegate in order to resize the plugin window.
+   * If calling from a UI interaction use EditorResizeFromUI()
    * When this is overridden in subclasses the subclass should call this in order to update the member variables
    * returns a bool to indicate whether the DAW or plugin class has resized the host window */
-  virtual bool EditorPropertiesChangedFromDelegate(int width, int height, const IByteChunk& data);
-
+  virtual bool EditorResizeFromDelegate(int width, int height);
+  
+   /** Call this method from a delegate if you want to store arbitrary data about the editor (e.g. layout/scale info).
+   * If calling from a UI interaction use EditorDataChangedFromUI()
+   * When this is overridden in subclasses the subclass should call this in order to update member variables */
+   virtual void EditorDataChangedFromDelegate(const IByteChunk& data) { mEditorData = data; }
+    
   /** Implemented by the API class, called by the UI (or by a delegate) at the beginning of a parameter change gesture
    * @param paramIdx The parameter that is being changed */
   virtual void BeginInformHostOfParamChange(int paramIdx) {};
@@ -157,7 +162,9 @@ public:
   
   void EndInformHostOfParamChangeFromUI(int paramIdx) override { EndInformHostOfParamChange(paramIdx); }
   
-  bool EditorPropertiesChangedFromUI(int viewWidth, int viewHeight, const IByteChunk& data) override { return EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data); }
+  bool EditorResizeFromUI(int viewWidth, int viewHeight) override { return EditorResizeFromDelegate(viewWidth, viewHeight); }
+    
+  void EditorDataChangedFromUI(const IByteChunk& data) override { EditorDataChangedFromDelegate(data); }
   
   void SendParameterValueFromUI(int paramIdx, double normalisedValue) override
   {

--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -249,6 +249,12 @@ public:
   /** @return An IByteChunk with any arbitrary data that the editor wishes to store  */
   const IByteChunk& GetEditorData() const { return mEditorData; }
   
+  /** This method should be called to set and unserialize editor data from the plugin
+   * @param data A IByteChunk containing the new data
+   * @param startPos Starting point in the chunk
+   * @return The new chunk position (endPos)*/
+  virtual int SetEditorData(const IByteChunk& data, int startPos) { return startPos; }
+
 protected:
   /** The width of the plug-in editor in pixels. Can be updated by resizing, exists here for persistance, even if UI doesn't exist. */
   int mEditorWidth = 0;

--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -209,10 +209,12 @@ public:
    *  You can use it if you restore a preset using a custom preset mechanism. */
   virtual void DirtyParametersFromUI() {};
   
-  /** If the editor changes UI dimensions or other state we need to call into the plug-in API to store state or resize the window in the plugin
-   * This method is implemented in various classes that inherit this interface to implement that behaviour
+  /** If the editor changes UI dimensions we need to call into the plug-in API to  resize the window in the plugin
    * returns a bool to indicate whether the DAW or plugin class has resized the host window */
-  virtual bool EditorPropertiesChangedFromUI(int viewWidth, int viewHeight, const IByteChunk& data) { return false; }
+  virtual bool EditorResizeFromUI(int viewWidth, int viewHeight) { return false; }
+    
+  /** If the editor changes arbitrary data (such as layout/scale) this is called to store data into the plugin*/
+  virtual void EditorDataChangedFromUI(const IByteChunk& data) {}
   
   /** SendMidiMsgFromUI (Abbreviation: SMMFUI)
    * This method should be used  when  sending a MIDI message from the UI. For example clicking on a key in a virtual keyboard.

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -159,7 +159,7 @@ bool IPluginBase::SerializeEditorData(IByteChunk& chunk) const
 
 int IPluginBase::UnserializeEditorData(const IByteChunk& chunk, int startPos)
 {
-  SetEditorData(chunk, startPos);
+  return SetEditorData(chunk, startPos);
 }
 
 void IPluginBase::InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char *label, int flags, const char *group, const IParam::Shape& shape, IParam::EParamUnit unit, IParam::DisplayFunc displayFunc)

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -152,6 +152,16 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
   return pos;
 }
 
+bool IPluginBase::SerializeEditorData(IByteChunk& chunk) const
+{
+  return chunk.PutChunk(&GetEditorData()) > 0;
+}
+
+int IPluginBase::UnserializeEditorData(const IByteChunk& chunk, int startPos)
+{
+  SetEditorData(chunk, startPos);
+}
+
 void IPluginBase::InitParamRange(int startIdx, int endIdx, int countStart, const char* nameFmtStr, double defaultVal, double minVal, double maxVal, double step, const char *label, int flags, const char *group, const IParam::Shape& shape, IParam::EParamUnit unit, IParam::DisplayFunc displayFunc)
 {
   WDL_String nameStr;

--- a/IPlug/IPlugPluginBase.h
+++ b/IPlug/IPlugPluginBase.h
@@ -135,6 +135,17 @@ public:
    * @param startPos The start position in the chunk where parameter values are stored
    * @return The new chunk position (endPos) */
   int UnserializeParams(const IByteChunk& chunk, int startPos);
+    
+  /** Serializes the editor data (such as scale) into a binary chunk.
+   * @param chunk The output chunk to serialize to. Will append data if the chunk has already been started.
+   * @return \c true if the serialization was successful */
+  bool SerializeEditorData(IByteChunk& chunk) const;
+    
+  /** Unserializes editor data (such as scale) into a byte chunk into the plugin.
+   * @param chunk The incoming chunk where editor data stored to unserialize
+   * @param startPos The start position in the chunk where parameter values are stored
+   * @return The new chunk position (endPos) */
+  int UnserializeEditorData(const IByteChunk& chunk, int startPos);
   
   /** Override this method to serialize custom state data, if your plugin does state chunks.
    * @param chunk The output bytechunk where data can be serialized

--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -101,7 +101,7 @@ void IPlugVST2::InformHostOfProgramChange()
   mHostCallback(&mAEffect, audioMasterUpdateDisplay, 0, 0, 0, 0.0f);
 }
 
-bool IPlugVST2::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data)
+bool IPlugVST2::EditorResizeFromDelegate(int viewWidth, int viewHeight)
 {
   bool resized = false;
 
@@ -116,7 +116,7 @@ bool IPlugVST2::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeigh
       resized = mHostCallback(&mAEffect, audioMasterSizeWindow, viewWidth, viewHeight, 0, 0.f);
     }
     
-    IPlugAPIBase::EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data);
+    IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
   }
 
   return resized;

--- a/IPlug/VST2/IPlugVST2.h
+++ b/IPlug/VST2/IPlugVST2.h
@@ -41,7 +41,7 @@ public:
   void EndInformHostOfParamChange(int idx) override;
   void InformHostOfProgramChange() override;
   void HostSpecificInit() override;
-  bool EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data) override;
+  bool EditorResizeFromDelegate(int viewWidth, int viewHeight) override;
 
   //IPlugProcessor
   void SetLatency(int samples) override;

--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -256,14 +256,14 @@ void IPlugVST3::InformHostOfParameterDetailsChange()
   handler->restartComponent(kParamTitlesChanged);
 }
 
-bool IPlugVST3::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data)
+bool IPlugVST3::EditorResizeFromDelegate(int viewWidth, int viewHeight)
 {
   if (HasUI())
   {
     if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
       mView->resize(viewWidth, viewHeight);
 
-    IPlugAPIBase::EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data);
+    IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
   }
   
   return true;

--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -58,12 +58,12 @@ public:
   void EndInformHostOfParamChange(int idx) override;
   void InformHostOfProgramChange() override {}
   void InformHostOfParameterDetailsChange() override;
-  
+  bool EditorResizeFromDelegate(int viewWidth, int viewHeight) override;
+
   // IEditorDelegate
   void DirtyParametersFromUI() override;
   
   // IPlugProcessor
-  bool EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data) override;
   void SetLatency(int samples) override;
   
   // AudioEffect

--- a/IPlug/VST3/IPlugVST3_Controller.cpp
+++ b/IPlug/VST3/IPlugVST3_Controller.cpp
@@ -133,14 +133,14 @@ tresult PLUGIN_API IPlugVST3Controller::getProgramName(ProgramListID listId, int
 //  }
 //}
 
-bool IPlugVST3Controller::EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data)
+bool IPlugVST3Controller::EditorResizeFromDelegate(int viewWidth, int viewHeight)
 {
   if (HasUI())
   {
     if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
       mView->resize(viewWidth, viewHeight);
  
-    IPlugAPIBase::EditorPropertiesChangedFromDelegate(viewWidth, viewHeight, data);
+    IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
   }
   
   return true;

--- a/IPlug/VST3/IPlugVST3_Controller.h
+++ b/IPlug/VST3/IPlugVST3_Controller.h
@@ -73,7 +73,7 @@ public:
   void InformHostOfParamChange(int idx, double normalizedValue) override  { performEdit(idx, normalizedValue); }
   void EndInformHostOfParamChange(int idx) override  { endEdit(idx); }
   void InformHostOfProgramChange() override  { /* TODO: */}
-  bool EditorPropertiesChangedFromDelegate(int viewWidth, int viewHeight, const IByteChunk& data) override;
+  bool EditorResizeFromDelegate(int viewWidth, int viewHeight) override;
   void DirtyParametersFromUI() override;
   
   // IEditorDelegate


### PR DESCRIPTION
Adds hooks for serialising and unserialising editor state. This also reworks editor calls to be more logical and separate arbitrary data from resizing. It doesn't deal with how the plugin actually recalls and saves state, as that needs some extra work, and I'd like to roll that in with storing the version.