### PR TITLE
Correct IVKnobControl zero tracksize

### DIFF
--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -573,7 +573,10 @@ void IVKnobControl::DrawWidget(IGraphics& g)
 
 void IVKnobControl::DrawIndicatorTrack(IGraphics& g, float angle, float cx, float cy, float radius)
 {
-  g.DrawArc(GetColor(kX1), cx, cy, radius, angle >= mAnchorAngle ? mAnchorAngle : mAnchorAngle - (mAnchorAngle - angle), angle >= mAnchorAngle ? angle : mAnchorAngle, &mBlend, mTrackSize);
+  if (mTrackSize > 0.f)
+  {
+    g.DrawArc(GetColor(kX1), cx, cy, radius, angle >= mAnchorAngle ? mAnchorAngle : mAnchorAngle - (mAnchorAngle - angle), angle >= mAnchorAngle ? angle : mAnchorAngle, &mBlend, mTrackSize);
+  }
 }
 
 void IVKnobControl::DrawPointer(IGraphics& g, float angle, float cx, float cy, float radius)


### PR DESCRIPTION
At least with Skia / Win10, IVKnobControl draws a very fine track arc even when the tracksize in the constructor is set to zero = 0.f. This fix prevents it, screenshot from IPlugControls example with tracksize 0.f:
![grafik](https://user-images.githubusercontent.com/48643530/81467568-c6f38400-91d9-11ea-94c6-982e0326ef22.png)
