### PR TITLE
fix Windows graphics-tablet mouse event detection

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -167,7 +167,8 @@ void IGraphicsWin::CheckTabletInput(UINT msg)
     const LONG_PTR c_MOUSEEVENTF_FROMTOUCH = 0xFF515700;
     
     LONG_PTR extraInfo = GetMessageExtraInfo();
-    SetTabletInput(((extraInfo & c_SIGNATURE_MASK) == c_MOUSEEVENTF_FROMTOUCH));
+    bool touchOrPen = !(((extraInfo & 0x7F) && (IsWindowsVistaOrGreater()? (extraInfo & 0x80) : 1)) || ((extraInfo & c_SIGNATURE_MASK) == c_MOUSEEVENTF_FROMTOUCH));
+    SetTabletInput(touchOrPen);
     mCursorLock &= !mTabletInput;
   }
 }


### PR DESCRIPTION
As discussed in the forum (https://iplug2.discourse.group/t/windows-tablets-not-detected-correctly/), the original code does not detect my Wacom graphics tablet correctly on Win10 Pro x64 (pen mouse events do not set c_MOUSEEVENTF_FROMTOUCH signature).  The extended detection code that works correctly is adapted  from libSDL (http://hg.libsdl.org/SDL/rev/8254c364ec4a), these are their comments:

* Mouse data (ignoring synthetic mouse events generated for touchscreens) */ 
/* Versions below Vista will set the low 7 bits to the Mouse ID and don't use bit 7:
   Check bits 8-32 for the signature (which will indicate a Tablet PC Pen or Touch Device).
   Only check bit 7 when Vista and up(Cleared=Pen, Set=Touch(which we need to filter out)),
   when the signature is set. The Mouse ID will be zero for an actual mouse. */
