### PR TITLE
removed round from GetDisplayForHost to make it behave like IParam::Int that does just a type cast

### DIFF
--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -285,7 +285,7 @@ void IParam::GetDisplayForHost(double value, bool normalized, WDL_String& str, b
 
   if (mDisplayPrecision == 0)
   {
-    str.SetFormatted(MAX_PARAM_DISPLAY_LEN, "%d", static_cast<int>(round(displayValue)));
+    str.SetFormatted(MAX_PARAM_DISPLAY_LEN, "%d", static_cast<int>(displayValue));
   }
   else if ((mFlags & kFlagSignDisplay) && displayValue)
   {


### PR DESCRIPTION

Removed a round in IParam::GetDisplayForHost when displaying integer parameters to bring the behaviour in line with IParam::Int that does just a cast to integer

This fixes #443 