### PR TITLE
Plugin config option to allow execution of multiple app instances

### DIFF
--- a/IPlug/APP/IPlugAPP_main.cpp
+++ b/IPlug/APP/IPlugAPP_main.cpp
@@ -34,6 +34,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdPa
 {
   try
   {
+#ifndef APP_ALLOW_MULTIPLE_INSTANCES
     HANDLE hMutex = OpenMutex(MUTEX_ALL_ACCESS, 0, BUNDLE_NAME); // BUNDLE_NAME used because it won't have spaces in it
     
     if (!hMutex)
@@ -44,7 +45,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdPa
       SetForegroundWindow(hWnd);
       return 0; // should return 1?
     }
-    
+#endif
     gHINSTANCE = hInstance;
     
     InitCommonControls();
@@ -129,7 +130,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdPa
     if (gHWND)
       DestroyWindow(gHWND);
     
+#ifndef APP_ALLOW_MULTIPLE_INSTANCES
     ReleaseMutex(hMutex);
+#endif
   }
   catch(...)
   {


### PR DESCRIPTION
For most of the plugins, when executed as standalone app makes sense to allow only 1 instance execution at the same time.

But there are some cases where more of 1 app instance execution at the same time is desirable.

This PR contains a small change on Windows platform where, when defined APP_ALLOW_MULTIPLE_INSTANCES in the plugin config.h file, it will allow multiple app instances at the same time.
