### PR TITLE
macOS: Switch to use CVDisplayLink instead of NSTimer, fix OpenGL on macOS

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -429,7 +429,7 @@ void IGraphicsNanoVG::OnViewInitialized(void* pContext)
 #if defined IGRAPHICS_METAL
   mVG = nvgCreateContext(pContext, NVG_ANTIALIAS | NVG_TRIPLE_BUFFER); //TODO: NVG_STENCIL_STROKES currently has issues
 #else
-  mVG = nvgCreateContext(NVG_ANTIALIAS | NVG_STENCIL_STROKES);
+  mVG = nvgCreateContext(NVG_ANTIALIAS /*| NVG_STENCIL_STROKES*/);
 #endif
 
   if (mVG == nullptr)

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -130,7 +130,7 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
       
 #ifdef IGRAPHICS_GL
-    [pView openGLContext makeCurrentContext];
+    [[pView openGLContext] makeCurrentContext];
 #endif
       
     [pView removeAllToolTips];

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -101,16 +101,13 @@ void* IGraphicsMac::OpenWindow(void* pParent)
 {
   TRACE
   CloseWindow();
-  mView = (IGRAPHICS_VIEW*) [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
-  
-#ifndef IGRAPHICS_GL // with OpenGL, we don't get given the glcontext until later, ContextReady will get called elsewhere
-  IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
+  IGRAPHICS_VIEW* pView = [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
+  mView = (void*) pView;
   ContextReady([pView layer]);
-#endif
   
   if (pParent)
   {
-    [(NSView*) pParent addSubview: (IGRAPHICS_VIEW*) mView];
+    [(NSView*) pParent addSubview: pView];
   }
 
   return mView;
@@ -133,7 +130,7 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
       
 #ifdef IGRAPHICS_GL
-    [((IGRAPHICS_GLLAYER *)pView.layer).openGLContext makeCurrentContext];
+    [pView openGLContext makeCurrentContext];
 #endif
       
     [pView removeAllToolTips];

--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -109,8 +109,8 @@ using namespace igraphics;
 
 @interface IGRAPHICS_VIEW : NSView <NSTextFieldDelegate/*, WKScriptMessageHandler*/>
 {
+  CVDisplayLinkRef displayLink;
   NSTrackingArea* mTrackingArea;
-  NSTimer* mTimer;
   IGRAPHICS_TEXTFIELD* mTextFieldView;
   NSCursor* mMoveCursor;
   float mPrevX, mPrevY;
@@ -128,7 +128,6 @@ using namespace igraphics;
 - (void) viewDidChangeBackingProperties: (NSNotification*) pNotification;
 - (void) drawRect: (NSRect) bounds;
 - (void) render;
-- (void) onTimer: (NSTimer*) pTimer;
 - (void) killTimer;
 //mouse
 - (void) getMouseXY: (NSEvent*) pEvent : (float&) x : (float&) y;

--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -107,7 +107,13 @@ using namespace igraphics;
 - (bool) becomeFirstResponder;
 @end
 
-@interface IGRAPHICS_VIEW : NSView <NSTextFieldDelegate/*, WKScriptMessageHandler*/>
+#ifdef IGRAPHICS_GL
+#define VIEW_BASE NSOpenGLView
+#else
+#define VIEW_BASE NSView
+#endif
+
+@interface IGRAPHICS_VIEW : VIEW_BASE <NSTextFieldDelegate/*, WKScriptMessageHandler*/>
 {
   CVDisplayLinkRef displayLink;
   NSTrackingArea* mTrackingArea;
@@ -165,14 +171,6 @@ using namespace igraphics;
 - (BOOL) performDragOperation: (id<NSDraggingInfo>) sender;
 //
 - (void) setMouseCursor: (ECursor) cursorType;
-@end
-
-@interface IGRAPHICS_GLLAYER : NSOpenGLLayer
-{
-  IGRAPHICS_VIEW* mView;
-}
-
-- (id) initWithIGraphicsView: (IGRAPHICS_VIEW*) pView;
 @end
 
 #ifdef IGRAPHICS_IMGUI

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -431,7 +431,7 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
     // that we can remove such calls.
     // Without this we'd simply get GL_INVALID_OPERATION error for calling legacy functions
     // but it would be more difficult to see where that function was called.
-    CGLEnable([context CGLContextObj], kCGLCECrashOnRemovedFunctions);
+//    CGLEnable([context CGLContextObj], kCGLCECrashOnRemovedFunctions); //SKIA_GL2 will crash
   #endif
   
     self.pixelFormat = pf;
@@ -444,7 +444,6 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
 #endif
   
   [self registerForDraggedTypes:[NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
-  
   
   #if !defined IGRAPHICS_GL
   [self setTimer];
@@ -620,7 +619,8 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
       mGraphics->Draw(drawRects);
     }
   }
-  #else
+  #else // this gets called on resize
+  //TODO: set GL context/flush?
   mGraphics->Draw(mDirtyRects);
   #endif
 }
@@ -644,7 +644,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
       mGraphics->Draw(mDirtyRects);
     #endif
     #ifdef IGRAPHICS_GL
-      CGLFlushDrawable([[self openGLContext] CGLContextObj]);
+    [[self openGLContext] flushBuffer];
     #endif
   }
 }


### PR DESCRIPTION
I believe this PR fixes #26, also fixes long standing issue of borked GL on macOS.

It completely removes the NSTimer, which maybe we should put back for the situation where you might want to have a lower FPS.