### PR TITLE
added GetHSL method to IColor

### DIFF
--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -398,6 +398,49 @@ struct IColor
     return col;
   }
   
+  void GetHSL(float* HSL) {
+    
+    float fR = R / 255.0;
+    float fG = G / 255.0;
+    float fB = B / 255.0;
+      
+    float fCMin = fmin(fR, fmin(fG, fB));
+    float fCMax = fmax(fR, fmax(fG, fB));
+    
+    // L
+    HSL[2] = 50 * (fCMin + fCMax);
+      
+    if (fCMin == fCMax) {
+      //S
+      HSL[1] = 0;
+      //H
+      HSL[0] = 0;
+      return;
+    } else if (HSL[2] < 50) {
+      HSL[1] = 100 * (fCMax - fCMin) / (fCMax + fCMin);
+    } else {
+      HSL[1] = 100 * (fCMax - fCMin) / (2.0 - fCMax - fCMin);
+    }
+      
+    if (fCMax == fR) {
+      HSL[0] = 60 * (fG - fB) / (fCMax - fCMin);
+    }
+    if (fCMax == fG) {
+      HSL[0] = 60 * (fB - fR) / (fCMax - fCMin) + 120;
+    }
+    if (fCMax == fB) {
+      HSL[0] = 60 * (fR - fG) / (fCMax - fCMin) + 240;
+    }
+    if (HSL[0] < 0) {
+      HSL[0] = HSL[0] + 360;
+    }
+    
+    HSL[0] /= 360.;
+    HSL[1] /= 100.;
+    HSL[2] /= 100.;
+  }
+
+
   /** /todo 
    * @return int /todo */
   int GetLuminosity() const


### PR DESCRIPTION
This PR adds a GetHSL method to IColor so that the HSL components are returned, it addresses issue #441 
