### PR TITLE
Add parameter display precision setter

### DIFF
--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -254,6 +254,11 @@ void IParam::SetDisplayText(double value, const char* str)
   strcpy(pDT->mText, str);
 }
 
+void IParam::SetDisplayPrecision(int precision)
+{
+  mDisplayPrecision = precision;
+}
+
 void IParam::GetDisplayForHost(double value, bool normalized, WDL_String& str, bool withDisplayText) const
 {
   if (normalized) value = FromNormalized(value);

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -304,7 +304,11 @@ public:
    * @param value /todo
    * @param str /todo */
   void SetDisplayText(double value, const char* str);
-  
+
+  /** Set the parameters display precision
+ * @param precision The display precision in digits*/
+  void SetDisplayPrecision(int precision);
+
   /** Set the parameters label after creation. WARNING: if this is called after the host has queried plugin parameters, the host may display the label as it was previously
    * @param label /todo */
   void SetLabel(const char* label) { strcpy(mLabel, label); }


### PR DESCRIPTION
With this addition the display precision can be easily set (independently from the step size) after initialization - without using a custom display function.