### PR TITLE
Auto switch to image surface

### DIFF
--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -632,23 +632,18 @@ void IGraphicsCairo::BeginFrame()
   if(mFrameCount > FPS()
      && mTotTime / mFrameCount > 1. / FPS()
      && mUseImageSurface == false) {
-    
+
     mSurface = mSurfaceImage;
     UpdateCairoContext();
     mUseImageSurface = true;
   }
   mFrameCount++;
 #endif
-  if(mContext)
-    cairo_push_group(mContext);
 }
 
 void IGraphicsCairo::EndFrame()
 {
 #ifdef OS_MAC
-  cairo_pop_group_to_source(mContext);
-  cairo_paint(mContext);
-  
   if (mUseImageSurface) {
     cairo_surface_flush(mSurface);
   

--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -615,13 +615,21 @@ void IGraphicsCairo::SetPlatformContext(void* pContext)
       cairo_fill(mContext);
     }
   }
-
+  
   IGraphics::SetPlatformContext(pContext);
+}
+
+void IGraphicsCairo::BeginFrame()
+{
+  IGraphics::BeginFrame();
+  cairo_push_group(mContext);
 }
 
 void IGraphicsCairo::EndFrame()
 {
 #ifdef OS_MAC
+  cairo_pop_group_to_source(mContext);
+  cairo_paint(mContext);
 #ifdef IMG_TEST
   cairo_surface_flush(mSurface);
   

--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -649,7 +649,8 @@ void IGraphicsCairo::EndFrame()
   
     CGImageRef img = NULL;
     CGRect r = CGRectMake(0, 0, WindowWidth() * GetScreenScale(), WindowHeight()  * GetScreenScale());
-    static CGColorSpaceRef mColorSpace = nullptr;
+    
+    // we should set mColorSpace only the first time the GUI is open
     if (!mColorSpace)
     {
         int v = GetSystemVersion();

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -109,4 +109,13 @@ private:
     
   cairo_t* mContext;
   cairo_surface_t* mSurface;
+
+#ifdef OS_MAC
+  double mPrevTimeStamp = 0.;
+  double mTotTime = 0.;
+  cairo_surface_t* mSurfaceImage;
+  cairo_surface_t* mSurfaceQuartz;
+  bool mUseImageSurface = false;
+  int mFrameCount = 0;
+#endif
 };

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -117,5 +117,6 @@ private:
   cairo_surface_t* mSurfaceQuartz;
   bool mUseImageSurface = false;
   int mFrameCount = 0;
+  CGColorSpaceRef mColorSpace = nullptr;
 #endif
 };

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -68,7 +68,8 @@ public:
   
   IColor GetPoint(int x, int y) override;
   void* GetDrawContext() override { return (void*) mContext; }
-    
+  
+  void BeginFrame() override;
   void EndFrame() override;
   void SetPlatformContext(void* pContext) override;
   void DrawResize() override;

--- a/Tests/IGraphicsStressTest/IGraphicsStressTest.cpp
+++ b/Tests/IGraphicsStressTest/IGraphicsStressTest.cpp
@@ -82,7 +82,8 @@ void IGraphicsStressTest::LayoutUI(IGraphics* pGraphics)
     {
       //        g.StartLayer(r);
       
-      for (int i=0; i<this->mNumberOfThings; i++)
+      //for (int i=0; i<this->mNumberOfThings; i++)
+      for (int i=0; i<1000; i++)
       {
         IRECT rr = r.GetRandomSubRect();
         IColor rc = IColor::GetRandomColor();
@@ -118,7 +119,7 @@ void IGraphicsStressTest::LayoutUI(IGraphics* pGraphics)
     
     //      g.DrawLayer(pCaller->mLayer);
     
-  }, 10000, false, false));
+  }, 10000, true, true));
   
   pGraphics->AttachControl(new ITextControl(bounds.GetGridCell(0, 2, 1), "", IText(100)), kCtrlTagNumThings);
   pGraphics->AttachControl(new ITextControl(bounds.GetGridCell(1, 2, 1), "", IText(100)), kCtrlTagTestNum);


### PR DESCRIPTION
Choose an image surface instead of a quartz one at runtime if for the first second of rendering the frame rate is not as required in PLUG_FPS in config.h because on some Macs image surface is actually faster than CoreGraphics