### PR TITLE
Resize window flickering on windows fixed

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1633,7 +1633,6 @@ private:
   bool mEnableTooltips = false;
   bool mShowControlBounds = false;
   bool mShowAreaDrawn = false;
-  bool mResizingInProcess = false;
   bool mLayoutOnResize = false;
   bool mEnableMultiTouch = false;
   EUIResizerMode mGUISizeMode = EUIResizerMode::Scale;
@@ -1644,6 +1643,7 @@ private:
 protected:
   IGEditorDelegate* mDelegate;
   void* mPlatformContext = nullptr;
+  bool mResizingInProcess = false;
   bool mCursorHidden = false;
   bool mCursorLock = false;
   bool mTabletInput = false;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -201,7 +201,7 @@ void IGraphicsWin::DestroyEditWindow()
  }
 }
 
-void IGraphicsWin::OnDisplayTimer(int vBlankCount)
+void IGraphicsWin::OnDisplayTimer(int vBlankCount, bool forceDraw)
 {
 #ifdef IGRAPHICS_VSYNC
   // Check the message vblank with the current one to see if we are way behind. If so, then throw these away.
@@ -209,14 +209,14 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   DWORD curCount = mVBlankCount;
 
   // skip until the actual vblank is at a certain number.
-  if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > mVBlankCount)
+  if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > mVBlankCount && !forceDraw)
   {
     return;
   }
 
   mVBlankSkipUntil = 0;
 
-  if (msgCount != curCount)
+  if (msgCount != curCount && !forceDraw)
   {
     // we are late, just skip it until we can get a message soon after the vblank event.
     // DBGMSG("vblank is late by %i frames.  Skipping.", (mVBlankCount - msgCount));
@@ -430,6 +430,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
           pGraphics->OnMouseDrag(list);
           if (pGraphics->MouseCursorIsLocked())
             pGraphics->MoveMouseCursor(pGraphics->mHiddenCursorX, pGraphics->mHiddenCursorY);
+          pGraphics->OnDisplayTimer(0,true);
         }
       }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -430,7 +430,10 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
           pGraphics->OnMouseDrag(list);
           if (pGraphics->MouseCursorIsLocked())
             pGraphics->MoveMouseCursor(pGraphics->mHiddenCursorX, pGraphics->mHiddenCursorY);
-          pGraphics->OnDisplayTimer(0,true);
+          if (pGraphics->mResizingInProcess)
+          {
+            pGraphics->OnDisplayTimer(0,true);
+          }
         }
       }
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -103,7 +103,7 @@ private:
 
   /** Called either in response to WM_TIMER tick or user message WM_VBLANK, triggered by VSYNC thread
     * @param vBlankCount will allow redraws to get paced by the vblank message. Passing 0 is a WM_TIMER fallback. */
-  void OnDisplayTimer(int vBlankCount = 0);
+  void OnDisplayTimer(int vBlankCount = 0, bool forceDraw = false);
 
   enum EParamEditMsg
   {


### PR DESCRIPTION
On windows when the plugin window is resized an unpleasant flickering is producted in the window viewport.

This PR fixes that issue.

Please, if you could test this PR with other Windows systems it would be great because I only tested it on my machine.

Windows 10 64bit, nvidia GPU. Both NanoVG and Skia. IGRAPHICS_VSYNC enabled and disabled.

