### PR TITLE
Detect keypresses of modifier keys (CTRL resp. CMD, ALT, SHIFT) with OnKeyDown() and OnKeyUp()

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1037,25 +1037,25 @@ bool IGraphics::OnKeyUp(float x, float y, const IKeyPress& key)
   return handled;
 }
 
-void IGraphics::OnModifierKeysChange(float x, float y, int flag){
+bool IGraphics::OnModifierKeysChange(float x, float y, int flag){
     int changedKey = flag - mModifierKeys;
+    mModifierKeys = flag;
     int code;
     switch(abs(changedKey)){
         case kFSHIFT:   code = kVK_SHIFT;   break;
         case kFCONTROL: code = kVK_CONTROL; break;
         case kFALT:     code = kVK_MENU;    break;
+        default:                            return false;
     }
     
     IKeyPress keyPress {"", code, static_cast<bool>(flag & kFSHIFT),
-                                    static_cast<bool>(flag & kFCONTROL),
-                                    static_cast<bool>(flag & kFALT)};
+                                  static_cast<bool>(flag & kFCONTROL),
+                                  static_cast<bool>(flag & kFALT)};
     
     if (changedKey > 0)
-        OnKeyDown(x, y, keyPress);
+        return OnKeyDown(x, y, keyPress);
     else if (changedKey < 0)
-        OnKeyUp(x, y, keyPress);
-    
-    mModifierKeys = flag;
+        return OnKeyUp(x, y, keyPress);
 }
 
 bool IGraphics::GetModifierKeyPressed(int key){

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1037,6 +1037,31 @@ bool IGraphics::OnKeyUp(float x, float y, const IKeyPress& key)
   return handled;
 }
 
+void IGraphics::OnModifierKeysChange(float x, float y, int flag){
+    int changedKey = flag - mModifierKeys;
+    int code;
+    switch(abs(changedKey)){
+        case kFSHIFT:   code = kVK_SHIFT;   break;
+        case kFCONTROL: code = kVK_CONTROL; break;
+        case kFALT:     code = kVK_MENU;    break;
+    }
+    
+    IKeyPress keyPress {"", code, static_cast<bool>(flag & kFSHIFT),
+                                    static_cast<bool>(flag & kFCONTROL),
+                                    static_cast<bool>(flag & kFALT)};
+    
+    if (changedKey > 0)
+        OnKeyDown(x, y, keyPress);
+    else if (changedKey < 0)
+        OnKeyUp(x, y, keyPress);
+    
+    mModifierKeys = flag;
+}
+
+bool IGraphics::GetModifierKeyPressed(int key){
+    return mModifierKeys & key;
+}
+
 void IGraphics::OnDrop(const char* str, float x, float y)
 {
   IControl* pControl = GetMouseControl(x, y, false);

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1299,7 +1299,7 @@ public:
    * @return \c true if handled \todo check this */
   bool OnKeyUp(float x, float y, const IKeyPress& key);
   
-  void OnModifierKeysChange(float x, float y, int flag);
+  bool OnModifierKeysChange(float x, float y, int flag);
     
   bool GetModifierKeyPressed(int key);
     

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1299,6 +1299,10 @@ public:
    * @return \c true if handled \todo check this */
   bool OnKeyUp(float x, float y, const IKeyPress& key);
   
+  void OnModifierKeysChange(float x, float y, int flag);
+    
+  bool GetModifierKeyPressed(int key);
+    
   /** @param x The X coordinate in the graphics context at which to draw
    * @param y The Y coordinate in the graphics context at which to draw
    * @param mod IMouseMod struct contain information about the modifiers held
@@ -1520,6 +1524,7 @@ private:
   int mTextEntryValIdx = kNoValIdx;
   int mPopupMenuValIdx = kNoValIdx;
   int mMouseOverIdx = -1;
+  int mModifierKeys = 0;
   float mMouseDownX = -1.f;
   float mMouseDownY = -1.f;
   float mMinScale;

--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -141,6 +141,7 @@ using namespace igraphics;
 - (void) mouseMoved: (NSEvent*) pEvent;
 - (void) scrollWheel: (NSEvent*) pEvent;
 - (void) keyDown: (NSEvent *)pEvent;
+- (void) flagsChanged:(NSEvent *)pEvent;
 //text entry
 - (void) removeFromSuperview;
 - (void) controlTextDidEndEditing: (NSNotification*) aNotification;

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -780,7 +780,11 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
     if (mod & NSShiftKeyMask) flag |= kFSHIFT;
     if (mod & NSCommandKeyMask) flag |= kFCONTROL; // todo: this should be command once we figure it out
     if (mod & NSAlternateKeyMask) flag |= kFALT;
-    mGraphics->OnModifierKeysChange(mPrevX, mPrevY, flag);
+    bool handle = mGraphics->OnModifierKeysChange(mPrevX, mPrevY, flag);
+    if (!handle)
+    {
+      [[self nextResponder] flagsChanged:pEvent];
+    }
 }
 
 - (void)keyUp: (NSEvent *)pEvent

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -774,6 +774,15 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   }
 }
 
+-(void) flagsChanged: (NSEvent *)pEvent{
+    int flag = 0;
+    const NSInteger mod = [pEvent modifierFlags];
+    if (mod & NSShiftKeyMask) flag |= kFSHIFT;
+    if (mod & NSCommandKeyMask) flag |= kFCONTROL; // todo: this should be command once we figure it out
+    if (mod & NSAlternateKeyMask) flag |= kFALT;
+    mGraphics->OnModifierKeysChange(mPrevX, mPrevY, flag);
+}
+
 - (void)keyUp: (NSEvent *)pEvent
 {
   int flag = 0;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -418,37 +418,52 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       return DLGC_WANTALLKEYS;
     case WM_KEYDOWN:
     case WM_KEYUP:
+    case WM_SYSKEYDOWN:
+    case WM_SYSKEYUP:
     {
       POINT p;
       GetCursorPos(&p);
       ScreenToClient(hWnd, &p);
 
-      BYTE keyboardState[256] = {};
-      GetKeyboardState(keyboardState);
-      const int keyboardScanCode = (lParam >> 16) & 0x00ff;
-      WORD character = 0;
-      const int len = ToAscii(wParam, keyboardScanCode, keyboardState, &character, 0);
-      // TODO: should get unicode?
       bool handle = false;
 
-      // send when len is 0 because wParam might be something like VK_LEFT or VK_HOME, etc.
-      if (len == 0 || len == 1)
-      {
-        char str[2];
-        str[0] = static_cast<char>(character);
-        str[1] = '\0';
-          
-        IKeyPress keyPress{ str, static_cast<int>(wParam),
-                            static_cast<bool>(GetKeyState(VK_SHIFT) & 0x8000),
-                            static_cast<bool>(GetKeyState(VK_CONTROL) & 0x8000),
-                            static_cast<bool>(GetKeyState(VK_MENU) & 0x8000) };
-
+      //Handling Modifier Keys
+      if (static_cast<int>(wParam) == kVK_MENU || static_cast<int>(wParam) == kVK_SHIFT || static_cast<int>(wParam) == kVK_CONTROL) {
+        int flag = 0;
+        if ((GetKeyState(VK_SHIFT) & 0x8000)) flag |= kFSHIFT;
+        if ((GetKeyState(VK_CONTROL) & 0x8000)) flag |= kFCONTROL;
+        if ((GetKeyState(VK_MENU) & 0x8000)) flag |= kFALT;
         double scale = pGraphics->GetDrawScale() * pGraphics->GetScreenScale();
+        handle = pGraphics->OnModifierKeysChange(p.x / scale, p.y / scale, flag);
+      }
+      else {
+        BYTE keyboardState[256] = {};
+        GetKeyboardState(keyboardState);
+        const int keyboardScanCode = (lParam >> 16) & 0x00ff;
+        WORD character = 0;
+        const int len = ToAscii(wParam, keyboardScanCode, keyboardState, &character, 0);
+        // TODO: should get unicode?
 
-        if(msg == WM_KEYDOWN)
-          handle = pGraphics->OnKeyDown(p.x / scale, p.y / scale, keyPress);
-        else
-          handle = pGraphics->OnKeyUp(p.x / scale, p.y / scale, keyPress);
+
+        // send when len is 0 because wParam might be something like VK_LEFT or VK_HOME, etc.
+        if (len == 0 || len == 1)
+        {
+          char str[2];
+          str[0] = static_cast<char>(character);
+          str[1] = '\0';
+
+          IKeyPress keyPress{ str, static_cast<int>(wParam),
+                              static_cast<bool>(GetKeyState(VK_SHIFT) & 0x8000),
+                              static_cast<bool>(GetKeyState(VK_CONTROL) & 0x8000),
+                              static_cast<bool>(GetKeyState(VK_MENU) & 0x8000) };
+
+          double scale = pGraphics->GetDrawScale() * pGraphics->GetScreenScale();
+
+          if (msg == WM_KEYDOWN)
+            handle = pGraphics->OnKeyDown(p.x / scale, p.y / scale, keyPress);
+          else
+            handle = pGraphics->OnKeyUp(p.x / scale, p.y / scale, keyPress);
+        }
       }
 
       if (!handle)


### PR DESCRIPTION
For Windows and MacOS, not for iOS and Linux.

OnKeyDown() and OnKeyUp() send an IKeyPress with key codes  kVK_SHIFT, kVK_CONTROL and kVK_MENU when these keys are pressed.

Additionally, IGraphics has a method GetModifierKeyPressed, that accepts kFSHIFT, kFCONTROL and kFALT. Could be translated to VK-Codes if you think it makes sense.