### PR TITLE
Add clip facility to IText and lice implementation

### DIFF
--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -533,16 +533,22 @@ IColor IGraphicsLice::GetPoint(int x, int y)
 
 void IGraphicsLice::PrepareAndMeasureText(const IText& text, const char* str, IRECT& r, LICE_IFont*& pFont) const
 {
+  pFont = CacheFont(text);
   RECT R = {0, 0, 0, 0};
 
   UINT fmt = DT_NOCLIP | DT_TOP | DT_LEFT | LICE_DT_USEFGALPHA;
-  
   pFont->DrawText(mRenderBitmap, str, -1, &R, fmt | DT_CALCRECT);
-  
-  const float textWidth = R.right / static_cast<float>(GetScreenScale());
-  const float textHeight = R.bottom / static_cast<float>(GetScreenScale());
+
+  float textWidth = R.right / static_cast<float>(GetScreenScale());
+  float textHeight = R.bottom / static_cast<float>(GetScreenScale());
   float x = 0.f;
   float y = 0.f;
+
+  if (text.mClip)
+  {
+    if (textWidth > r.W()) textWidth = r.W();
+    if (textHeight > r.H()) textHeight = r.H();
+  }
 
   switch (text.mAlign)
   {
@@ -578,9 +584,7 @@ void IGraphicsLice::DoDrawText(const IText& text, const char* str, const IRECT& 
   fmt |= DT_TOP | DT_LEFT | LICE_DT_USEFGALPHA;
   
   NeedsClipping();
-
-  pFont = CacheFont(text);
-  if(!text.mClip) PrepareAndMeasureText(text, str, measured, pFont);
+  PrepareAndMeasureText(text, str, measured, pFont);
   
   if (text.mAngle)
   {

--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -533,8 +533,8 @@ IColor IGraphicsLice::GetPoint(int x, int y)
 
 void IGraphicsLice::PrepareAndMeasureText(const IText& text, const char* str, IRECT& r, LICE_IFont*& pFont) const
 {
-  pFont = CacheFont(text);
   RECT R = {0, 0, 0, 0};
+
   UINT fmt = DT_NOCLIP | DT_TOP | DT_LEFT | LICE_DT_USEFGALPHA;
   
   pFont->DrawText(mRenderBitmap, str, -1, &R, fmt | DT_CALCRECT);
@@ -573,10 +573,14 @@ void IGraphicsLice::DoDrawText(const IText& text, const char* str, const IRECT& 
 {
   IRECT measured = bounds;
   LICE_IFont* pFont;
-  UINT fmt = DT_NOCLIP | DT_TOP | DT_LEFT | LICE_DT_USEFGALPHA;
+
+  UINT fmt = text.mClip ? 0 : DT_NOCLIP;
+  fmt |= DT_TOP | DT_LEFT | LICE_DT_USEFGALPHA;
   
   NeedsClipping();
-  PrepareAndMeasureText(text, str, measured, pFont);
+
+  pFont = CacheFont(text);
+  if(!text.mClip) PrepareAndMeasureText(text, str, measured, pFont);
   
   if (text.mAngle)
   {

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -570,6 +570,7 @@ struct IText
   float mAngle = 0.f; // Degrees ccwise from normal.
   EAlign mAlign = EAlign::Near;
   EVAlign mVAlign = EVAlign::Middle;
+  bool mClip = false;
 };
 
 const IText DEFAULT_TEXT = IText();


### PR DESCRIPTION
Atm, drawing custom texts inside of a control can't be bounded to the specified rectangle, it extends automatically and overwrites the boundaries. This implementation adds my (long time used) clipping member to IText and I added the Lice implementation. I can't add the other gfx implementations atm, maybe this could be easy for someone who is familar with these.