### PR TITLE
added missing EndInformHostOfParamChangeFromUI on dropdown selection

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1806,6 +1806,14 @@ void IGraphics::DoCreatePopupMenu(IControl& control, IPopupMenu& menu, const IRE
     if(!isAsync)
       SetControlValueAfterPopupMenu(pReturnMenu);
   }
+  
+  int nVals = control.NVals();
+  
+  for (int v = 0; v < nVals; v++)
+  {
+    if (control.GetParamIdx(v) > kNoParameter)
+      GetDelegate()->EndInformHostOfParamChangeFromUI(control.GetParamIdx(v));
+  }
 }
 
 void IGraphics::CreatePopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds, int valIdx)


### PR DESCRIPTION
Fixes issue #540 adding the missing call to EndInformHostOfParamChangeFromUI when an option is chosen from a dropdown or the dropdown is dismissed.

The BeginInformHostOfParamChangeFromUI is called on IGraphics::OnMouseDown and the EndInformHostOfParamChangeFromUI is never called for a dropdown since it's linked to the OnMouseOut event of the control that is never triggered for an ICaptionControl with a dropdown.