### PR TITLE
Fix AU timeInfo.mPPQPos being invalid at 0.0

### DIFF
--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -1892,7 +1892,7 @@ void IPlugAU::PreProcess()
     mHostCallbacks.beatAndTempoProc(mHostCallbacks.hostUserData, &currentBeat, &tempo);
 
     if (tempo > 0.0) timeInfo.mTempo = tempo;
-    if (currentBeat> 0.0) timeInfo.mPPQPos = currentBeat;
+    if (currentBeat>= 0.0) timeInfo.mPPQPos = currentBeat;
   }
 
   if (mHostCallbacks.transportStateProc)


### PR DESCRIPTION
0.0 is a valid PPQ position and ITimeInfo initializes mPPQPos at -1 so if the host sends 0 we need to accept it