### PR TITLE
Correctly sizes plugin window on windows and 200% screen scaling

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -75,9 +75,9 @@ IGraphics::~IGraphics()
 
 void IGraphics::SetScreenScale(int scale)
 {
+  mScreenScale = scale;
   int windowWidth = WindowWidth() * GetPlatformWindowScale();
   int windowHeight = WindowHeight() * GetPlatformWindowScale();
-  mScreenScale = scale;
     
   PlatformResize(GetDelegate()->EditorResizeFromUI(windowWidth, windowHeight, true));
   ForAllControls(&IControl::OnRescale);


### PR DESCRIPTION
Fixes issue #575 simply moving the setting of mDrawScale before sizing the plugin window in IGraphics::SetScreenScale

