### PR TITLE
Ensure that skia clipping and transforms are always applied correctly

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -138,6 +138,8 @@ private:
   SkCanvas* mCanvas = nullptr;
   SkPath mMainPath;
   SkMatrix mMatrix;
+  SkMatrix mClipMatrix;
+  SkMatrix mFinalMatrix;
 
 #if defined OS_WIN && defined IGRAPHICS_CPU
   WDL_TypedBuf<uint8_t> mSurfaceMemory;


### PR DESCRIPTION
This PR fixes an issue with the skia backend on windows in which the use of save/restore is incorrectly balanced when the window resizes during creation - the result of this is incorrect clipping and transformation, leading to an incorrectly drawn interface. 

By managing the transform matrix more explicitly, as well as clearing initialising the skia clip/transform stack we maintain better control over the backends state and avoid this problem.