### PR TITLE
VS Disable warning 5030 produced by latest skia version

### DIFF
--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -28,6 +28,7 @@
 #ifdef IGRAPHICS_SKIA
   #pragma warning( push )
   #pragma warning( disable : 4244 )
+  #pragma warning( disable : 5030 )
   #include "experimental/svg/model/SkSVGDOM.h"
   #include "include/core/SkCanvas.h"
   #include "include/core/SkStream.h"


### PR DESCRIPTION
With latest Skia version a warning is produced when compiling IPlug from Visual Studio with Skia enabled.

This PR disables the warning when including skia headers.
