### PR TITLE
VST2: add missing DAW latency reporting, fixes issue 447

### DIFF
--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -222,6 +222,7 @@ void IPlugVST2::SetLatency(int samples)
 {
   mAEffect.initialDelay = samples;
   IPlugProcessor::SetLatency(samples);
+  mHostCallback(&mAEffect, audioMasterIOChanged, 0, 0, 0, 0.0f);
 }
 
 bool IPlugVST2::SendVSTEvent(VstEvent& event)


### PR DESCRIPTION
Description:
If plugin creates internal latency (e.g. convo engine) it needs to report this to VST2 host, otherwise tracks with the plugin get out of sync.
Currently iPlug2/VST2 does not report any latency changes to DAW via mHostCallback.

To Reproduce:
add SetLatency to e.g. ProcessBlock, DAW does not recognize new latency, no PDC

Expected behaviour:
VST2 plugin should report latency to VST2 host in order to enable proper PDC