### PR TITLE
Allow ICornerResizerControl colour customisation (backwards compat.)

### DIFF
--- a/IGraphics/Controls/ICornerResizerControl.h
+++ b/IGraphics/Controls/ICornerResizerControl.h
@@ -26,19 +26,21 @@ BEGIN_IGRAPHICS_NAMESPACE
 class ICornerResizerControl : public IControl
 {
 public:
-  ICornerResizerControl(IRECT graphicsBounds, float size)
+  ICornerResizerControl(IRECT graphicsBounds, float size, IColor color = COLOR_TRANSLUCENT, IColor mouseOverColour = COLOR_BLACK, IColor dragColor = COLOR_BLACK)
   : IControl(graphicsBounds.GetFromBRHC(size, size).GetPadded(-1))
   , mInitialGraphicsBounds(graphicsBounds)
   , mSize(size)
+  , mColor (color)
+  , mMouseOverColor (mouseOverColour)
+  , mDragColor (dragColor)
   {
   }
 
   void Draw(IGraphics& g) override
   {
-    if(GetMouseIsOver() || GetUI()->mResizingInProcess)
-      g.FillTriangle(COLOR_BLACK, mRECT.L, mRECT.B, mRECT.R, mRECT.T, mRECT.R, mRECT.B);
-    else
-      g.FillTriangle(COLOR_TRANSLUCENT, mRECT.L, mRECT.B, mRECT.R, mRECT.T, mRECT.R, mRECT.B);
+  const IColor &col = GetUI()->mResizingInProcess? mDragColor :
+                      GetMouseIsOver()? mMouseOverColor : mColor;
+  g.FillTriangle(col, mRECT.L, mRECT.B, mRECT.R, mRECT.T, mRECT.R, mRECT.B);
   }
 
   void OnMouseDown(float x, float y, const IMouseMod& mod) override
@@ -78,6 +80,8 @@ private:
   bool mMouseOver = false;
   ECursor mPrevCursorType = ECursor::ARROW;
   IRECT mInitialGraphicsBounds;
+
+  IColor mColor, mMouseOverColor, mDragColor;
 };
 
 END_IGRAPHICS_NAMESPACE

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -273,9 +273,9 @@ IControl* IGraphics::AttachControl(IControl* pControl, int ctrlTag, const char* 
   return pControl;
 }
 
-void IGraphics::AttachCornerResizer(EUIResizerMode sizeMode, bool layoutOnResize)
+void IGraphics::AttachCornerResizer(EUIResizerMode sizeMode, bool layoutOnResize, IColor color, IColor mouseOverColor, IColor dragColor)
 {
-  AttachCornerResizer(new ICornerResizerControl(GetBounds(), 20), sizeMode, layoutOnResize);
+  AttachCornerResizer(new ICornerResizerControl(GetBounds(), 20, color, mouseOverColor, dragColor), sizeMode, layoutOnResize);
 }
 
 void IGraphics::AttachCornerResizer(ICornerResizerControl* pControl, EUIResizerMode sizeMode, bool layoutOnResize)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1226,7 +1226,7 @@ public:
   
   /** Attach the default control to scale or increase the UI size by dragging the plug-in bottom right-hand corner
    * @param sizeMode Choose whether to scale or size the UI */
-  void AttachCornerResizer(EUIResizerMode sizeMode = EUIResizerMode::Scale, bool layoutOnResize = false);
+  void AttachCornerResizer(EUIResizerMode sizeMode = EUIResizerMode::Scale, bool layoutOnResize = false, IColor color = COLOR_TRANSLUCENT, IColor mouseOverColour = COLOR_BLACK, IColor dragColor = COLOR_BLACK);
 
   /** Attach your own control to scale or increase the UI size by dragging the plug-in bottom right-hand corner
    * @param pControl control a control that inherits from ICornerResizerControl


### PR DESCRIPTION
Extends ICornerResizerControl with customisable colours for dragging, mouseover and idle, including the IGraphics::AttachCornerResizer() call.  Fully backwards compatible.

Especially useful for dark backgrounds where the current black colour is largely invisible.