### PR TITLE
Fix VST host lookup for OpenMPT

### DIFF
--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -202,7 +202,7 @@ static EHost LookUpHost(const char* inHost)
   if (strstr(host, "vst3plugintesthost"))   return kHostVST3TestHost;
   if (strstr(host, "ardour"))               return kHostArdour;
   if (strstr(host, "renoise"))              return kHostRenoise;
-  if (strstr(host, "OpenMPT"))              return kHostOpenMPT;
+  if (strstr(host, "openmpt"))              return kHostOpenMPT;
   if (strstr(host, "wavelab elements"))     return kHostWaveLabElements; // check for wavelab elements should come before wavelab ...
   if (strstr(host, "wavelab"))              return kHostWaveLab;
   if (strstr(host, "twistedwave"))          return kHostTwistedWave;


### PR DESCRIPTION
`strstr(host, "OpenMPT")` would never be true,
since `host` is converted to lowercase.
