### PR TITLE
BREAKING: rename IParam:GetXForHost -> GetX

### DIFF
--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -127,7 +127,7 @@ void IVSwitchControl::SetDirty(bool push, int valIdx)
   const IParam* pParam = GetParam();
 
   if(pParam)
-    pParam->GetDisplayForHost(mValueStr);
+    pParam->GetDisplay(mValueStr);
 }
 
 void IVSwitchControl::OnResize()
@@ -149,10 +149,10 @@ void IVSwitchControl::OnInit()
   
   if(pParam)
   {
-    pParam->GetDisplayForHostWithLabel(mValueStr);
+    pParam->GetDisplayWithLabel(mValueStr);
   
     if(!mLabelStr.GetLength())
-      mLabelStr.Set(pParam->GetNameForHost());
+      mLabelStr.Set(pParam->GetName());
   }
 }
 
@@ -338,7 +338,7 @@ void IVTabSwitchControl::OnInit()
     }
     
     if(!mLabelStr.GetLength())
-      mLabelStr.Set(pParam->GetNameForHost());
+      mLabelStr.Set(pParam->GetName());
   }
 }
 
@@ -630,7 +630,7 @@ void IVKnobControl::SetDirty(bool push, int valIdx)
   const IParam* pParam = GetParam();
   
   if(pParam)
-    pParam->GetDisplayForHostWithLabel(mValueStr);
+    pParam->GetDisplayWithLabel(mValueStr);
 }
 
 void IVKnobControl::OnInit()
@@ -639,10 +639,10 @@ void IVKnobControl::OnInit()
   
   if(pParam)
   {
-    pParam->GetDisplayForHostWithLabel(mValueStr);
+    pParam->GetDisplayWithLabel(mValueStr);
     
     if(!mLabelStr.GetLength())
-      mLabelStr.Set(pParam->GetNameForHost());
+      mLabelStr.Set(pParam->GetName());
   }
 }
 
@@ -786,7 +786,7 @@ void IVSliderControl::SetDirty(bool push, int valIdx)
   const IParam* pParam = GetParam();
   
   if(pParam)
-    pParam->GetDisplayForHostWithLabel(mValueStr);
+    pParam->GetDisplayWithLabel(mValueStr);
 }
 
 void IVSliderControl::OnInit()
@@ -796,9 +796,9 @@ void IVSliderControl::OnInit()
   if(pParam)
   {
     if(!mLabelStr.GetLength())
-      mLabelStr.Set(pParam->GetNameForHost());
+      mLabelStr.Set(pParam->GetName());
     
-    pParam->GetDisplayForHostWithLabel(mValueStr);
+    pParam->GetDisplayWithLabel(mValueStr);
   }
 }
 

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -59,7 +59,7 @@ void ShowBubbleHorizontalActionFunc(IControl* pCaller)
   const IParam* pParam = pCaller->GetParam();
   IRECT bounds = pCaller->GetRECT();
   WDL_String display;
-  pParam->GetDisplayForHostWithLabel(display);
+  pParam->GetDisplayWithLabel(display);
   pGraphics->ShowBubbleControl(pCaller, bounds.R, bounds.MH(), display.Get(), EDirection::Horizontal, IRECT(0,0,50,30));
 }
 
@@ -69,7 +69,7 @@ void ShowBubbleVerticalActionFunc(IControl* pCaller)
   const IParam* pParam = pCaller->GetParam();
   IRECT bounds = pCaller->GetRECT();
   WDL_String display;
-  pParam->GetDisplayForHostWithLabel(display);
+  pParam->GetDisplayWithLabel(display);
   pGraphics->ShowBubbleControl(pCaller, bounds.MW(), bounds.T, display.Get(), EDirection::Vertical, IRECT(0,0,50,30));
 }
 
@@ -594,12 +594,12 @@ void ICaptionControl::Draw(IGraphics& g)
 
   if(pParam)
   {
-    pParam->GetDisplayForHost(mStr);
+    pParam->GetDisplay(mStr);
 
     if (mShowParamLabel)
     {
       mStr.Append(" ");
-      mStr.Append(pParam->GetLabelForHost());
+      mStr.Append(pParam->GetLabel());
     }
   }
 

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -460,7 +460,7 @@ void IGraphics::AssignParamNameToolTips()
   auto func = [](IControl& control)
   {
     if (control.GetParamIdx() > kNoParameter)
-      control.SetTooltip(control.GetParam()->GetNameForHost());
+      control.SetTooltip(control.GetParam()->GetName());
   };
   
   ForStandardControlsFunc(func);
@@ -499,7 +499,7 @@ void IGraphics::PromptUserInput(IControl& control, const IRECT& bounds, int valI
 
     if ( type == IParam::kTypeEnum || (type == IParam::kTypeBool && nDisplayTexts))
     {
-      pParam->GetDisplayForHost(currentText);
+      pParam->GetDisplay(currentText);
       mPromptPopupMenu.Clear();
 
       // Fill the menu
@@ -512,7 +512,7 @@ void IGraphics::PromptUserInput(IControl& control, const IRECT& bounds, int valI
         else // not equal
           mPromptPopupMenu.AddItem( new IPopupMenu::Item(str), -1 );
         
-        mPromptPopupMenu.SetRootTitle(pParam->GetNameForHost());
+        mPromptPopupMenu.SetRootTitle(pParam->GetName());
       }
 
       CreatePopupMenu(control, mPromptPopupMenu, bounds, valIdx);
@@ -520,12 +520,12 @@ void IGraphics::PromptUserInput(IControl& control, const IRECT& bounds, int valI
     // TODO: what if there are Int/Double Params with a display text e.g. -96db = "mute"
     else // type == IParam::kTypeInt || type == IParam::kTypeDouble
     {
-      pParam->GetDisplayForHost(currentText, false);
+      pParam->GetDisplay(currentText, false);
       
       if(control.GetPromptShowsParamLabel())
       {
         currentText.Append(" ");
-        currentText.Append(pParam->GetLabelForHost());
+        currentText.Append(pParam->GetLabel());
       }
       
       CreateTextEntry(control, control.GetText(), bounds, currentText.Get(), valIdx);

--- a/IPlug/AAX/IPlugAAX.cpp
+++ b/IPlug/AAX/IPlugAAX.cpp
@@ -151,10 +151,10 @@ AAX_Result IPlugAAX::EffectInit()
       case IParam::kTypeDouble:
       {
         pAAXParam = new AAX_CParameter<double>(pParamIDStr->Get(),
-                                          AAX_CString(pParam->GetNameForHost()),
+                                          AAX_CString(pParam->GetName()),
                                           pParam->GetDefault(),
                                           AAX_CIPlugTaperDelegate<double>(*pParam),
-                                          AAX_CUnitDisplayDelegateDecorator<double>(AAX_CNumberDisplayDelegate<double>(), AAX_CString(pParam->GetLabelForHost())),
+                                          AAX_CUnitDisplayDelegateDecorator<double>(AAX_CNumberDisplayDelegate<double>(), AAX_CString(pParam->GetLabel())),
                                           pParam->GetCanAutomate());
         
         pAAXParam->SetNumberOfSteps(128); // TODO: check this https://developer.digidesign.com/index.php?L1=5&L2=13&L3=56
@@ -165,10 +165,10 @@ AAX_Result IPlugAAX::EffectInit()
       case IParam::kTypeInt:
       {
         pAAXParam = new AAX_CParameter<int>(pParamIDStr->Get(),
-                                        AAX_CString(pParam->GetNameForHost()),
+                                        AAX_CString(pParam->GetName()),
                                         (int)pParam->GetDefault(),
                                         AAX_CLinearTaperDelegate<int,1>((int)pParam->GetMin(), (int)pParam->GetMax()),
-                                        AAX_CUnitDisplayDelegateDecorator<int>(AAX_CNumberDisplayDelegate<int,0>(), AAX_CString(pParam->GetLabelForHost())),
+                                        AAX_CUnitDisplayDelegateDecorator<int>(AAX_CNumberDisplayDelegate<int,0>(), AAX_CString(pParam->GetLabel())),
                                         pParam->GetCanAutomate());
         
         pAAXParam->SetNumberOfSteps(128);
@@ -192,7 +192,7 @@ AAX_Result IPlugAAX::EffectInit()
         }
         
         pAAXParam = new AAX_CParameter<int>(pParamIDStr->Get(),
-                                        AAX_CString(pParam->GetNameForHost()),
+                                        AAX_CString(pParam->GetName()),
                                         (int)pParam->GetDefault(),
                                         AAX_CLinearTaperDelegate<int,1>((int) pParam->GetMin(), (int) pParam->GetMax()),
                                         AAX_CStringDisplayDelegate<int>(displayTexts),

--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -538,8 +538,8 @@ OSStatus IPlugAU::GetProperty(AudioUnitPropertyID propID, AudioUnitScope scope, 
         if (pParam->GetMeta()) pInfo->flags |= kAudioUnitParameterFlag_IsElementMeta;
         if (pParam->NDisplayTexts()) pInfo->flags |= kAudioUnitParameterFlag_ValuesHaveStrings;
 
-        const char* paramName = pParam->GetNameForHost();
-        pInfo->cfNameString = CFStringCreateWithCString(0, pParam->GetNameForHost(), kCFStringEncodingUTF8);
+        const char* paramName = pParam->GetName();
+        pInfo->cfNameString = CFStringCreateWithCString(0, pParam->GetName(), kCFStringEncodingUTF8);
         strcpy(pInfo->name, paramName);   // Max 52.
 
         switch (pParam->Type())
@@ -623,7 +623,7 @@ OSStatus IPlugAU::GetProperty(AudioUnitPropertyID propID, AudioUnitScope scope, 
         pInfo->maxValue = pParam->GetMax();
         pInfo->defaultValue = pParam->GetDefault();
         
-        const char* paramGroupName = pParam->GetGroupForHost();
+        const char* paramGroupName = pParam->GetGroup();
 
         if (CStringHasContents(paramGroupName))
         {
@@ -949,7 +949,7 @@ OSStatus IPlugAU::GetProperty(AudioUnitPropertyID propID, AudioUnitScope scope, 
         AudioUnitParameterIDName* pIDName = (AudioUnitParameterIDName*) pData;
         char cStr[MAX_PARAM_NAME_LEN];
         ENTER_PARAMS_MUTEX
-        strcpy(cStr, GetParam(pIDName->inID)->GetNameForHost());
+        strcpy(cStr, GetParam(pIDName->inID)->GetName());
         LEAVE_PARAMS_MUTEX
         if (pIDName->inDesiredLength != kAudioUnitParameterName_Full)
         {
@@ -997,7 +997,7 @@ OSStatus IPlugAU::GetProperty(AudioUnitPropertyID propID, AudioUnitScope scope, 
       {
         AudioUnitParameterStringFromValue* pSFV = (AudioUnitParameterStringFromValue*) pData;
         ENTER_PARAMS_MUTEX
-        GetParam(pSFV->inParamID)->GetDisplayForHost(*(pSFV->inValue), false, mParamDisplayStr);
+        GetParam(pSFV->inParamID)->GetDisplay(*(pSFV->inValue), false, mParamDisplayStr);
         LEAVE_PARAMS_MUTEX
         pSFV->outString = MakeCFString((const char*) mParamDisplayStr.Get());
       }

--- a/IPlug/AUv3/IPlugAUAudioUnit.mm
+++ b/IPlug/AUv3/IPlugAUAudioUnit.mm
@@ -314,7 +314,7 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
       }
     }
     
-    const char* paramGroupName = pParam->GetGroupForHost();
+    const char* paramGroupName = pParam->GetGroup();
     auto clumpID = 0;
 
     if (CStringHasContents(paramGroupName))
@@ -339,7 +339,7 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
     AUParameterAddress address = AUParameterAddress(paramIdx);
 
     AUParameter *pAUParam = [AUParameterTree createParameterWithIdentifier:    [NSString stringWithFormat:@"%d", paramIdx ]
-                                                                         name: [NSString stringWithCString:pParam->GetNameForHost() encoding:NSUTF8StringEncoding]
+                                                                         name: [NSString stringWithCString:pParam->GetName() encoding:NSUTF8StringEncoding]
                                                                       address: address
                                                                           min: pParam->GetMin()
                                                                           max: pParam->GetMax()
@@ -417,7 +417,7 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
 
   mParameterTree.implementorStringFromValueCallback = ^(AUParameter *param, const AUValue *__nullable valuePtr) {
     AUValue value = valuePtr == nil ? param.value : *valuePtr;
-    return [NSString stringWithCString:pPlug->GetParamDisplayForHost(param.address, value) encoding:NSUTF8StringEncoding];
+    return [NSString stringWithCString:pPlug->GetParamDisplay(param.address, value) encoding:NSUTF8StringEncoding];
   };
 
   mParameterTree.implementorValueFromStringCallback = ^(AUParameter* param, NSString* string) {

--- a/IPlug/AUv3/IPlugAUv3.h
+++ b/IPlug/AUv3/IPlugAUv3.h
@@ -61,7 +61,7 @@ public:
   void SetParameterFromValueObserver(uint64_t address, float value);
   void SendParameterValueFromObserver(uint64_t address, float value);
   float GetParameter(uint64_t address);
-  const char* GetParamDisplayForHost(uint64_t address, float value);
+  const char* GetParamDisplay(uint64_t address, float value);
   float GetParamStringToValue(uint64_t address, const char* str);
   void SetBuffers(AudioBufferList* pInBufferList, AudioBufferList* pOutBufferList);
   void Prepare(double sampleRate, uint32_t blockSize);

--- a/IPlug/AUv3/IPlugAUv3.mm
+++ b/IPlug/AUv3/IPlugAUv3.mm
@@ -228,12 +228,12 @@ float IPlugAUv3::GetParameter(uint64_t address)
   return val;
 }
 
-const char* IPlugAUv3::GetParamDisplayForHost(uint64_t address, float value)
+const char* IPlugAUv3::GetParamDisplay(uint64_t address, float value)
 {
   const int paramIdx = GetParamIdx(address);
 
   ENTER_PARAMS_MUTEX
-  GetParam(paramIdx)->GetDisplayForHost(value, false, mParamDisplayStr);
+  GetParam(paramIdx)->GetDisplay(value, false, mParamDisplayStr);
   LEAVE_PARAMS_MUTEX
   return (const char*) mParamDisplayStr.Get();
 }

--- a/IPlug/Extras/Faust/IPlugFaust.h
+++ b/IPlug/Extras/Faust/IPlugFaust.h
@@ -134,7 +134,7 @@ public:
       if(mZones.GetSize() == NParams())
         *(mZones.Get(paramIdx)) = mParams.Get(paramIdx)->Value();
       else
-        DBGMSG("IPlugFaust-%s:: Missing zone for parameter %s\n", mName.Get(), mParams.Get(paramIdx)->GetNameForHost());
+        DBGMSG("IPlugFaust-%s:: Missing zone for parameter %s\n", mName.Get(), mParams.Get(paramIdx)->GetName());
     }
   }
   
@@ -149,7 +149,7 @@ public:
     if(mZones.GetSize() == NParams())
       *(mZones.Get(paramIdx)) = nonNormalizedValue;
     else
-      DBGMSG("IPlugFaust-%s:: Missing zone for parameter %s\n", mName.Get(), mParams.Get(paramIdx)->GetNameForHost());
+      DBGMSG("IPlugFaust-%s:: Missing zone for parameter %s\n", mName.Get(), mParams.Get(paramIdx)->GetName());
     }
     else
       DBGMSG("SetParameterValue called with no FAUST params\n");
@@ -287,7 +287,7 @@ protected:
   {
     for(auto p = 0; p < NParams(); p++)
     {
-      mMap.Insert(mParams.Get(p)->GetNameForHost(), mZones.Get(p)); // insert will overwrite keys with the same name
+      mMap.Insert(mParams.Get(p)->GetName(), mZones.Get(p)); // insert will overwrite keys with the same name
     }
     
     if(mIPlugParamStartIdx > -1 && mPlug != nullptr) // if we've already linked parameters
@@ -297,7 +297,7 @@ protected:
     
     for(auto p = 0; p < NParams(); p++)
     {
-      DBGMSG("%i %s\n", p, mParams.Get(p)->GetNameForHost());
+      DBGMSG("%i %s\n", p, mParams.Get(p)->GetName());
     }
   }
 
@@ -305,7 +305,7 @@ protected:
   {
     for(auto p = 0; p < NParams(); p++)
     {
-      if(strcmp(name, mParams.Get(p)->GetNameForHost()) == 0)
+      if(strcmp(name, mParams.Get(p)->GetName()) == 0)
       {
         return p;
       }

--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -254,7 +254,7 @@ void IParam::SetDisplayText(double value, const char* str)
   strcpy(pDT->mText, str);
 }
 
-void IParam::GetDisplayForHost(double value, bool normalized, WDL_String& str, bool withDisplayText) const
+void IParam::GetDisplay(double value, bool normalized, WDL_String& str, bool withDisplayText) const
 {
   if (normalized) value = FromNormalized(value);
 
@@ -299,17 +299,17 @@ void IParam::GetDisplayForHost(double value, bool normalized, WDL_String& str, b
   }
 }
 
-const char* IParam::GetNameForHost() const
+const char* IParam::GetName() const
 {
   return mName;
 }
 
-const char* IParam::GetLabelForHost() const
+const char* IParam::GetLabel() const
 {
   return (CStringHasContents(GetDisplayText(static_cast<int>(mValue.load())))) ? "" : mLabel;
 }
 
-const char* IParam::GetGroupForHost() const
+const char* IParam::GetGroup() const
 {
   return mParamGroup;
 }
@@ -382,7 +382,7 @@ void IParam::GetJSON(WDL_String& json, int idx) const
 {
   json.AppendFormatted(8192, "{");
   json.AppendFormatted(8192, "\"id\":%i, ", idx);
-  json.AppendFormatted(8192, "\"name\":\"%s\", ", GetNameForHost());
+  json.AppendFormatted(8192, "\"name\":\"%s\", ", GetName());
   switch (Type())
   {
     case IParam::kTypeNone:
@@ -411,5 +411,5 @@ void IParam::GetJSON(WDL_String& json, int idx) const
 
 void IParam::PrintDetails() const
 {
-  DBGMSG("%s %f", GetNameForHost(), Value());
+  DBGMSG("%s %f", GetName(), Value());
 }

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -335,13 +335,13 @@ public:
   /** /todo 
    * @param display /todo
    * @param withDisplayText /todo */
-  void GetDisplayForHost(WDL_String& display, bool withDisplayText = true) const { GetDisplayForHost(mValue.load(), false, display, withDisplayText); }
+  void GetDisplay(WDL_String& display, bool withDisplayText = true) const { GetDisplay(mValue.load(), false, display, withDisplayText); }
 
-  void GetDisplayForHostWithLabel(WDL_String& display, bool withDisplayText = true) const
+  void GetDisplayWithLabel(WDL_String& display, bool withDisplayText = true) const
   {
-    GetDisplayForHost(mValue.load(), false, display, withDisplayText);
+    GetDisplay(mValue.load(), false, display, withDisplayText);
     display.Append(" ");
-    display.Append(GetLabelForHost());
+    display.Append(GetLabel());
   }
   
   /** /todo 
@@ -349,19 +349,19 @@ public:
    * @param normalized /todo
    * @param display /todo
    * @param withDisplayText /todo */
-  void GetDisplayForHost(double value, bool normalized, WDL_String& display, bool withDisplayText = true) const;
+  void GetDisplay(double value, bool normalized, WDL_String& display, bool withDisplayText = true) const;
 
   /** /todo 
    * @return const char* /todo */
-  const char* GetNameForHost() const;
+  const char* GetName() const;
 
   /** /todo 
    * @return const char* /todo */
-  const char* GetLabelForHost() const;
+  const char* GetLabel() const;
 
   /** /todo 
    * @return const char* /todo */
-  const char* GetGroupForHost() const;
+  const char* GetGroup() const;
 
   /** /todo 
    * @return const char* /todo */

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -112,7 +112,7 @@ bool IPluginBase::SerializeParams(IByteChunk& chunk) const
   for (i = 0; i < n && savedOK; ++i)
   {
     IParam* pParam = mParams.Get(i);
-    Trace(TRACELOC, "%d %s %f", i, pParam->GetNameForHost(), pParam->Value());
+    Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());
     double v = pParam->Value();
     savedOK &= (chunk.Put(&v) > 0);
   }
@@ -130,7 +130,7 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
     double v = 0.0;
     pos = chunk.Get(&v, pos);
     pParam->Set(v);
-    Trace(TRACELOC, "%d %s %f", i, pParam->GetNameForHost(), pParam->Value());
+    Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());
   }
 
   OnParamReset(kPresetRecall);
@@ -179,11 +179,11 @@ void IPluginBase::CopyParamValues(const char* inGroup, const char *outGroup)
   for (auto p = 0; p < NParams(); p++)
   {
     IParam* pParam = GetParam(p);
-    if(strcmp(pParam->GetGroupForHost(), inGroup) == 0)
+    if(strcmp(pParam->GetGroup(), inGroup) == 0)
     {
       inParams.Add(pParam);
     }
-    else if(strcmp(pParam->GetGroupForHost(), outGroup) == 0)
+    else if(strcmp(pParam->GetGroup(), outGroup) == 0)
     {
       outParams.Add(pParam);
     }
@@ -210,7 +210,7 @@ void IPluginBase::ForParamInGroup(const char* paramGroup, std::function<void (in
   for (auto p = 0; p < NParams(); p++)
   {
     IParam* pParam = GetParam(p);
-    if(strcmp(pParam->GetGroupForHost(), paramGroup) == 0)
+    if(strcmp(pParam->GetGroup(), paramGroup) == 0)
     {
       func(p, *pParam);
     }

--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -343,7 +343,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
       if (idx >= 0 && idx < _this->NParams())
       {
         ENTER_PARAMS_MUTEX_STATIC
-        strcpy((char*) ptr, _this->GetParam(idx)->GetLabelForHost());
+        strcpy((char*) ptr, _this->GetParam(idx)->GetLabel());
         LEAVE_PARAMS_MUTEX_STATIC
       }
       return 0;
@@ -353,7 +353,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
       if (idx >= 0 && idx < _this->NParams())
       {
         ENTER_PARAMS_MUTEX_STATIC
-        _this->GetParam(idx)->GetDisplayForHost(_this->mParamDisplayStr);
+        _this->GetParam(idx)->GetDisplay(_this->mParamDisplayStr);
         LEAVE_PARAMS_MUTEX_STATIC
         strcpy((char*) ptr, _this->mParamDisplayStr.Get());
       }
@@ -364,7 +364,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
       if (idx >= 0 && idx < _this->NParams())
       {
         ENTER_PARAMS_MUTEX_STATIC
-        strcpy((char*) ptr, _this->GetParam(idx)->GetNameForHost());
+        strcpy((char*) ptr, _this->GetParam(idx)->GetName());
         LEAVE_PARAMS_MUTEX_STATIC
       }
       return 0;
@@ -396,7 +396,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
             break;
         }
 
-        strcpy(props->label, pParam->GetLabelForHost());
+        strcpy(props->label, pParam->GetLabel());
         LEAVE_PARAMS_MUTEX_STATIC
 
         return 1;
@@ -777,7 +777,7 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
           {
             if (value >= 0 && value < _this->NParams())
             {
-              _this->GetParam((int) value)->GetDisplayForHost((double) opt, true, _this->mParamDisplayStr);
+              _this->GetParam((int) value)->GetDisplay((double) opt, true, _this->mParamDisplayStr);
               strcpy((char*) ptr, _this->mParamDisplayStr.Get());
             }
             return 0xbeef;

--- a/IPlug/VST3/IPlugVST3_ControllerBase.h
+++ b/IPlug/VST3/IPlugVST3_ControllerBase.h
@@ -86,7 +86,7 @@ public:
       IParam* pParam = pPlug->GetParam(i);
       unitID = Steinberg::Vst::kRootUnitId; // reset unitID
     
-      const char* paramGroupName = pParam->GetGroupForHost();
+      const char* paramGroupName = pParam->GetGroup();
       
       if (CStringHasContents(paramGroupName)) // if the parameter has a group
       {

--- a/IPlug/VST3/IPlugVST3_Parameter.h
+++ b/IPlug/VST3/IPlugVST3_Parameter.h
@@ -25,8 +25,8 @@ public:
   IPlugVST3Parameter(IParam* pParam, Steinberg::Vst::ParamID tag, Steinberg::Vst::UnitID unitID)
   : mIPlugParam(pParam)
   {
-    Steinberg::UString(info.title, str16BufferSize(Steinberg::Vst::String128)).assign(pParam->GetNameForHost());
-    Steinberg::UString(info.units, str16BufferSize(Steinberg::Vst::String128)).assign(pParam->GetLabelForHost());
+    Steinberg::UString(info.title, str16BufferSize(Steinberg::Vst::String128)).assign(pParam->GetName());
+    Steinberg::UString(info.units, str16BufferSize(Steinberg::Vst::String128)).assign(pParam->GetLabel());
 
     precision = pParam->GetDisplayPrecision();
 
@@ -49,7 +49,7 @@ public:
   void toString(Steinberg::Vst::ParamValue valueNormalized, Steinberg::Vst::String128 string) const override
   {
     WDL_String display;
-    mIPlugParam->GetDisplayForHost(valueNormalized, true, display);
+    mIPlugParam->GetDisplay(valueNormalized, true, display);
     Steinberg::UString(string, 128).fromAscii(display.Get());
   }
 

--- a/Tests/MetaParamTest/MetaParamTest.cpp
+++ b/Tests/MetaParamTest/MetaParamTest.cpp
@@ -40,7 +40,7 @@ struct FourValues : public IControl
     {
       WDL_String str;
       IRECT r = GetRect(num);
-      GetParam(num)->GetDisplayForHost(str);
+      GetParam(num)->GetDisplay(str);
       g.DrawText(mText, str.Get(), r);
     };
     


### PR DESCRIPTION
Shorten some IParam method names that have a pointless "ForHost" in their names