### PR TITLE
IPopupMenu::Item checked flag not working with submenus

### DIFF
--- a/IGraphics/IGraphicsPopupMenu.h
+++ b/IGraphics/IGraphicsPopupMenu.h
@@ -93,15 +93,19 @@ public:
       return true;
     }
     
-    void SetChecked(bool state)
+    void SetEnabled(bool state) { SetFlag(kDisabled,!state); }
+    void SetChecked(bool state) { SetFlag(kChecked,state); }
+    void SetTitle(bool state) {SetFlag(kTitle,state); }
+
+  protected:
+    void SetFlag(Flags flag, bool state)
     {
       if (state)
-        mFlags |= kChecked;
+        mFlags |= flag;
       else
-        mFlags &= ~kChecked;
+        mFlags &= ~flag;
     }
-    
-  protected:
+
     WDL_String mText;
     std::unique_ptr<IPopupMenu> mSubmenu;
     int mFlags;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1371,27 +1371,27 @@ HMENU IGraphicsWin::CreateMenu(IPopupMenu& menu, long* pOffsetIdx)
       //if (nItems < 160 && pMenu->getNbItemsPerColumn () > 0 && inc && !(inc % _menu->getNbItemsPerColumn ()))
       //  flags |= MF_MENUBARBREAK;
 
+      if (pMenuItem->GetEnabled())
+        flags |= MF_ENABLED;
+      else
+        flags |= MF_GRAYED;
+      if (pMenuItem->GetIsTitle())
+        flags |= MF_DISABLED;
+      if (pMenuItem->GetChecked())
+        flags |= MF_CHECKED;
+      else
+        flags |= MF_UNCHECKED;
+
       if (pMenuItem->GetSubmenu())
       {
         HMENU submenu = CreateMenu(*pMenuItem->GetSubmenu(), pOffsetIdx);
         if (submenu)
         {
-          AppendMenu(hMenu, flags|MF_POPUP|MF_ENABLED, (UINT_PTR)submenu, (const TCHAR*)entryText.Get());
+          AppendMenu(hMenu, flags|MF_POPUP, (UINT_PTR)submenu, (const TCHAR*)entryText.Get());
         }
       }
       else
       {
-        if (pMenuItem->GetEnabled())
-          flags |= MF_ENABLED;
-        else
-          flags |= MF_GRAYED;
-        if (pMenuItem->GetIsTitle())
-          flags |= MF_DISABLED;
-        if (pMenuItem->GetChecked())
-          flags |= MF_CHECKED;
-        else
-          flags |= MF_UNCHECKED;
-
         AppendMenu(hMenu, flags, offset + inc, entryText.Get());
       }
     }


### PR DESCRIPTION
Reported issue #485 

The pull request fixes the issue. I also added (for test properly the changes and improve existing API) the SetEnabled and SetTitle functions to the IPopupMenu::Item class.

Tested on Windows 10.