### PR TITLE
added Set opacity and get with opacity

### DIFF
--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -267,6 +267,22 @@ struct IColor
     return n;
   }
   
+  /** @param o /todo */
+  void SetOpacity(double o)
+  {
+    A *= o;
+    A = std::min(A, 255);
+    A = std::max(A, 0);
+  }
+  
+  /** @param + /todo */
+  IColor GetWithOpacity(double o) const
+  {
+    IColor n = *this;
+    n.SetOpacity(o);
+    return n;
+  }
+  
   /** Get the color as a 3 float array
    * @param rgbf ptr to array of 3 floats */
   void GetRGBf(float* rgbf) const


### PR DESCRIPTION
This PR add two handy methods to set the alpha channel and get a new IColor with modified alpha channel.
this saves some time in coding instead of creating a new IColor, assigning the old one then modifying the alpha value.
I took the idea from the GetContrasted methods.