### PR TITLE
Multiline Tooltips

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -36,6 +36,8 @@ static double sFPS = 0.0;
 #define IPLUG_TIMER_ID 2
 #define IPLUG_WIN_MAX_WIDE_PATH 4096
 
+#define TOOLTIPWND_MAXWIDTH 250
+
 #pragma mark - Private Classes and Structs
 
 // Fonts
@@ -986,6 +988,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
         TOOLINFO ti = { TTTOOLINFOA_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR)mPlugWnd };
         ti.lpszText = (LPTSTR)NULL;
         SendMessage(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM)&ti);
+        SendMessage(mTooltipWnd, TTM_SETMAXTIPWIDTH, 0, TOOLTIPWND_MAXWIDTH);
         ok = true;
       }
     }


### PR DESCRIPTION
Enables multiline tooltips. Breaks the tooltip at a certain width to make longer tooltips well readable. You can also use \n in tooltip strings now.

Just for IGraphicsWin.cpp

Would be useful for mac as well I guess, unless the mac graphics already have multiline tooltips.