### PR TITLE
Ensure that the correct context is current when deleting resources

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -142,6 +142,11 @@ void IGraphicsMac::CloseWindow()
 #endif
     
     IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
+      
+#ifdef IGRAPHICS_GL
+    [((IGRAPHICS_GLLAYER *)pView.layer).openGLContext makeCurrentContext];
+#endif
+      
     [pView removeAllToolTips];
     [pView killTimer];
     [pView removeFromSuperview];

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1149,11 +1149,15 @@ void IGraphicsWin::CloseWindow()
 #else
     KillTimer(mPlugWnd, IPLUG_TIMER_ID);
 #endif
-    ActivateGLContext();
-    OnViewDestroyed();
-    DeactivateGLContext();
 
 #ifdef IGRAPHICS_GL
+    ActivateGLContext();
+#endif
+
+    OnViewDestroyed();
+
+#ifdef IGRAPHICS_GL
+    DeactivateGLContext();
     DestroyGLContext();
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1061,6 +1061,10 @@ void* IGraphicsWin::OpenWindow(void* pParent)
     }
 
     if (!ok) EnableTooltips(ok);
+
+#ifdef IGRAPHICS_GL
+    wglMakeCurrent(NULL, NULL);
+#endif
   }
 
   GetDelegate()->OnUIOpen();
@@ -1145,8 +1149,9 @@ void IGraphicsWin::CloseWindow()
 #else
     KillTimer(mPlugWnd, IPLUG_TIMER_ID);
 #endif
-
+    ActivateGLContext();
     OnViewDestroyed();
+    DeactivateGLContext();
 
 #ifdef IGRAPHICS_GL
     DestroyGLContext();


### PR DESCRIPTION
This seems to fix the issues with deletion of plugin windows blanking out other plug-in windows under windows (#350)