### PR TITLE
Fixed crash when a ICaptionControl is constructed with no param linked

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -644,7 +644,8 @@ void ICaptionControl::Draw(IGraphics& g)
 
 void ICaptionControl::OnResize()
 {
-  if(GetParam()->Type() == IParam::kTypeEnum)
+  const IParam* param = GetParam();
+  if(param != NULL && param->Type() == IParam::kTypeEnum)
   {
     mTri = mRECT.FracRectHorizontal(0.2f, true).GetCentredInside(IRECT(0, 0, 8, 5)); //TODO: This seems rubbish
   }


### PR DESCRIPTION
With this fix a caption control can be created without any param linked to it during its construction, otherwise it crashed.

