### PR TITLE
Add ClampZero method to IColor

### DIFF
--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -183,7 +183,10 @@ struct IColor
   
   /** /todo */
   void Clamp() { A = Clip(A, 0, 255); R = Clip(R, 0, 255); Clip(G, 0, 255); B = Clip(B, 0, 255); }
-  
+
+  /** /todo */
+  void ClampZero() { A = ClipLo(A, 0); R = ClipLo(R, 0); ClipLo(G, 0); B = ClipLo(B, 0); }
+
   /** /todo 
    * @param alpha */
   void Randomise(int alpha = 255) { A = alpha; R = std::rand() % 255; G = std::rand() % 255; B = std::rand() % 255; }

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -50,6 +50,13 @@ BEGIN_IPLUG_NAMESPACE
 template <typename T>
 T Clip(T x, T lo, T hi) { return std::min(std::max(x, lo), hi); }
 
+/** Clips the value \p x to \p lo
+ * @param x Input value
+ * @param lo Minimum value to be allowed
+ * If \p x is lower than the low value, it will be set to \p lo */
+template <typename T>
+T ClipLo(T x, T lo) { return std::max(x, lo); }
+
 static inline bool CStringHasContents(const char* str) { return str && str[0] != '\0'; }
 
 #define MAKE_QUOTE(str) #str


### PR DESCRIPTION
For performance reasons, ClampZero is faster than Clamp (if it's sure that the values are not bigger than 255). Used in my projects for years.