### PR TITLE
Fix VST3 crashes concerning resizing

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -271,8 +271,9 @@ bool IPlugVST3::EditorResizeFromDelegate(int viewWidth, int viewHeight)
   if (HasUI())
   {
     if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
-      mView->resize(viewWidth, viewHeight);
-
+    {
+      if (mView != nullptr) mView->resize(viewWidth, viewHeight);
+    }
     IPlugAPIBase::EditorResizeFromDelegate(viewWidth, viewHeight);
   }
   

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -123,7 +123,7 @@ public:
     TRACE
     
     Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w, h);
-    plugFrame->resizeView(this, &newSize);
+    if(plugFrame != nullptr) plugFrame->resizeView(this, &newSize);
   }
 
   T& mOwner;


### PR DESCRIPTION
I ran into random crashes in the vst3 implementation - here windows & reaper - when restoring projects/states at program launch. After debugging it appears, that program/call method execution order from host side is sometimes "unconventional". These changes fixed it for me.