### PR TITLE
Rename standalone to app api

### DIFF
--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -76,7 +76,7 @@ const char* IPluginBase::GetAPIStr() const
     case kAPIVST3: return "VST3";
     case kAPIAU: return "AU";
     case kAPIAAX: return "AAX";
-    case kAPIAPP: return "Standalone";
+    case kAPIAPP: return "APP";
     case kAPIWAM: return "WAM";
     case kAPIWEB: return "WEB";
     default: return "";


### PR DESCRIPTION
Displaying API strings at a plug-in UI reveals that the string is to long and this change here would make it a lot more consistent.