### PR TITLE
Disable warning 4244 on windows when including skia header files

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -3,11 +3,14 @@
 
 #include "IGraphicsSkia.h"
 
+#pragma warning( push )
+#pragma warning( disable : 4244 )
 #include "SkDashPathEffect.h"
 #include "SkGradientShader.h"
 #include "SkFont.h"
 #include "SkFontMetrics.h"
 #include "SkTypeface.h"
+#pragma warning( pop )
 
 #include "GrContext.h"
 

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -8,10 +8,13 @@
 #define SK_METAL
 #endif
 
+#pragma warning( push )
+#pragma warning( disable : 4244 )
 #include "SkSurface.h"
 #include "SkPath.h"
 #include "SkCanvas.h"
 #include "SkImage.h"
+#pragma warning( pop )
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -26,10 +26,13 @@
 #include "heapbuf.h"
 
 #ifdef IGRAPHICS_SKIA
+  #pragma warning( push )
+  #pragma warning( disable : 4244 )
   #include "experimental/svg/model/SkSVGDOM.h"
   #include "include/core/SkCanvas.h"
   #include "include/core/SkStream.h"
   #include "src/xml/SkDOM.h"
+  #pragma warning( pop )
 #else
   #include "nanosvg.h"
 #endif
@@ -51,8 +54,11 @@
 #elif defined IGRAPHICS_NANOVG
   #define BITMAP_DATA_TYPE int;
 #elif defined IGRAPHICS_SKIA
+  #pragma warning( push )
+  #pragma warning( disable : 4244 )
   #include "SkImage.h"
   #include "SkSurface.h"
+  #pragma warning( pop )
   struct SkiaDrawable
   {
     bool mIsSurface;


### PR DESCRIPTION
When building any IPlug project using skia on windows several 4244 warnings (conversion between types) appears.

It is a bit annoying and it makes harder to find own warnings.

Perfect solution would be fixing the warnings in skia but it would take too much time until an available version of skia with the fixes be available.

So the workaround in this PR is to disable the warning before including these files in IPlug and to re-enable the warning after it.

