### PR TITLE
Channel name, index, namespace, namespace index and color working

### DIFF
--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -146,11 +146,20 @@ public:
   void SetParameterValue(int paramIdx, double normalizedValue);
   
   /** Get the color of the track that the plug-in is inserted on */
-  virtual void GetTrackColor(int& r, int& g, int& b) {};
+  virtual void GetTrackColor(int& r, int& g, int& b) { r = 0; g = 0; b = 0; };
 
   /** Get the name of the track that the plug-in is inserted on */
   virtual void GetTrackName(WDL_String& str) {};
-  
+
+  /** Get the index of the track that the plug-in is inserted on */
+  virtual int GetTrackIndex() { return 0; };
+
+  /** Get the namespace of the track that the plug-in is inserted on */
+  virtual void GetTrackNamespace(WDL_String& str) {};
+
+  /** Get the namespace index of the track that the plug-in is inserted on */
+  virtual int GetTrackNamespaceIndex() { return 0; };
+
   /** /todo */
   virtual void DirtyParametersFromUI() override;
 

--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -189,33 +189,32 @@ Steinberg::tresult PLUGIN_API IPlugVST3::setChannelContextInfos(Steinberg::Vst::
   if (pList)
   {
     // optional we can ask for the Channel Name Length
-    int64 length = 0;
+    int64 length;
     if (pList->getInt(ChannelContext::kChannelNameLengthKey, length) == kResultTrue)
     {
+      // get the Channel Name where we, as Plug-in, are instantiated
+      std::vector<TChar> name(length+1);
+      if (pList->getString(ChannelContext::kChannelNameKey, name.data(), length+1) == kResultTrue)
+      {
+        Steinberg::String str(name.data());
+        str.toMultiByte(kCP_Utf8);
+        mChannelName.Set(str);
+      }
     }
     
-    // get the Channel Name where we, as Plug-in, are instantiated
-    std::vector<TChar> name(length+1);
-    if (pList->getString(ChannelContext::kChannelNameKey, name.data(), length+1) == kResultTrue)
-    {
-      Steinberg::String str(name.data());
-      str.toMultiByte(kCP_Utf8);
-      mChannelName.Set(str);
-    }
-
     // get the channel uid Namespace Length
     if (pList->getInt(ChannelContext::kChannelUIDLengthKey, length) == kResultTrue)
     {
+      // get the Channel UID
+      std::vector<TChar> name(length+1);
+      if (pList->getString(ChannelContext::kChannelUIDKey, name.data(), length+1) == kResultTrue)
+      {
+        Steinberg::String str(name.data());
+        str.toMultiByte(kCP_Utf8);
+        mChannelUID.Set(str);
+      }
     }
 
-    // get the Channel UID
-    name = std::vector<TChar>(length+1);
-    if (pList->getString(ChannelContext::kChannelUIDKey, name.data(), length+1) == kResultTrue)
-    {
-      Steinberg::String str(name.data());
-      str.toMultiByte(kCP_Utf8);
-      mChannelUID.Set(str);
-    }
     
     // get Channel Index
     int64 index;
@@ -238,19 +237,18 @@ Steinberg::tresult PLUGIN_API IPlugVST3::setChannelContextInfos(Steinberg::Vst::
     }
   
     // get the channel Index Namespace Length
-    length = 0;
     if (pList->getInt(ChannelContext::kChannelIndexNamespaceLengthKey, length) == kResultTrue)
     {
+      // get the channel Index Namespace
+      std::vector<TChar> name(length+1);
+      if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, name.data(), length+1) == kResultTrue)
+      {
+        Steinberg::String str(name.data());
+        str.toMultiByte(kCP_Utf8);
+        mChannelNamespace.Set(str);
+      }
     }
     
-    // get the channel Index Namespace
-    name = std::vector<TChar>(length+1);
-    if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, name.data(), length+1) == kResultTrue)
-    {
-      Steinberg::String str(name.data());
-      str.toMultiByte(kCP_Utf8);
-      mChannelNamespace.Set(str);
-    }
 
     // get Plug-in Channel Location
     int64 location;

--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -30,6 +30,9 @@ IPlugVST3::IPlugVST3(const InstanceInfo& info, const Config& config)
 : IPlugAPIBase(config, kAPIVST3)
 , IPlugVST3ProcessorBase(config, *this)
 , mView(nullptr)
+, mChannelIndex(0)
+, mChannelColor(0)
+, mChannelNamespaceIndex(0)
 {
   CreateTimer();
 }
@@ -186,56 +189,67 @@ Steinberg::tresult PLUGIN_API IPlugVST3::setChannelContextInfos(Steinberg::Vst::
   if (pList)
   {
     // optional we can ask for the Channel Name Length
-    int64 length;
+    int64 length = 0;
     if (pList->getInt(ChannelContext::kChannelNameLengthKey, length) == kResultTrue)
     {
     }
     
     // get the Channel Name where we, as Plug-in, are instantiated
-    String128 name;
-    if (pList->getString(ChannelContext::kChannelNameKey, name, sizeof (name)) == kResultTrue)
+    std::vector<TChar> name(length+1);
+    if (pList->getString(ChannelContext::kChannelNameKey, name.data(), length+1) == kResultTrue)
+    {
+      Steinberg::String str(name.data());
+      str.toMultiByte(kCP_Utf8);
+      mChannelName.Set(str);
+    }
+
+    // get the channel uid Namespace Length
+    if (pList->getInt(ChannelContext::kChannelUIDLengthKey, length) == kResultTrue)
     {
     }
 
     // get the Channel UID
-    if (pList->getString(ChannelContext::kChannelUIDKey, name, sizeof (name)) == kResultTrue)
+    name = std::vector<TChar>(length+1);
+    if (pList->getString(ChannelContext::kChannelUIDKey, name.data(), length+1) == kResultTrue)
     {
+      Steinberg::String str(name.data());
+      str.toMultiByte(kCP_Utf8);
+      mChannelUID.Set(str);
     }
     
     // get Channel Index
     int64 index;
     if (pList->getInt(ChannelContext::kChannelIndexKey, index) == kResultTrue)
     {
+      mChannelIndex = index;
     }
     
     // get the Channel Color
     int64 color;
     if (pList->getInt(ChannelContext::kChannelColorKey, color) == kResultTrue)
     {
-      uint32 channelColor = (uint32)color;
-      String str;
-      str.printf ("%x%x%x%x", ChannelContext::GetAlpha (channelColor),
-      ChannelContext::GetRed (channelColor),
-      ChannelContext::GetGreen (channelColor),
-      ChannelContext::GetBlue (channelColor));
-      String128 string128;
-      Steinberg::UString (string128, 128).fromAscii (str);
+      mChannelColor = (uint32)color;
     }
 
     // get Channel Index Namespace Order of the current used index namespace
     if (pList->getInt(ChannelContext::kChannelIndexNamespaceOrderKey, index) == kResultTrue)
     {
+      mChannelNamespaceIndex = index;
     }
   
     // get the channel Index Namespace Length
+    length = 0;
     if (pList->getInt(ChannelContext::kChannelIndexNamespaceLengthKey, length) == kResultTrue)
     {
     }
     
     // get the channel Index Namespace
-    String128 namespaceName;
-    if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, namespaceName, sizeof (namespaceName)) == kResultTrue)
+    name = std::vector<TChar>(length+1);
+    if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, name.data(), length+1) == kResultTrue)
     {
+      Steinberg::String str(name.data());
+      str.toMultiByte(kCP_Utf8);
+      mChannelNamespace.Set(str);
     }
 
     // get Plug-in Channel Location

--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -96,7 +96,23 @@ public:
   
   // IInfoListener
   Steinberg::tresult PLUGIN_API setChannelContextInfos(Steinberg::Vst::IAttributeList* list) override;
-  
+
+
+  /** Get the color of the track that the plug-in is inserted on */
+  virtual void GetTrackColor(int& r, int& g, int& b) override { r = (mChannelColor>>16)&0xff; g = (mChannelColor>>8)&0xff; b = mChannelColor&0xff; };
+
+  /** Get the name of the track that the plug-in is inserted on */
+  virtual void GetTrackName(WDL_String& str) override { str = mChannelName; };
+
+  /** Get the index of the track that the plug-in is inserted on */
+  virtual int GetTrackIndex() override { return mChannelIndex; };
+
+  /** Get the namespace of the track that the plug-in is inserted on */
+  virtual void GetTrackNamespace(WDL_String& str) override { str = mChannelNamespace; };
+
+  /** Get the namespace index of the track that the plug-in is inserted on */
+  virtual int GetTrackNamespaceIndex() override { return mChannelNamespaceIndex; };
+
   Steinberg::Vst::IComponentHandler* GetComponentHandler() { return componentHandler; }
   ViewType* GetView() { return mView; }
    
@@ -110,6 +126,12 @@ public:
 
 private:
   ViewType* mView;
+  WDL_String mChannelName;
+  int mChannelIndex;
+  unsigned int mChannelColor;
+  WDL_String mChannelNamespace;
+  int mChannelNamespaceIndex;
+  WDL_String mChannelUID;
 };
 
 IPlugVST3* MakePlug(const InstanceInfo& info);


### PR DESCRIPTION
Channel context functions implemented

Here's another branch with a modified IPlugEffect that uses the channel context functions:

https://github.com/baktery/iPlug2/tree/VST3/ichannelcontext_extended_example

