### PR TITLE
Correct parameter value display

### DIFF
--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -340,8 +340,12 @@ public:
   void GetDisplayForHostWithLabel(WDL_String& display, bool withDisplayText = true) const
   {
     GetDisplayForHost(mValue.load(), false, display, withDisplayText);
-    display.Append(" ");
-    display.Append(GetLabelForHost());
+    const char* hostlabel = GetLabelForHost();
+    if (CStringHasContents(hostlabel))
+    {
+      display.Append(" ");
+      display.Append(hostlabel);
+    }
   }
   
   /** /todo 


### PR DESCRIPTION
At the moment all display values without a unit aren't centered below knobs (due to unnecessary extra space), this fixes it.