### PR TITLE
Fix examples breaking on case-sensitive FS

### DIFF
--- a/Examples/IPlugControls/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugControls/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 

--- a/Examples/IPlugControls/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugControls/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugControls/scripts/prepare_resources-win.py
+++ b/Examples/IPlugControls/scripts/prepare_resources-win.py
@@ -7,16 +7,16 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def main():
   print("not modifying rc file");
   # config = parse_config(projectpath)
-  
+
   # rc = open(projectpath + "/resources/main.rc", "w")
-  
+
   # rc.write("\n")
   # rc.write("/////////////////////////////////////////////////////////////////////////////\n")
   # rc.write("// Version\n")
@@ -48,7 +48,7 @@ def main():
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.aaxplugin"\0\n')
   # rc.write("#elif defined APP_API\n")
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.exe"\0\n')
-  # rc.write("#endif\n")  
+  # rc.write("#endif\n")
   # rc.write('            VALUE "FileDescription", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "InternalName", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "ProductName", "' + config['PLUG_NAME'] + '"\0\n')

--- a/Examples/IPlugControls/scripts/update_installer_version.py
+++ b/Examples/IPlugControls/scripts/update_installer_version.py
@@ -8,13 +8,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -22,7 +22,7 @@ def replacestrs(filename, s, r):
 
 def main():
   demo = 0
-  
+
   if len(sys.argv) != 2:
     print("Usage: update_installer_version.py demo(0 or 1)")
     sys.exit(1)
@@ -34,10 +34,10 @@ def main():
 # MAC INSTALLER
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = projectpath + "/installer/" + config['BUNDLE_NAME'] + ".pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   # range  = number of items in the installer (VST 2, VST 3, app, audiounit, aax)
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
@@ -51,10 +51,10 @@ def main():
 
   plistlib.writePlist(installer, plistpath)
 #   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
 # WIN INSTALLER
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(projectpath + "/installer/" + config['BUNDLE_NAME'] + ".iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"
@@ -63,28 +63,28 @@ def main():
         line="OutputBaseFilename=IPlugControls Demo Installer\n"
       else:
         line="OutputBaseFilename=IPlugControls Installer\n"
-        
+
     if 'Source: "readme' in line:
      if demo:
       line='Source: "readme-win-demo.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
      else:
       line='Source: "readme-win.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
-    
+
     if "WelcomeLabel1" in line:
      if demo:
        line="WelcomeLabel1=Welcome to the IPlugControls Demo installer\n"
      else:
        line="WelcomeLabel1=Welcome to the IPlugControls installer\n"
-       
+
     if "SetupWindowTitle" in line:
      if demo:
        line="SetupWindowTitle=IPlugControls Demo installer\n"
      else:
        line="SetupWindowTitle=IPlugControls installer\n"
-       
+
     sys.stdout.write(line)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
   main()

--- a/Examples/IPlugControls/scripts/update_version.py
+++ b/Examples/IPlugControls/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugControls-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugControls-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugControls-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugControls-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugControls-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugControls.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugControls.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"

--- a/Examples/IPlugEffect/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugEffect/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 
@@ -90,7 +90,7 @@ def main():
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Synth"
   else:
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Effects"
-    
+
   auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][1] = "size:{" + str(config['PLUG_WIDTH']) + "," + str(config['PLUG_HEIGHT']) + "}"
 
   plistlib.writePlist(auv3, plistpath)

--- a/Examples/IPlugEffect/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugEffect/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugEffect/scripts/prepare_resources-win.py
+++ b/Examples/IPlugEffect/scripts/prepare_resources-win.py
@@ -7,16 +7,16 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def main():
   print("not modifying rc file");
   # config = parse_config(projectpath)
-  
+
   # rc = open(projectpath + "/resources/main.rc", "w")
-  
+
   # rc.write("\n")
   # rc.write("/////////////////////////////////////////////////////////////////////////////\n")
   # rc.write("// Version\n")
@@ -48,7 +48,7 @@ def main():
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.aaxplugin"\0\n')
   # rc.write("#elif defined APP_API\n")
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.exe"\0\n')
-  # rc.write("#endif\n")  
+  # rc.write("#endif\n")
   # rc.write('            VALUE "FileDescription", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "InternalName", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "ProductName", "' + config['PLUG_NAME'] + '"\0\n')

--- a/Examples/IPlugEffect/scripts/update_installer_version.py
+++ b/Examples/IPlugEffect/scripts/update_installer_version.py
@@ -8,13 +8,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -22,7 +22,7 @@ def replacestrs(filename, s, r):
 
 def main():
   demo = 0
-  
+
   if len(sys.argv) != 2:
     print("Usage: update_installer_version.py demo(0 or 1)")
     sys.exit(1)
@@ -34,10 +34,10 @@ def main():
 # MAC INSTALLER
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = projectpath + "/installer/" + config['BUNDLE_NAME'] + ".pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   # range  = number of items in the installer (VST 2, VST 3, app, audiounit, aax)
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
@@ -51,10 +51,10 @@ def main():
 
   plistlib.writePlist(installer, plistpath)
 #   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
 # WIN INSTALLER
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(projectpath + "/installer/" + config['BUNDLE_NAME'] + ".iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"
@@ -63,28 +63,28 @@ def main():
         line="OutputBaseFilename=IPlugEffect Demo Installer\n"
       else:
         line="OutputBaseFilename=IPlugEffect Installer\n"
-        
+
     if 'Source: "readme' in line:
      if demo:
       line='Source: "readme-win-demo.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
      else:
       line='Source: "readme-win.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
-    
+
     if "WelcomeLabel1" in line:
      if demo:
        line="WelcomeLabel1=Welcome to the IPlugEffect Demo installer\n"
      else:
        line="WelcomeLabel1=Welcome to the IPlugEffect installer\n"
-       
+
     if "SetupWindowTitle" in line:
      if demo:
        line="SetupWindowTitle=IPlugEffect Demo installer\n"
      else:
        line="SetupWindowTitle=IPlugEffect installer\n"
-       
+
     sys.stdout.write(line)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
   main()

--- a/Examples/IPlugEffect/scripts/update_version.py
+++ b/Examples/IPlugEffect/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugEffect-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugEffect-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugEffect-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugEffect-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugEffect-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugEffect.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugEffect.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"

--- a/Examples/IPlugFaustDSP/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugFaustDSP/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 
@@ -90,7 +90,7 @@ def main():
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Synth"
   else:
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Effects"
-    
+
   auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][1] = "size:{" + str(config['PLUG_WIDTH']) + "," + str(config['PLUG_HEIGHT']) + "}"
 
 

--- a/Examples/IPlugFaustDSP/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugFaustDSP/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugFaustDSP/scripts/prepare_resources-win.py
+++ b/Examples/IPlugFaustDSP/scripts/prepare_resources-win.py
@@ -7,16 +7,16 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def main():
   print("not modifying rc file");
   # config = parse_config(projectpath)
-  
+
   # rc = open(projectpath + "/resources/main.rc", "w")
-  
+
   # rc.write("\n")
   # rc.write("/////////////////////////////////////////////////////////////////////////////\n")
   # rc.write("// Version\n")
@@ -48,7 +48,7 @@ def main():
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.aaxplugin"\0\n')
   # rc.write("#elif defined APP_API\n")
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.exe"\0\n')
-  # rc.write("#endif\n")  
+  # rc.write("#endif\n")
   # rc.write('            VALUE "FileDescription", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "InternalName", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "ProductName", "' + config['PLUG_NAME'] + '"\0\n')

--- a/Examples/IPlugFaustDSP/scripts/update_installer_version.py
+++ b/Examples/IPlugFaustDSP/scripts/update_installer_version.py
@@ -8,13 +8,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -22,7 +22,7 @@ def replacestrs(filename, s, r):
 
 def main():
   demo = 0
-  
+
   if len(sys.argv) != 2:
     print("Usage: update_installer_version.py demo(0 or 1)")
     sys.exit(1)
@@ -34,10 +34,10 @@ def main():
 # MAC INSTALLER
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = projectpath + "/installer/" + config['BUNDLE_NAME'] + ".pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   # range  = number of items in the installer (VST 2, VST 3, app, audiounit, aax)
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
@@ -51,10 +51,10 @@ def main():
 
   plistlib.writePlist(installer, plistpath)
 #   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
 # WIN INSTALLER
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(projectpath + "/installer/" + config['BUNDLE_NAME'] + ".iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"
@@ -63,28 +63,28 @@ def main():
         line="OutputBaseFilename=IPlugFaustDSP Demo Installer\n"
       else:
         line="OutputBaseFilename=IPlugFaustDSP Installer\n"
-        
+
     if 'Source: "readme' in line:
      if demo:
       line='Source: "readme-win-demo.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
      else:
       line='Source: "readme-win.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
-    
+
     if "WelcomeLabel1" in line:
      if demo:
        line="WelcomeLabel1=Welcome to the IPlugFaustDSP Demo installer\n"
      else:
        line="WelcomeLabel1=Welcome to the IPlugFaustDSP installer\n"
-       
+
     if "SetupWindowTitle" in line:
      if demo:
        line="SetupWindowTitle=IPlugFaustDSP Demo installer\n"
      else:
        line="SetupWindowTitle=IPlugFaustDSP installer\n"
-       
+
     sys.stdout.write(line)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
   main()

--- a/Examples/IPlugFaustDSP/scripts/update_version.py
+++ b/Examples/IPlugFaustDSP/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugFaustDSP-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugFaustDSP-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugFaustDSP-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugFaustDSP-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugFaustDSP-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugFaustDSP.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugFaustDSP.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"

--- a/Examples/IPlugInstrument/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugInstrument/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 
@@ -90,7 +90,7 @@ def main():
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Synth"
   else:
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Effects"
-    
+
   auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][1] = "size:{" + str(config['PLUG_WIDTH']) + "," + str(config['PLUG_HEIGHT']) + "}"
 
 

--- a/Examples/IPlugInstrument/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugInstrument/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugInstrument/scripts/prepare_resources-win.py
+++ b/Examples/IPlugInstrument/scripts/prepare_resources-win.py
@@ -7,16 +7,16 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def main():
   print("not modifying rc file");
   # config = parse_config(projectpath)
-  
+
   # rc = open(projectpath + "/resources/main.rc", "w")
-  
+
   # rc.write("\n")
   # rc.write("/////////////////////////////////////////////////////////////////////////////\n")
   # rc.write("// Version\n")
@@ -48,7 +48,7 @@ def main():
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.aaxplugin"\0\n')
   # rc.write("#elif defined APP_API\n")
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.exe"\0\n')
-  # rc.write("#endif\n")  
+  # rc.write("#endif\n")
   # rc.write('            VALUE "FileDescription", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "InternalName", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "ProductName", "' + config['PLUG_NAME'] + '"\0\n')

--- a/Examples/IPlugInstrument/scripts/update_installer_version.py
+++ b/Examples/IPlugInstrument/scripts/update_installer_version.py
@@ -8,13 +8,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -22,7 +22,7 @@ def replacestrs(filename, s, r):
 
 def main():
   demo = 0
-  
+
   if len(sys.argv) != 2:
     print("Usage: update_installer_version.py demo(0 or 1)")
     sys.exit(1)
@@ -34,10 +34,10 @@ def main():
 # MAC INSTALLER
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = projectpath + "/installer/" + config['BUNDLE_NAME'] + ".pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   # range  = number of items in the installer (VST 2, VST 3, app, audiounit, aax)
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
@@ -51,10 +51,10 @@ def main():
 
   plistlib.writePlist(installer, plistpath)
 #   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
 # WIN INSTALLER
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(projectpath + "/installer/" + config['BUNDLE_NAME'] + ".iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"
@@ -63,28 +63,28 @@ def main():
         line="OutputBaseFilename=IPlugInstrument Demo Installer\n"
       else:
         line="OutputBaseFilename=IPlugInstrument Installer\n"
-        
+
     if 'Source: "readme' in line:
      if demo:
       line='Source: "readme-win-demo.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
      else:
       line='Source: "readme-win.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
-    
+
     if "WelcomeLabel1" in line:
      if demo:
        line="WelcomeLabel1=Welcome to the IPlugInstrument Demo installer\n"
      else:
        line="WelcomeLabel1=Welcome to the IPlugInstrument installer\n"
-       
+
     if "SetupWindowTitle" in line:
      if demo:
        line="SetupWindowTitle=IPlugInstrument Demo installer\n"
      else:
        line="SetupWindowTitle=IPlugInstrument installer\n"
-       
+
     sys.stdout.write(line)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
   main()

--- a/Examples/IPlugInstrument/scripts/update_version.py
+++ b/Examples/IPlugInstrument/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugInstrument-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugInstrument-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugInstrument-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugInstrument-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugInstrument-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugInstrument.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugInstrument.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"

--- a/Examples/IPlugMidiEffect/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugMidiEffect/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 

--- a/Examples/IPlugMidiEffect/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugMidiEffect/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugMidiEffect/scripts/prepare_resources-win.py
+++ b/Examples/IPlugMidiEffect/scripts/prepare_resources-win.py
@@ -7,16 +7,16 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def main():
   print("not modifying rc file");
   # config = parse_config(projectpath)
-  
+
   # rc = open(projectpath + "/resources/main.rc", "w")
-  
+
   # rc.write("\n")
   # rc.write("/////////////////////////////////////////////////////////////////////////////\n")
   # rc.write("// Version\n")
@@ -48,7 +48,7 @@ def main():
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.aaxplugin"\0\n')
   # rc.write("#elif defined APP_API\n")
   # rc.write('            VALUE "OriginalFilename", "' + config['BUNDLE_NAME'] + '.exe"\0\n')
-  # rc.write("#endif\n")  
+  # rc.write("#endif\n")
   # rc.write('            VALUE "FileDescription", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "InternalName", "' + config['PLUG_NAME'] + '"\0\n')
   # rc.write('            VALUE "ProductName", "' + config['PLUG_NAME'] + '"\0\n')

--- a/Examples/IPlugMidiEffect/scripts/update_version.py
+++ b/Examples/IPlugMidiEffect/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugMidiEffect-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugMidiEffect-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugMidiEffect-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugMidiEffect-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugMidiEffect-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugMidiEffect.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugMidiEffect.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"

--- a/Examples/IPlugSwift/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugSwift/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 
@@ -90,7 +90,7 @@ def main():
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Synth"
   else:
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Effects"
-    
+
   auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][1] = "size:{" + str(config['PLUG_WIDTH']) + "," + str(config['PLUG_HEIGHT']) + "}"
 
 

--- a/Examples/IPlugWebView/scripts/prepare_resources-ios.py
+++ b/Examples/IPlugWebView/scripts/prepare_resources-ios.py
@@ -14,7 +14,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -22,21 +22,21 @@ def main():
   if(len(sys.argv) == 2):
      if(sys.argv[1] == "app"):
        print "Copying resources ..."
-     
+
        dst = os.environ["TARGET_BUILD_DIR"] + "/" + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
-          
+
        if os.path.exists(projectpath + "/resources/img/"):
          imgs = os.listdir(projectpath + "/resources/img/")
          for img in imgs:
            print "copying " + img + " to " + dst
            shutil.copy(projectpath + "/resources/img/" + img, dst)
-     
+
        if os.path.exists(projectpath + "/resources/fonts/"):
          fonts = os.listdir(projectpath + "/resources/fonts/")
          for font in fonts:
            print "copying " + font + " to " + dst
            shutil.copy(projectpath + "/resources/fonts/" + font, dst)
-           
+
   config = parse_config(projectpath)
   xcconfig = parse_xcconfig(os.path.join(os.getcwd(), IPLUG2_ROOT +  '/common-ios.xcconfig'))
 
@@ -90,7 +90,7 @@ def main():
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Synth"
   else:
     auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][0] = "Effects"
-    
+
   auv3['NSExtension']['NSExtensionAttributes']['AudioComponents'][0]['tags'][1] = "size:{" + str(config['PLUG_WIDTH']) + "," + str(config['PLUG_HEIGHT']) + "}"
 
 

--- a/Examples/IPlugWebView/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugWebView/scripts/prepare_resources-mac.py
@@ -16,7 +16,7 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
@@ -90,7 +90,7 @@ def main():
 
 # AUDIOUNIT v2
 
-  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-au-Info.plist"
+  plistpath = projectpath + "/resources/" + config['BUNDLE_NAME'] + "-AU-Info.plist"
   auv2 = plistlib.readPlist(plistpath)
   auv2['CFBundleExecutable'] = config['BUNDLE_NAME']
   auv2['CFBundleGetInfoString'] = CFBundleGetInfoString

--- a/Examples/IPlugWebView/scripts/update_installer_version.py
+++ b/Examples/IPlugWebView/scripts/update_installer_version.py
@@ -8,13 +8,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -22,7 +22,7 @@ def replacestrs(filename, s, r):
 
 def main():
   demo = 0
-  
+
   if len(sys.argv) != 2:
     print("Usage: update_installer_version.py demo(0 or 1)")
     sys.exit(1)
@@ -34,10 +34,10 @@ def main():
 # MAC INSTALLER
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = projectpath + "/installer/" + config['BUNDLE_NAME'] + ".pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   # range  = number of items in the installer (VST 2, VST 3, app, audiounit, aax)
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
@@ -51,10 +51,10 @@ def main():
 
   plistlib.writePlist(installer, plistpath)
 #   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
 # WIN INSTALLER
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(projectpath + "/installer/" + config['BUNDLE_NAME'] + ".iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"
@@ -63,28 +63,28 @@ def main():
         line="OutputBaseFilename=IPlugWebView Demo Installer\n"
       else:
         line="OutputBaseFilename=IPlugWebView Installer\n"
-        
+
     if 'Source: "readme' in line:
      if demo:
       line='Source: "readme-win-demo.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
      else:
       line='Source: "readme-win.rtf"; DestDir: "{app}"; DestName: "readme.rtf"; Flags: isreadme\n'
-    
+
     if "WelcomeLabel1" in line:
      if demo:
        line="WelcomeLabel1=Welcome to the IPlugWebView Demo installer\n"
      else:
        line="WelcomeLabel1=Welcome to the IPlugWebView installer\n"
-       
+
     if "SetupWindowTitle" in line:
      if demo:
        line="SetupWindowTitle=IPlugWebView Demo installer\n"
      else:
        line="SetupWindowTitle=IPlugWebView installer\n"
-       
+
     sys.stdout.write(line)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
   main()

--- a/Examples/IPlugWebView/scripts/update_version.py
+++ b/Examples/IPlugWebView/scripts/update_version.py
@@ -9,13 +9,13 @@ projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
 IPLUG2_ROOT = "../../.."
 
-sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/scripts'))
+sys.path.insert(0, os.path.join(os.getcwd(), IPLUG2_ROOT + '/Scripts'))
 
 from parse_config import parse_config, parse_xcconfig
 
 def replacestrs(filename, s, r):
   files = glob.glob(filename)
-  
+
   for line in fileinput.input(files,inplace=1):
     string.find(line, s)
     line = line.replace(s, r)
@@ -24,15 +24,15 @@ def replacestrs(filename, s, r):
 def main():
 
   config = parse_config(projectpath)
-    
+
   today = datetime.date.today()
-  
+
   CFBundleGetInfoString = config['BUNDLE_NAME'] + " v" + config['FULL_VER_STR'] + " " + config['PLUG_COPYRIGHT_STR']
   CFBundleVersion = config['FULL_VER_STR']
 
   print "update_version.py - setting version to " + config['FULL_VER_STR']
   print "Updating plist version info..."
-  
+
   plistpath = scriptpath + "/resources/IPlugWebView-VST2-Info.plist"
   vst2 = plistlib.readPlist(plistpath)
   vst2['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -40,7 +40,7 @@ def main():
   vst2['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst2, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugWebView-AU-Info.plist"
   au = plistlib.readPlist(plistpath)
   au['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -48,7 +48,7 @@ def main():
   au['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(au, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugWebView-VST3-Info.plist"
   vst3 = plistlib.readPlist(plistpath)
   vst3['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -56,7 +56,7 @@ def main():
   vst3['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(vst3, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugWebView-macOS-Info.plist"
   app = plistlib.readPlist(plistpath)
   app['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -64,7 +64,7 @@ def main():
   app['CFBundleShortVersionString'] = CFBundleVersion
   plistlib.writePlist(app, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   plistpath = scriptpath + "/resources/IPlugWebView-AAX-Info.plist"
   aax = plistlib.readPlist(plistpath)
   aax['CFBundleGetInfoString'] = CFBundleGetInfoString
@@ -74,18 +74,18 @@ def main():
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
 
   print "Updating Mac Installer version info..."
-  
+
   plistpath = scriptpath + "/installer/IPlugWebView.pkgproj"
   installer = plistlib.readPlist(plistpath)
-  
+
   for x in range(0,5):
     installer['PACKAGES'][x]['PACKAGE_SETTINGS']['VERSION'] = config['FULL_VER_STR']
-  
+
   plistlib.writePlist(installer, plistpath)
   replacestrs(plistpath, "//Apple//", "//Apple Computer//");
-  
+
   print "Updating Windows Installer version info..."
-  
+
   for line in fileinput.input(scriptpath + "/installer/IPlugWebView.iss",inplace=1):
     if "AppVersion" in line:
       line="AppVersion=" + config['FULL_VER_STR'] + "\n"


### PR DESCRIPTION
This PR attempts to fix the problem stated in the issue #499: the examples break on a case-sensitive FS.

This is my first contribution attempt and I am just starting to learn and use IPlug2 :) Might have missed something (some other case-dependent stuff). This fix eliminates the problem for me.

