### PR TITLE
ReleaseMouseCapture called too early 

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -270,7 +270,7 @@ void IGraphicsMac::StoreCursorPosition()
 
 EMsgBoxResult IGraphicsMac::ShowMessageBox(const char* str, const char* caption, EMsgBoxType type, IMsgBoxCompletionHanderFunc completionHandler)
 {
-  ReleaseMouseCapture();
+  //ReleaseMouseCapture();
 
   long result = (long) kCANCEL;
   

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -372,7 +372,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     case WM_LBUTTONUP:
     case WM_RBUTTONUP:
     {
-      ReleaseCapture();
+      //ReleaseCapture();
       IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
       pGraphics->OnMouseUp(info.x, info.y, info.ms);
       return 0;
@@ -902,7 +902,7 @@ void IGraphicsWin::DeactivateGLContext()
 
 EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* text, const char* caption, EMsgBoxType type, IMsgBoxCompletionHanderFunc completionHandler)
 {
-  ReleaseMouseCapture();
+  //ReleaseMouseCapture();
   
   EMsgBoxResult result = static_cast<EMsgBoxResult>(MessageBox(GetMainWnd(), text, caption, static_cast<int>(type)));
   


### PR DESCRIPTION
when displaying info boxes the ReleaseMouseCapture is called too early, this destroys the IControl that called the ShowMessageBox method causing an access violation later on