### PR TITLE
Add "return key ends text edit" facility

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -934,7 +934,14 @@ public:
   /** Called by PopupMenuControl in order to update a control with a new value after returning from the non-blocking menu. The base class has a record of the control, so it is not needed here.
    * @param pReturnMenu The new value as a CString */
   void SetControlValueAfterPopupMenu(IPopupMenu* pMenu);
-    
+
+  /** Call this before CreateTextEntry to set if return key will end text edit
+   * @param end true if return key will end text edit */
+  void SetReturnKeyEndsTextInput(bool end) { mReturnKeyEndsTextInput = end; };
+
+  /** @return true if the return key will end text edit */
+  bool GetReturnKeyEndsTextInput() { return mReturnKeyEndsTextInput; };
+
   /** /todo 
    * @param lo /todo
    * @param hi /todo */
@@ -1545,7 +1552,8 @@ protected:
   float mCursorY = -1.f;
   float mXTranslation = 0.f;
   float mYTranslation = 0.f;
-  
+  bool mReturnKeyEndsTextInput = true;
+
   friend class IGraphicsLiveEdit;
   friend class ICornerResizerControl;
   friend class ITextEntryControl;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -600,7 +600,7 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
       {
         if (wParam == VK_RETURN)
         {
-          pGraphics->mParamEditMsg = kCommit;
+          if(pGraphics->GetReturnKeyEndsTextInput()) pGraphics->mParamEditMsg = kCommit;
           return 0;
         }
         else if (wParam == VK_ESCAPE)


### PR DESCRIPTION
This implementation customizes the return key in text edits (with windows implementation - macOS should have same "true" behaviour by default). STRG+RETURN allows line feeds in multi line text inputs. Hope, this could be helpful, implementations for Linux etc. missing (if necessary).