### PR TITLE
Improve combo box and button control

### DIFF
--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -455,72 +455,20 @@ void IVRadioButtonControl::DrawWidget(IGraphics& g)
   }
 }
 
-bool IVRadioButtonControl::IsHit(float x, float y) const
+int IVRadioButtonControl::EntryIndexForPoint(float x, float y) const
 {
-  if(mOnlyButtonsRespondToMouse)
+  if (mOnlyButtonsRespondToMouse)
   {
-    bool hit = false;
-    
     for (int i = 0; i < mNumStates; i++)
     {
-      hit |= mButtons.Get()[i].FracRectHorizontal(0.25f).Contains(x, y);
+      if (mButtons.Get()[i].FracRectHorizontal(0.25f).Contains(x, y))
+        return i;
     }
     
-    return hit;
+    return -1;
   }
   else
-    return IVTabSwitchControl::IsHit(x, y);
-}
-
-void IVRadioButtonControl::OnMouseDown(float x, float y, const IMouseMod& mod)
-{
-  int hit = -1;
-  
-  for (int i = 0; i < mNumStates; i++)
-  {
-    if(mButtons.Get()[i].FracRectHorizontal(0.25f).Contains(x, y))
-    {
-      hit = i;
-      break;
-    }
-  }
-  
-  if(hit > -1)
-    SetValue(((double) hit * (1./(double) (mNumStates-1))));
-  
-  SetDirty(true);
-}
-
-void IVRadioButtonControl::OnMouseOver(float x, float y, const IMouseMod& mod)
-{
-  mMouseOverButton = -1;
-  
-  for (int i = 0; i < mNumStates; i++)
-  {
-    if(mButtons.Get()[i].FracRectHorizontal(0.25f).Contains(x, y))
-    {
-      mMouseOverButton = i;
-      break;
-    }
-  }
-  
-  IVTabSwitchControl::OnMouseOver(x, y, mod);
-  
-  SetDirty(false);
-}
-
-void IVRadioButtonControl::OnResize()
-{
-  SetTargetRECT(MakeRects(mRECT));
-  
-  mButtons.Resize(0);
-  
-  for (int i = 0; i < mNumStates; i++)
-  {
-    mButtons.Add(mWidgetBounds.SubRect(mDirection, mNumStates, i));
-  }
-  
-  SetDirty(false);
+    return IVTabSwitchControl::EntryIndexForPoint(x, y);
 }
 
 IVKnobControl::IVKnobControl(const IRECT& bounds, int paramIdx, const char* label, const IVStyle& style, bool valueIsEditable, bool valueInWidget, float a1, float a2, float aAnchor,  EDirection direction, double gearing)

--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -374,49 +374,34 @@ void IVTabSwitchControl::DrawWidget(IGraphics& g)
   }
 }
 
-bool IVTabSwitchControl::IsHit(float x, float y) const
+int IVTabSwitchControl::EntryIndexForPoint(float x, float y) const
 {
-  bool hit = false;
-  
   for (int i = 0; i < mNumStates; i++)
   {
-    hit |= mButtons.Get()[i].Contains(x, y);
+    if (mButtons.Get()[i].Contains(x, y))
+      return i;
   }
   
-  return hit;
+  return -1;
+}
+
+bool IVTabSwitchControl::IsHit(float x, float y) const
+{
+  return EntryIndexForPoint(x, y) > -1;
 }
 
 void IVTabSwitchControl::OnMouseDown(float x, float y, const IMouseMod& mod)
 {
-  int hit = -1;
-  
-  for (int i = 0; i < mNumStates; i++)
-  {
-    if(mButtons.Get()[i].Contains(x, y))
-    {
-      hit = i;
-      break;
-    }
-  }
-  
-  if(hit > -1)
-    SetValue(((double) hit * (1./(double) (mNumStates-1))));
+  int index = EntryIndexForPoint(x, y);
+  if (index > -1)
+    SetValue(((double) index * (1./(double) (mNumStates-1))));
   
   SetDirty(true);
 }
 
 void IVTabSwitchControl::OnMouseOver(float x, float y, const IMouseMod& mod)
 {
-  mMouseOverButton = -1;
-  
-  for (int i = 0; i < mNumStates; i++)
-  {
-    if(mButtons.Get()[i].Contains(x, y))
-    {
-      mMouseOverButton = i;
-      break;
-    }
-  }
+  mMouseOverButton = EntryIndexForPoint(x, y);
   
   ISwitchControlBase::OnMouseOver(x, y, mod);
   

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -166,8 +166,8 @@ public:
   virtual bool IsHit(float x, float y) const override;
   void SetShape(EVShape shape) { mShape = shape; SetDirty(false); }
 protected:
-  int EntryIndexForPoint(float x, float y) const;
   /** @return the index of the entry at the given point or -1 if no entry was hit */
+  virtual int EntryIndexForPoint(float x, float y) const;
 
   int mMouseOverButton = -1;
   WDL_TypedBuf<IRECT> mButtons;
@@ -201,12 +201,10 @@ public:
   IVRadioButtonControl(const IRECT& bounds, IActionFunction actionFunc, const std::initializer_list<const char*>& options, const char* label = "", const IVStyle& style = DEFAULT_STYLE, EVShape shape = EVShape::Ellipse, EDirection direction = EDirection::Vertical, float buttonSize = 20.f);
   
   virtual void DrawWidget(IGraphics& g) override;
-  void OnMouseDown(float x, float y, const IMouseMod& mod) override;
-  void OnMouseOver(float x, float y, const IMouseMod& mod) override;
-  void OnMouseOut() override { mMouseOverButton = -1; }
-  void OnResize() override;
-  virtual bool IsHit(float x, float y) const override;
 protected:
+  /** @return the index of the clickable entry at the given point or -1 if no entry was hit */
+  int EntryIndexForPoint(float x, float y) const override;
+
   float mButtonSize;
   bool mOnlyButtonsRespondToMouse = false;
 };

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -166,6 +166,9 @@ public:
   virtual bool IsHit(float x, float y) const override;
   void SetShape(EVShape shape) { mShape = shape; SetDirty(false); }
 protected:
+  int EntryIndexForPoint(float x, float y) const;
+  /** @return the index of the entry at the given point or -1 if no entry was hit */
+
   int mMouseOverButton = -1;
   WDL_TypedBuf<IRECT> mButtons;
   WDL_PtrList<WDL_String> mTabLabels;

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -505,7 +505,7 @@ void IPopupMenuControl::Expand(const IRECT& anchorArea)
   mAnchorArea = anchorArea;
   
   float x = anchorArea.L;
-  float y = anchorArea.T;
+  float y = anchorArea.B;
   
   if(mCallOut)
   {

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -494,7 +494,7 @@ void IPopupMenuControl::CalculateMenuPanels(float x, float y)
   SetDirty(false);
 }
 
-void IPopupMenuControl::Expand(const IRECT& bounds)
+void IPopupMenuControl::Expand(const IRECT& anchorArea)
 {
   Hide(false);
   mState = kExpanding;
@@ -502,25 +502,25 @@ void IPopupMenuControl::Expand(const IRECT& bounds)
   
   mMenuPanels.Empty(true);
   
-  mOriginalBounds = bounds;
+  mAnchorArea = anchorArea;
   
-  float x = bounds.L;
-  float y = bounds.T;
+  float x = anchorArea.L;
+  float y = anchorArea.T;
   
   if(mCallOut)
   {
-    x = bounds.R + CALLOUT_SPACE;
-    y = bounds.MH() - CALLOUT_SPACE - mText.mSize;
-    mCalloutArrowBounds = IRECT(bounds.R, bounds.MH() - CALLOUT_SPACE, x, bounds.MH() + CALLOUT_SPACE);
+    x = anchorArea.R + CALLOUT_SPACE;
+    y = anchorArea.MH() - CALLOUT_SPACE - mText.mSize;
+    mCalloutArrowBounds = IRECT(anchorArea.R, anchorArea.MH() - CALLOUT_SPACE, x, anchorArea.MH() + CALLOUT_SPACE);
     mCalloutArrowDir = kEast;
     
-    if(y < (mMaxBounds.T+PAD)) // if we're going off the top of the max bounds
+    if(y < (mMaxBounds.T+PAD)) // if we're going off the top of the max anchorArea
     {
       IRECT maxCell = GetLargestCellRectForMenu(*mMenu, 0, 0);
       
-      x = bounds.MW() - (maxCell.W() / 2.f);
-      y = bounds.B + CALLOUT_SPACE;
-      mCalloutArrowBounds = IRECT(bounds.MW() - CALLOUT_SPACE, bounds.B, bounds.MW() + CALLOUT_SPACE, bounds.B + CALLOUT_SPACE);
+      x = anchorArea.MW() - (maxCell.W() / 2.f);
+      y = anchorArea.B + CALLOUT_SPACE;
+      mCalloutArrowBounds = IRECT(anchorArea.MW() - CALLOUT_SPACE, anchorArea.B, anchorArea.MW() + CALLOUT_SPACE, anchorArea.B + CALLOUT_SPACE);
       mCalloutArrowDir = kNorth;
     }
   }
@@ -604,7 +604,7 @@ void IPopupMenuControl::OnEndAnimation()
       
     mState = kIdling;
     mMouseCellBounds = nullptr;
-    mOriginalBounds = IRECT();
+    mAnchorArea = IRECT();
     
     SetDirty(true); // triggers animation again
     return; // don't cancel animation
@@ -730,7 +730,7 @@ IPopupMenuControl::MenuPanel::MenuPanel(IPopupMenuControl& control, IPopupMenu& 
   {
     if(control.mCallOut)
     {
-      const float newRight = control.mOriginalBounds.L - control.CALLOUT_SPACE - control.PAD;
+      const float newRight = control.mAnchorArea.L - control.CALLOUT_SPACE - control.PAD;
       const float shiftLeft = span.R-newRight;
 
       for(auto i = 0; i < mCellBounds.GetSize(); i++)
@@ -739,7 +739,7 @@ IPopupMenuControl::MenuPanel::MenuPanel(IPopupMenuControl& control, IPopupMenu& 
       }
       
       control.mCalloutArrowDir = kWest;
-      control.mCalloutArrowBounds = IRECT(control.mOriginalBounds.L - control.CALLOUT_SPACE, control.mOriginalBounds.MH() - control.CALLOUT_SPACE, control.mOriginalBounds.L, control.mOriginalBounds.MH() + control.CALLOUT_SPACE);
+      control.mCalloutArrowBounds = IRECT(control.mAnchorArea.L - control.CALLOUT_SPACE, control.mAnchorArea.MH() - control.CALLOUT_SPACE, control.mAnchorArea.L, control.mAnchorArea.MH() + control.CALLOUT_SPACE);
     }
     else
     {

--- a/IGraphics/Controls/IPopupMenuControl.h
+++ b/IGraphics/Controls/IPopupMenuControl.h
@@ -98,9 +98,9 @@ public:
 
   /** Call this to create a pop-up menu
    @param menu Reference to a menu from which to populate this user interface control. NOTE: this object should not be a temporary, otherwise when the menu returns asynchronously, it may not exist.
-   @param bounds \todo
+   @param anchorArea The pop-up menu opens adjacent to this area, but won't occupy it. At the moment, the menu is always below or right of that region.
    @param pCaller The IControl that called this method, and will receive the call back after menu selection */
-  void CreatePopupMenu(IPopupMenu& menu, const IRECT& bounds);
+  void CreatePopupMenu(IPopupMenu& menu, const IRECT& anchorArea);
 
   /** @return \true if the pop-up is fully expanded */
   bool GetExpanded() const { return mState == kExpanded; }
@@ -200,7 +200,7 @@ private:
   const float ARROW_SIZE = 8; // The width of the area on the right of the cell where an arrow appears for new submenus
   const float PAD = 5.; // How much white space between the background and the cells
   const float CALLOUT_SPACE = 8; // The space between start bounds and callout
-  IRECT mOriginalBounds; // The rectangular area where the menu was triggered
+  IRECT mAnchorArea; // The area where the menu was triggered; menu will be adjacent, but won't occupy it.
   EArrowDir mCalloutArrowDir = kEast;
   IRECT mCalloutArrowBounds;
 


### PR DESCRIPTION
I looked at the `IPlugControls` example and changed two things:
– create the non-platform pop-up menu below the combo box, as it's done by the platform widget
– make the text on a button control clickable, unless it's disabled for this control (as advertised in the code)
