### PR TITLE
VS multiprocessor compilation enabled

### DIFF
--- a/common-win.props
+++ b/common-win.props
@@ -80,6 +80,7 @@
       <DisableSpecificWarnings>4996;4250;4018;4267;4068;</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(WDL_PATH);$(IPLUG_PATH);$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp14</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Multiprocessor compilation enabled for all the projects, from common win props.

Faster compilation times are always welcome.
