### PR TITLE
Windows popup menu position improvement

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -615,7 +615,7 @@ void ICaptionControl::OnMouseDown(float x, float y, const IMouseMod& mod)
 {
   if (mod.L || mod.R)
   {
-    PromptUserInput(mRECT);
+    PromptUserInput(IRECT(x,y,x,y));
   }
 }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1420,7 +1420,21 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
 
     ::ClientToScreen(mPlugWnd, &cPos);
 
-    if (TrackPopupMenu(hMenu, TPM_LEFTALIGN, cPos.x, cPos.y, 0, mPlugWnd, 0))
+    UINT flags = TPM_LEFTALIGN;
+    HMONITOR hMonitor = MonitorFromPoint(cPos,MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo;
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (GetMonitorInfo(hMonitor,&monitorInfo))
+    {
+      LONG distanceLeft = abs(cPos.x-monitorInfo.rcWork.left);
+      LONG distanceRight = abs(cPos.x-monitorInfo.rcWork.right);
+      if (distanceRight < distanceLeft)
+      {
+        flags = TPM_RIGHTALIGN;
+      }
+    }
+
+    if (TrackPopupMenu(hMenu, flags, cPos.x, cPos.y, 0, mPlugWnd, 0))
     {
       MSG msg;
       if (PeekMessage(&msg, mPlugWnd, WM_COMMAND, WM_COMMAND, PM_REMOVE))


### PR DESCRIPTION
On Windows when a popupmenu window is created sometimes the position, depending on several factors, is not a good one and produces a very bad user experience when the mouse cursor is just over a selectable option of the popup menu and unintencionally the option is selected and the popup is closed.

This PR contains two improvements:

1) To open the popup the caption control uses the mouse position instead of the control rect. This improves a lot the user experience because the popup menu in most cases will not appear over the mouse cursor.

2) The second improvement covers the case when the vertical size of the popupmenu is bigger than the distance from the mouse cursor to the top/bottom position of the screen. The improvement consist in: when the track menu is created instead of always using the left align position of the menu it checks if the mouse position is nearest to the left or right side of the screen and will select the left/right align option for the menu depending on it. This avoids the cases when the window is near to a horizontal border of the screen and part of the menu appears over the mouse cursor.

With both improvements the only border case I found is when the popupmenu size (horizontal+vertical) is as big as the computer screen. Anyway this was already happening without these improvements, so that's not a problem.



