### PR TITLE
ADSREnvelope callback to notify when released

### DIFF
--- a/IPlug/Extras/ADSREnvelope.h
+++ b/IPlug/Extras/ADSREnvelope.h
@@ -58,6 +58,8 @@ private:
   bool mSustainEnabled = true; // when false env is AD only
   
   std::function<void()> mResetFunc = nullptr; // reset func
+    
+  std::function<void()> mEndReleaseFunc = nullptr; // end release func
 
 public:
   ADSREnvelope(const char* name = "", std::function<void()> resetFunc = nullptr, bool sustainEnabled = true)
@@ -212,6 +214,8 @@ public:
         {
           mStage = kIdle;
           mEnvValue = 0.;
+            if(mEndReleaseFunc)
+                mEndReleaseFunc();
         }
         result = mEnvValue * mReleaseLevel;
         break;
@@ -239,6 +243,8 @@ public:
           mEnvValue = 0.;
           mPrevResult = 0.;
           mReleaseLevel = 0.;
+            if(mEndReleaseFunc)
+                mEndReleaseFunc();
         }
         result = mEnvValue * mReleaseLevel;
         break;
@@ -251,6 +257,9 @@ public:
     mPrevOutput = (result * mLevel);
     return mPrevOutput;
   }
+    
+    inline void SetEndReleaseFunc(std::function<void()> func) { mEndReleaseFunc = func; }
+    
 private:
   inline T CalcIncrFromTimeLinear(T timeMS, T sr) const
   {


### PR DESCRIPTION
Use case:

I want to trigger an envelope with `sustainEnabled = false`

to do that I have a 2 states button (play/stop). When the envelope run is over according to _attack_ and _decay_ values I want my play button turns to the "play state"

therefore I can write:

`mAMPEnv.SetEndReleaseFunc([&](){
          static_cast<IVButtonControl*>(GetUI()->GetControlWithTag(mFilterEnvelopeButton))->SetShape(EVShape::Triangle);
          isPlaying = false;
      });`

I didn't find another way to achieve this other than adding a new callback triggered at the end of a release state. If a better solution already exists please discard the pull request and let us know the correct strategy.

thanks
