### PR TITLE
Native window maximize and resize supported on Apps

### DIFF
--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -10,6 +10,7 @@
 
 #include "IPlugAPP.h"
 #include "IPlugAPP_host.h"
+#include "IGraphics.h"
 
 #if defined OS_MAC || defined OS_LINUX
 #include <IPlugSWELL.h>
@@ -35,9 +36,21 @@ IPlugAPP::IPlugAPP(const InstanceInfo& info, const Config& config)
   CreateTimer();
 }
 
+void IPlugAPP::WindowResize(int width, int height)
+{
+  igraphics::IGraphics* pGraphics = GetUI();
+
+  m_parentResized = true;
+  if(pGraphics && pGraphics->GetResizerMode() == igraphics::EUIResizerMode::Size)
+  {
+    pGraphics->Resize(width,height,pGraphics->GetDrawScale());
+  }
+  m_parentResized = false;
+}
+
 bool IPlugAPP::EditorResize(int viewWidth, int viewHeight)
 {
-  bool parentResized = false;
+  bool parentResized = m_parentResized;
     
   if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
   {

--- a/IPlug/APP/IPlugAPP.h
+++ b/IPlug/APP/IPlugAPP.h
@@ -55,10 +55,13 @@ public:
   //IPlugAPP
   void AppProcess(double** inputs, double** outputs, int nFrames);
 
+  void WindowResize(int width, int height);
+
 private:
   IPlugAPPHost* mAppHost = nullptr;
   IPlugQueue<IMidiMsg> mMidiMsgsFromCallback {MIDI_TRANSFER_SIZE};
   IPlugQueue<SysExData> mSysExMsgsFromCallback {SYSEX_TRANSFER_SIZE};
+  bool m_parentResized = false;
 
   friend class IPlugAPPHost;
 };

--- a/IPlug/APP/IPlugAPP_dialog.cpp
+++ b/IPlug/APP/IPlugAPP_dialog.cpp
@@ -566,6 +566,23 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
     case WM_CLOSE:
       DestroyWindow(hwndDlg);
       return 0;
+
+    #ifdef OS_WIN
+    case WM_SIZE:
+    {
+      int w = LOWORD(lParam);
+      int h = HIWORD(lParam);
+
+      IPlugAPP* pPlug = pAppHost->GetPlug();
+
+      if(pPlug)
+      {
+        pPlug->WindowResize(w,h);
+      }
+    }
+    return 0;
+    #endif
+
     case WM_COMMAND:
       switch (LOWORD(wParam))
       {


### PR DESCRIPTION
For some plugins, when built as standalone app, it is interesting to enable the native window maximize button and the native window resize feature with the mouse (window borders).

IPlug2 already supported configuring the main app window dialog just modifying the IDD_DIALOG_MAIN resource, so enabling the window maximize button and setting the window borders as resizable was possible but it was not managed by the main window dialog function.

This PR adds the needed management on Windows. Native mouse resizing and native windows maximize button will work when the plugin is built as standalone app, a EUIResizerMode::Size type corner resizer has been attached to IGraphics and a maximize button and/or window border resize type has been enabled in the IDD_DIALOG_MAIN.

Native resizing lives together with corner resizer, so both resizing mechanisms are available at the same time.

It has been tested on Windows 10 with Skia and NanoVG, 


