### PR TITLE
Invalid ppq pos set by AAX wrapper

### DIFF
--- a/IPlug/AAX/IPlugAAX.cpp
+++ b/IPlug/AAX/IPlugAAX.cpp
@@ -308,6 +308,9 @@ void IPlugAAX::RenderAudio(AAX_SIPlugRenderInfo* pRenderInfo)
     
     mTransport->GetCurrentTickPosition(&ppqPos);
     timeInfo.mPPQPos = (double) ppqPos / 960000.0;
+    if(timeInfo.mPPQPos < 0) {
+      timeInfo.mPPQPos = 0;
+    }
     
     mTransport->GetCurrentNativeSampleLocation(&samplePos);
     timeInfo.mSamplePos = (double) samplePos;


### PR DESCRIPTION
Sometimes PT sends a negative or invalid number in the

mTransport->GetCurrentTickPosition(&ppqPos);

call that is used to set TimeInfo ppqPos this fix prevent this from happening