### PR TITLE
do not extend existing path when calling PathArc (skia)

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -463,7 +463,7 @@ void IGraphicsSkia::PathArc(float cx, float cy, float r, float a1, float a2, EWi
     }
       
     arc.arcTo(SkRect::MakeLTRB(cx - r, cy - r, cx + r, cy + r), a1 - 90.f, sweep, false);
-    mMainPath.addPath(arc, mMatrix, SkPath::kExtend_AddPathMode);
+    mMainPath.addPath(arc, mMatrix, SkPath::kAppend_AddPathMode);
   }
 }
 


### PR DESCRIPTION
Calling PathArc twice before calling PathStroke would result in a connecting line between the curves, which is not intended I believe. Haven't checked the other drawing backends, however.