### PR TITLE
Some MacOS mods to make it build with cmake and clion

### DIFF
--- a/IPlug/AUv2/IPlugAU_view_factory.mm
+++ b/IPlug/AUv2/IPlugAU_view_factory.mm
@@ -54,7 +54,11 @@ static const AudioUnitPropertyID kIPlugObjectPropertyID = UINT32_MAX-100;
     {
       if (mPlug->HasUI())
       {
+#if __has_feature(objc_arc)
+        NSView* pView = (__bridge NSView*) mPlug->OpenWindow(nullptr);
+#else
         NSView* pView = (NSView*) mPlug->OpenWindow(nullptr);
+#endif
         return pView;
       }
     }

--- a/IPlug/IPlugPaths.mm
+++ b/IPlug/IPlugPaths.mm
@@ -18,7 +18,7 @@
 #include <string>
 #include <map>
 
-#if defined OS_IOS
+#if defined(OS_IOS) || defined(OS_MAC)
 #import <Foundation/Foundation.h>
 #endif
 


### PR DESCRIPTION
* #import <Foundation/Foundation.h> is needed by MacOS otherwise some…… types are undefined (build errors)

* __bridge is needed if ARC is on