### PR TITLE
Allow layers/APIBitmaps to be explicitly cacheable

### DIFF
--- a/IGraphics/Drawing/IGraphicsAGG.cpp
+++ b/IGraphics/Drawing/IGraphicsAGG.cpp
@@ -480,7 +480,7 @@ APIBitmap* IGraphicsAGG::LoadAPIBitmap(const char* fileNameOrResID, int scale, E
   return new APIBitmap();
 }
 
-APIBitmap* IGraphicsAGG::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsAGG::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   return new Bitmap(CreatePixmap<PixelMapType>(width, height), scale, drawScale, true);
 }

--- a/IGraphics/Drawing/IGraphicsAGG.h
+++ b/IGraphics/Drawing/IGraphicsAGG.h
@@ -266,7 +266,7 @@ public:
 
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsAGG.h
+++ b/IGraphics/Drawing/IGraphicsAGG.h
@@ -266,7 +266,7 @@ public:
 
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsCairo.cpp
+++ b/IGraphics/Drawing/IGraphicsCairo.cpp
@@ -262,7 +262,7 @@ APIBitmap* IGraphicsCairo::LoadAPIBitmap(const char* fileNameOrResID, int scale,
   return new Bitmap(pSurface, scale, 1.f);
 }
 
-APIBitmap* IGraphicsCairo::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsCairo::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   return new Bitmap(mSurface, width, height, scale, drawScale);
 }

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -86,7 +86,7 @@ public:
 
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
     

--- a/IGraphics/Drawing/IGraphicsCairo.h
+++ b/IGraphics/Drawing/IGraphicsCairo.h
@@ -86,7 +86,7 @@ public:
 
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
     

--- a/IGraphics/Drawing/IGraphicsCanvas.cpp
+++ b/IGraphics/Drawing/IGraphicsCanvas.cpp
@@ -354,7 +354,7 @@ APIBitmap* IGraphicsCanvas::LoadAPIBitmap(const char* fileNameOrResID, int scale
   return new Bitmap(GetPreloadedImages()[fileNameOrResID], fileNameOrResID + 1, scale);
 }
 
-APIBitmap* IGraphicsCanvas::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsCanvas::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   return new Bitmap(width, height, scale, drawScale);
 }

--- a/IGraphics/Drawing/IGraphicsCanvas.h
+++ b/IGraphics/Drawing/IGraphicsCanvas.h
@@ -60,7 +60,7 @@ public:
     
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsCanvas.h
+++ b/IGraphics/Drawing/IGraphicsCanvas.h
@@ -60,7 +60,7 @@ public:
     
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsLice.cpp
+++ b/IGraphics/Drawing/IGraphicsLice.cpp
@@ -834,7 +834,7 @@ APIBitmap* IGraphicsLice::LoadAPIBitmap(const char* fileNameOrResID, int scale, 
   return nullptr;
 }
 
-APIBitmap* IGraphicsLice::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsLice::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   LICE_IBitmap* pBitmap = new LICE_MemBitmap(width, height);
   memset(pBitmap->getBits(), 0, pBitmap->getRowSpan() * pBitmap->getHeight() * sizeof(LICE_pixel));

--- a/IGraphics/Drawing/IGraphicsLice.h
+++ b/IGraphics/Drawing/IGraphicsLice.h
@@ -96,7 +96,7 @@ public:
   bool BitmapExtSupported(const char* ext) override;
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsLice.h
+++ b/IGraphics/Drawing/IGraphicsLice.h
@@ -96,7 +96,7 @@ public:
   bool BitmapExtSupported(const char* ext) override;
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -347,7 +347,7 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* fileNameOrResID, int scale
   return new Bitmap(mVG, fileNameOrResID, scale, idx, location == EResourceLocation::kPreloadedTexture);
 }
 
-APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   if (mInDraw)
   {

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -123,7 +123,7 @@ public:
     
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -123,7 +123,7 @@ public:
     
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -799,13 +799,20 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
   mCanvas->clipRect(SkiaRect(r));
 }
 
-APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, int scale, double drawScale)
+APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
 {
   sk_sp<SkSurface> surface;
   
   #ifndef IGRAPHICS_CPU
   SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
-  surface = SkSurface::MakeRenderTarget(mGrContext.get(), SkBudgeted::kYes, info);
+  if (cacheable)
+  {
+    surface = SkSurface::MakeRasterN32Premul(width, height);
+  }
+  else
+  {
+    surface = SkSurface::MakeRenderTarget(mGrContext.get(), SkBudgeted::kYes, info);
+  }
   #else
   surface = SkSurface::MakeRasterN32Premul(width, height);
   #endif

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -110,7 +110,7 @@ public:
   int AlphaChannel() const override { return 3; }
   bool FlippedBitmap() const override { return false; }
 
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
 
   void GetLayerBitmapData(const ILayerPtr& layer, RawBitmapData& data) override;
   void ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, const IShadow& shadow) override;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -110,7 +110,7 @@ public:
   int AlphaChannel() const override { return 3; }
   bool FlippedBitmap() const override { return false; }
 
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable) override;
 
   void GetLayerBitmapData(const ILayerPtr& layer, RawBitmapData& data) override;
   void ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, const IShadow& shadow) override;

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1726,7 +1726,7 @@ IBitmap IGraphics::ScaleBitmap(const IBitmap& inBitmap, const char* name, int sc
   mDrawScale = inBitmap.GetDrawScale();
 
   IRECT bounds = IRECT(0, 0, inBitmap.W() / inBitmap.GetDrawScale(), inBitmap.H() / inBitmap.GetDrawScale());
-  StartLayer(nullptr, bounds);
+  StartLayer(nullptr, bounds, true);
   DrawBitmap(inBitmap, bounds, 0, 0, nullptr);
   ILayerPtr layer = EndLayer();
   IBitmap outBitmap = IBitmap(layer->mBitmap.release(), inBitmap.N(), inBitmap.GetFramesAreHorizontal(), name);
@@ -1852,14 +1852,14 @@ void IGraphics::EndDragResize()
   }
 }
 
-void IGraphics::StartLayer(IControl* pControl, const IRECT& r)
+void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable)
 {
   auto pixelBackingScale = GetBackingPixelScale();
   IRECT alignedBounds = r.GetPixelAligned(pixelBackingScale);
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale()), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
+  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
 }
 
 void IGraphics::ResumeLayer(ILayerPtr& layer)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -495,8 +495,9 @@ public:
   
   /** Create an IGraphics layer. Switches drawing to an offscreen bitmap for drawing
    * IControl* pOwner The control that owns the layer
-   * @param r The bounds of the layer within the IGraphics context */
-  void StartLayer(IControl* pOwner, const IRECT& r);
+   * @param r The bounds of the layer within the IGraphics context
+   * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances */
+  void StartLayer(IControl* pOwner, const IRECT& r, bool cacheable = false);
   
   /** If a layer already exists, continue drawing to it
    * @param layer the layer to resume */
@@ -1536,8 +1537,9 @@ protected:
    * @param height The desired height
    * @param scale The scale in relation to 1:1 pixels
    * @param drawScale /todo
+   * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances
    * @return APIBitmap* The new API Bitmap */
-  virtual APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale) = 0;
+  virtual APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) = 0;
 
   /** /todo
    * @param fontID /todo


### PR DESCRIPTION
This PR primarily addresses an issue with Skia on GL (and possibly metal - untested) in which bitmaps that are scaled using ScaleBitmap() do not cache correctly, as they are bound to the drawing context of the loading plug-in.

As ScaleBitmap() calls StartLayer and the CreateAPIBitmap (where the actual backing for the scaling is created) I've added options to these methods to request a cacheable backing. That would also mean a layer could be created with a (raster) backing suitable for sharing between plug-in instances.

The only downside of this approach is that NanoVG backings are *never* shareable between plug-ins, so it gives the impression that you can request a layer that you could share between instances, which is not the case (as NanoVG bitmaps are simply IDs of the GPU framebuffer which is context-dependent). 

If preferred I can add a protected variable to IGraphics that holds this parameter specifically for the purposes of ScaleBitmap() so that the base drawing class can see it, but it isn't exposed to plug-in developers.