### PR TITLE
IControl: assert when gfx isn't attached

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -388,6 +388,7 @@ public:
   {
     mDelegate = &dlg;
     mGraphics = dlg.GetUI();
+    assert(mGraphics && "Graphics not attached");
     OnInit();
     OnResize();
     OnRescale();


### PR DESCRIPTION
Coming from IPlug1 it easily happens, that AttachGraphics is called after attaching controls. This crashes the initialization of controls.