### PR TITLE
Ensure that clipping is always correct

### DIFF
--- a/IGraphics/Drawing/IGraphicsAGG.cpp
+++ b/IGraphics/Drawing/IGraphicsAGG.cpp
@@ -274,7 +274,7 @@ bool CheckTransform(const agg::trans_affine& mtx)
 void IGraphicsAGG::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int srcX, int srcY, const IBlend* pBlend)
 {
   bool preMultiplied = static_cast<Bitmap*>(bitmap.GetAPIBitmap())->IsPreMultiplied();
-  IRECT bounds = mClipRECT.Empty() ? dest : mClipRECT.Intersect(dest);
+  IRECT bounds = mClipRECT.Intersect(dest);
   bounds.Scale(GetBackingPixelScale());
 
   APIBitmap* pAPIBitmap = dynamic_cast<Bitmap*>(bitmap.GetAPIBitmap());

--- a/IGraphics/Drawing/IGraphicsAGG.h
+++ b/IGraphics/Drawing/IGraphicsAGG.h
@@ -191,7 +191,7 @@ private:
     void SetPath(VertexSourceType& path)
     {
       // Clip
-      IRECT clip = mGraphics.mClipRECT.Empty() ? mGraphics.GetBounds() : mGraphics.mClipRECT;
+      IRECT clip = mGraphics.mClipRECT;
       clip.Translate(mGraphics.XTranslate(), mGraphics.YTranslate());
       clip.Scale(mGraphics.GetBackingPixelScale());
       mRasterizer.clip_box(clip.L, clip.T, clip.R, clip.B);

--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -713,10 +713,7 @@ void IGraphicsCairo::SetClipRegion(const IRECT& r)
     return;
     
   cairo_reset_clip(mContext);
-  if (!r.Empty())
-  {
-    cairo_new_path(mContext);
-    cairo_rectangle(mContext, r.L, r.T, r.W(), r.H());
-    cairo_clip(mContext);
-  }
+  cairo_new_path(mContext);
+  cairo_rectangle(mContext, r.L, r.T, r.W(), r.H());
+  cairo_clip(mContext);
 }

--- a/IGraphics/Drawing/IGraphicsCanvas.cpp
+++ b/IGraphics/Drawing/IGraphicsCanvas.cpp
@@ -335,13 +335,10 @@ void IGraphicsCanvas::SetClipRegion(const IRECT& r)
   val context = GetContext();
   context.call<void>("restore");
   context.call<void>("save");
-  if (!r.Empty())
-  {
-    context.call<void>("beginPath");
-    context.call<void>("rect", r.L, r.T, r.W(), r.H());
-    context.call<void>("clip");
-    context.call<void>("beginPath");
-  }
+  context.call<void>("beginPath");
+  context.call<void>("rect", r.L, r.T, r.W(), r.H());
+  context.call<void>("clip");
+  context.call<void>("beginPath");
 }
 
 bool IGraphicsCanvas::BitmapExtSupported(const char* ext)

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -780,10 +780,7 @@ void IGraphicsNanoVG::PathTransformSetMatrix(const IMatrix& m)
 
 void IGraphicsNanoVG::SetClipRegion(const IRECT& r)
 {
-  if (!r.Empty())
-    nvgScissor(mVG, r.L, r.T, r.W(), r.H());
-  else
-    nvgResetScissor(mVG);
+  nvgScissor(mVG, r.L, r.T, r.W(), r.H());
 }
 
 void IGraphicsNanoVG::DrawDottedLine(const IColor& color, float x1, float y1, float x2, float y2, const IBlend* pBlend, float thickness, float dashLen)


### PR DESCRIPTION
This PR fixes an issue with IGraphics path classes in which the requested clip region doesn't intersect with the area currently being drawn (as specified by PrepareRegion()). This was previously resetting the clip region in each of the draw classes (because they were responding to an empty RECT by reset the clip) and thus unwanted pixels are drawn.

The circumstance in which this issue occurred was two overlapping controls, one with a clip region in some of the drawing that didn't intersect with the second control. When drawing the first control the clip would work, but when drawing the second control the clip would fail, sometime leading to flickering drawing.