### PR TITLE
Igraphics sweep gradients

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -166,8 +166,9 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
   SkPaint paint;
   paint.setAntiAlias(true);
   paint.setBlendMode(SkiaBlendMode(pBlend));
+  int numStops = pattern.NStops();
     
-  if (pattern.mType == EPatternType::Solid || pattern.NStops() <  2)
+  if (pattern.mType == EPatternType::Solid || numStops <  2)
   {
     paint.setColor(SkiaColor(pattern.GetStop(0).mColor, pBlend));
   }
@@ -192,9 +193,9 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
     SkColor colors[8];
     SkScalar positions[8];
       
-    assert(pattern.NStops() <= 8);
+    assert(numStops <= 8);
     
-    for(int i = 0; i < pattern.NStops(); i++)
+    for(int i = 0; i < numStops; i++)
     {
       const IColorStop& stop = pattern.GetStop(i);
       colors[i] = SkiaColor(stop.mColor, pBlend);
@@ -204,7 +205,7 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
     switch (pattern.mType)
     {
     case EPatternType::Linear:
-      paint.setShader(SkGradientShader::MakeLinear(points, colors, positions, pattern.NStops(), SkiaTileMode(pattern), 0, nullptr));
+      paint.setShader(SkGradientShader::MakeLinear(points, colors, positions, numStops, SkiaTileMode(pattern), 0, nullptr));
       break;
 
     case EPatternType::Radial:
@@ -212,7 +213,7 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
       float xd = points[0].x() - points[1].x();
       float yd = points[0].y() - points[1].y();
       float radius = std::sqrt(xd * xd + yd * yd);
-      paint.setShader(SkGradientShader::MakeRadial(points[0], radius, colors, positions, pattern.NStops(), SkiaTileMode(pattern), 0, nullptr));
+      paint.setShader(SkGradientShader::MakeRadial(points[0], radius, colors, positions, numStops, SkiaTileMode(pattern), 0, nullptr));
       break;
     }
 
@@ -220,8 +221,8 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
     {
       SkMatrix matrix = SkMatrix::MakeAll(m.mXX, m.mYX, 0, m.mXY, m.mYY, 0, 0, 0, 1);
       
-      paint.setShader(SkGradientShader::MakeSweep(x1, y1, colors, positions, pattern.NStops(), SkTileMode::kDecal,
-        0, 360*positions[pattern.NStops()-1], 0, &matrix));
+      paint.setShader(SkGradientShader::MakeSweep(x1, y1, colors, positions, numStops, SkTileMode::kDecal,
+        0, 360*positions[numStops - 1], 0, &matrix));
 
       break;
     }

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -221,8 +221,8 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
     {
       SkMatrix matrix = SkMatrix::MakeAll(m.mXX, m.mYX, 0, m.mXY, m.mYY, 0, 0, 0, 1);
       
-      paint.setShader(SkGradientShader::MakeSweep(x1, y1, colors, positions, numStops, SkTileMode::kDecal,
-        0, 360*positions[numStops - 1], 0, &matrix));
+      paint.setShader(SkGradientShader::MakeSweep(x1, y1, colors, nullptr, numStops, SkTileMode::kDecal,
+        0, 360 * positions[numStops - 1], 0, &matrix));
 
       break;
     }

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -200,16 +200,34 @@ SkPaint SkiaPaint(const IPattern& pattern, const IBlend* pBlend)
       colors[i] = SkiaColor(stop.mColor, pBlend);
       positions[i] = stop.mOffset;
     }
-   
-    if(pattern.mType == EPatternType::Linear)
+
+    switch (pattern.mType)
+    {
+    case EPatternType::Linear:
       paint.setShader(SkGradientShader::MakeLinear(points, colors, positions, pattern.NStops(), SkiaTileMode(pattern), 0, nullptr));
-    else
+      break;
+
+    case EPatternType::Radial:
     {
       float xd = points[0].x() - points[1].x();
       float yd = points[0].y() - points[1].y();
       float radius = std::sqrt(xd * xd + yd * yd);
-        
       paint.setShader(SkGradientShader::MakeRadial(points[0], radius, colors, positions, pattern.NStops(), SkiaTileMode(pattern), 0, nullptr));
+      break;
+    }
+
+    case EPatternType::Sweep:
+    {
+      SkMatrix matrix = SkMatrix::MakeAll(m.mXX, m.mYX, 0, m.mXY, m.mYY, 0, 0, 0, 1);
+      
+      paint.setShader(SkGradientShader::MakeSweep(x1, y1, colors, positions, pattern.NStops(), SkTileMode::kDecal,
+        0, 360*positions[pattern.NStops()-1], 0, &matrix));
+
+      break;
+    }
+
+    default:
+      break;
     }
   }
     

--- a/IGraphics/IGraphicsConstants.h
+++ b/IGraphics/IGraphicsConstants.h
@@ -136,7 +136,7 @@ enum class ELineCap { Butt, Round, Square };
 enum class ELineJoin { Miter, Round, Bevel };
 
 /** /todo */
-enum class EPatternType { Solid, Linear, Radial };
+enum class EPatternType { Solid, Linear, Radial, Sweep };
 
 /** /todo */
 enum class EPatternExtend { None, Pad, Reflect, Repeat };

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -2149,6 +2149,24 @@ struct IPattern
     
     return pattern;
   }
+
+  static IPattern CreateSweepGradient(float x1, float y1, const std::initializer_list<IColorStop>& stops = {},
+    float angleStart = 0.0, float angleEnd = 360.0)
+  {
+    IPattern pattern(EPatternType::Sweep);
+
+    float rad = DegToRad(angleStart);
+    float c = std::cos(rad);
+    float s = std::sin(rad);
+
+    pattern.SetTransform(c, s, -s, c, -x1, -y1);
+
+    for (auto& stop : stops)
+    {
+      pattern.AddStop(stop.mColor, stop.mOffset * (angleEnd - angleStart) / 360.0);
+    }
+    return pattern;
+  }
   
   /** /todo 
    * @return int /todo */

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -2155,6 +2155,11 @@ struct IPattern
   {
     IPattern pattern(EPatternType::Sweep);
 
+    #ifdef IGRAPHICS_SKIA
+      angleStart -= 90;
+      angleEnd -= 90;
+    #endif
+
     float rad = DegToRad(angleStart);
     float c = std::cos(rad);
     float s = std::sin(rad);


### PR DESCRIPTION
This PR adds a new `IPattern` type for gradients: the sweep gradient.

Unfortunately, this is only implemented for the SKIA backend, so I can totally understand if you reject it.

I followed the existing code style in the sense that I added a static create method to the IPattern class where in addition to the center position and the color stops, you can provide the angle start and end points.

If I remember correctly (it is already one year old or so) it works in both rotation directions and I definitely know that it works for angles > 360°.

Disclaimer: not optimized, not documented, not unit tested, works on my computer :)