### PR TITLE
Introduce OnUnserializeParamSet

### DIFF
--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -129,7 +129,13 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
     IParam* pParam = mParams.Get(i);
     double v = 0.0;
     pos = chunk.Get(&v, pos);
-    pParam->Set(v);
+    if (pos > -1)
+    {
+      if (OnUnserializeParamSet(i, v))
+      {
+        pParam->Set(v);
+      }
+    }
     Trace(TRACELOC, "%d %s %f", i, pParam->GetNameForHost(), pParam->Value());
   }
 

--- a/IPlug/IPlugPluginBase.h
+++ b/IPlug/IPlugPluginBase.h
@@ -124,7 +124,13 @@ public:
    * @param startPos The start position in the chunk where parameter values are stored
    * @return The new chunk position (endPos) */
   int UnserializeParams(const IByteChunk& chunk, int startPos);
-    
+
+  /** Override this method to prevent setting/overwriting parameters from unserializing
+   * @param paramidx The index of the parameter that would be set/overwritten
+   * @param value Reference to the parameter value that would be set, can be changed to a custom value
+   * @return true if the parameter will be set/overwritten */
+  virtual bool OnUnserializeParamSet(int paramidx, double& value) { return true; }
+
   /** Serializes the editor data (such as scale) into a binary chunk.
    * @param chunk The output chunk to serialize to. Will append data if the chunk has already been started.
    * @return \c true if the serialization was successful */


### PR DESCRIPTION
This change
- prevents crashes when loading States from older plug-in versions (fewer parameters)
- introduces OnUnserializeParamSet, a method I use to customize the restoration of parameter values