### PR TITLE
bugfix: IAttributeList::getString() size parameter is bytes, not TChars

### DIFF
--- a/IPlug/VST3/IPlugVST3_ControllerBase.h
+++ b/IPlug/VST3/IPlugVST3_ControllerBase.h
@@ -212,8 +212,11 @@ public:
       if (pList->getInt(ChannelContext::kChannelNameLengthKey, length) == kResultTrue)
       {
         // get the channel name where we, as plug-in, are instantiated
-        std::vector<TChar> name(length + 1);
-        if (pList->getString(ChannelContext::kChannelNameKey, name.data(), static_cast<Steinberg::uint32>(length + 1)) == kResultTrue)
+        // Note: length is multiplied by two because Ableton Live 10.1.13 is buggy
+        // and pList->getString() size parameter is interpreted as TChar instead
+        // of byte: end of string zero value is written in an out of memory position
+        std::vector<TChar> name((length+1)*2);
+        if (pList->getString(ChannelContext::kChannelNameKey, name.data(),  static_cast<Steinberg::uint32>(length+1)*sizeof(TChar)) == kResultTrue)
         {
           Steinberg::String str(name.data());
           str.toMultiByte(kCP_Utf8);
@@ -225,8 +228,11 @@ public:
       if (pList->getInt(ChannelContext::kChannelUIDLengthKey, length) == kResultTrue)
       {
         // get the channel UID
-        std::vector<TChar> name(length + 1);
-        if (pList->getString(ChannelContext::kChannelUIDKey, name.data(), static_cast<Steinberg::uint32>(length + 1)) == kResultTrue)
+        // Note: length is multiplied by two because Ableton Live 10.1.13 is buggy
+        // and pList->getString() size parameter is interpreted as TChar instead
+        // of byte: end of string zero value is written in an out of memory position
+        std::vector<TChar> name((length+1)*2);
+        if (pList->getString(ChannelContext::kChannelUIDKey, name.data(), static_cast<Steinberg::uint32>(length+1)*sizeof(TChar)) == kResultTrue)
         {
           Steinberg::String str(name.data());
           str.toMultiByte(kCP_Utf8);
@@ -258,8 +264,11 @@ public:
       if (pList->getInt(ChannelContext::kChannelIndexNamespaceLengthKey, length) == kResultTrue)
       {
         // get the channel index namespace
-        std::vector<TChar> name(length + 1);
-        if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, name.data(), static_cast<Steinberg::uint32>(length + 1)) == kResultTrue)
+        // Note: length is multiplied by two because Ableton Live 10.1.13 is buggy
+        // and pList->getString() size parameter is interpreted as TChar instead
+        // of byte: end of string zero value is written in an out of memory position
+        std::vector<TChar> name((length+1)*2);
+        if (pList->getString(ChannelContext::kChannelIndexNamespaceKey, name.data(), static_cast<Steinberg::uint32>(length+1)*sizeof(TChar)) == kResultTrue)
         {
           Steinberg::String str(name.data());
           str.toMultiByte(kCP_Utf8);


### PR DESCRIPTION
Channel name was working fine on Live 10. Today I installed Reaper and tried my plugin with it and I noticed that names were cropped.

Two issues are fixed in this PR:

1. First issue is on IPlug side:

From Steinberg's SDK:

```
/** Gets string value (UTF16). Note that Size is in Byte, not the string Length! (Do not forget to multiply the length by sizeof (TChar)!) */
virtual tresult PLUGIN_API getString (AttrID id, TChar* string, uint32 size) = 0;
```
pList->getString() size parameter is the number of bytes of the buffer, not the number of TChars. So, now size if multiplied by sizeof(TChar) in order to send the proper size value to the host when calling getString() function.

2. Second issue is on Ableton Live 10.1.13 side:

Once the proper size in bytes is sent to the getString function IPlug crashed on Live.

I did some tests and I noticed that Live is incorrectly interpreting size as TChars and not in bytes as specified by Steinberg's VST3 SDK.

This is a simple way to reproduce the issue:

```
const int dataSize = 1024; 
unsigned char* data = new unsigned char[dataSize*2]; 
memset(data,0xff,dataSize*2); 
memset(data,0xfe,dataSize); 
if (pList->getString(ChannelContext::kChannelNameKey,(TChar*)data,dataSize) == kResultTrue) 
{ 
  // out of range offset 2046 and 2057 are set to zero 
  assert(data[2046] == 0xff && data[2047] == 0xff); 
}
```

In order to protect IPlug against memory corruption on users using a Live buggy version, with this PR IPlug doubles the buffer size, that way Live writes the extra end of string zero in a valid memory location.

Also a bug report has been sent to Ableton.
