### PR TITLE
Be smarter when cloning LLVM to build Faust

### DIFF
--- a/Dependencies/Extras/faust/build-faust-win.ps1
+++ b/Dependencies/Extras/faust/build-faust-win.ps1
@@ -20,7 +20,7 @@ if(!(Test-Path -PathType Container $LLVM_REPO_DIR)) {
     Pop-Location
 }
 
-if(![System.IO.File]::Exists($FAUST_REPO_DIR)) {
+if(!(Test-Path -PathType Container $FAUST_REPO_DIR)) {
     git clone --depth=1 https://github.com/grame-cncm/faust.git $FAUST_REPO_DIR
 }
 

--- a/Dependencies/Extras/faust/build-faust-win.ps1
+++ b/Dependencies/Extras/faust/build-faust-win.ps1
@@ -8,14 +8,20 @@ $FAUST_REPO_DIR="$TMP_DIR\faust"
 $LLVM_CMAKE_BUILD_DIR="$TMP_DIR\llvm-cmake"
 $FAUST_CMAKE_BUILD_DIR="$TMP_DIR\faust-cmake"
 $INSTALL_DIR="$BUILD_DIR\win\x64\Debug"
+$LLVM_COMMIT_HASH="ef32c611aa214dea855364efd7ba451ec5ec3f74"
 
-if(![System.IO.File]::Exists($LLVM_REPO_DIR)) {
-    git clone --config core.autocrlf=false https://github.com/llvm/llvm-project.git $LLVM_REPO_DIR
-    git checkout $LLVM_VER
+if(!(Test-Path -PathType Container $LLVM_REPO_DIR)) {
+    mkdir $LLVM_REPO_DIR
+    Push-Location $LLVM_REPO_DIR
+    git init
+    git remote add origin https://github.com/llvm/llvm-project.git
+    git fetch --depth 1 origin $LLVM_COMMIT_HASH
+    git checkout FETCH_HEAD
+    Pop-Location
 }
 
 if(![System.IO.File]::Exists($FAUST_REPO_DIR)) {
-    git clone https://github.com/grame-cncm/faust.git $FAUST_REPO_DIR
+    git clone --depth=1 https://github.com/grame-cncm/faust.git $FAUST_REPO_DIR
 }
 
 mkdir $LLVM_CMAKE_BUILD_DIR


### PR DESCRIPTION
The LLVM git repo is massive, and currently the `build-faust-win.ps1` script clones the entire history. It also doesn't use a specific commit, meaning if the LLVM master is broken when the user clones it, they have to wait a few hours to find out their build didn't work. This PR fixes this by
* **A:** Cloning a specific, known-good commit (LLVM 10.0.1).
* **B:** Creating a shallow clone of that commit only, so we don't need to download the entire LLVM history.
* **C:** Also using `Test-Path` instead of `[System.IO.File]::Exists` because the second one wasn't working on my system for some reason.

Personally I suggest we provide a pre-built version of Faust, because the Faust master may also be broken when they try to download it, and that's out of our control. But for now this is an improvement. Note that I can do the same thing with Faust, but I need a specific commit hash to use. Just LMK and I'll change the Faust cloning code to be similar to the new LLVM cloning code.