### PR TITLE
Fix issue with mouseouts when the mouse leaves the window during drag…

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -110,6 +110,7 @@ using namespace igraphics;
   IGRAPHICS_TEXTFIELD* mTextFieldView;
   NSCursor* mMoveCursor;
   float mPrevX, mPrevY;
+  bool mMouseOutDuringDrag;
   IRECTList mDirtyRects;
   IColorPickerHandlerFunc mColorPickerFunc;
 @public


### PR DESCRIPTION
…ging

This is an issue as I only display values when the mouse is over but if mousing is rapdi the mouse leaves the window and then the value disappears. this is a Mac only issue - the fix will prevent the call being made but then if the mouse up happens before the window is re-entered the mouseOut will be sent after the mouse up.