### PR TITLE
IPopupMenuControl- Fix positioning, drawing of triangles, and add color customization. Ref. issue #595

### DIFF
--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -25,6 +25,7 @@
 #include "IRTTextControl.h"
 #include "IVDisplayControl.h"
 #include "ILEDControl.h"
+#include "IPopupMenuControl.h"
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -271,34 +271,34 @@ void IPopupMenuControl::DrawCalloutArrow(IGraphics& g, const IRECT& bounds, IBle
   switch (mCalloutArrowDir) {
     case kNorth:
       ax = bounds.MW() - halftri;
-      ay = bounds.MH() + halftri;
-      bx = ax + trisize;
-      by = ay;
-      cx = bounds.MW();
-      cy = ay - trisize;
-      break;
-    case kEast:
-      ax = bounds.MW() - halftri;
-      ay = bounds.MH() + halftri;
-      bx = ax;
-      by = ay - trisize;
-      cx = ax + trisize;
-      cy = bounds.MH();
-      break;
-    case kSouth:
-      ax = bounds.MW() - halftri;
       ay = bounds.MH() - halftri;
       bx = ax + trisize;
       by = ay;
       cx = bounds.MW();
       cy = ay + trisize;
       break;
-    case kWest:
+    case kEast:
       ax = bounds.MW() + halftri;
       ay = bounds.MH() + halftri;
       bx = ax;
       by = ay - trisize;
       cx = ax - trisize;
+      cy = bounds.MH();
+      break;
+    case kSouth:
+      ax = bounds.MW() - halftri;
+      ay = bounds.MH() + halftri;
+      bx = ax + trisize;
+      by = ay;
+      cx = bounds.MW();
+      cy = ay - trisize;
+      break;
+    case kWest:
+      ax = bounds.MW() - halftri;
+      ay = bounds.MH() + halftri;
+      bx = ax;
+      by = ay - trisize;
+      cx = ax + trisize;
       cy = bounds.MH();
       break;
     default:

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -221,30 +221,19 @@ void IPopupMenuControl::OnMouseOver(float x, float y, const IMouseMod& mod)
       mMouseCellBounds = mActiveMenuPanel->HitTestCells(x, y);
     }
   }
-  else
-    if (mPrevMouseCellBounds != *mMouseCellBounds)
-    {
-      if (mMenuHasSubmenu && mActiveMenuPanel->mParentIdx)
-      {
-        CalculateMenuPanels(x, y);
-      }
-    }
   
-    if(mActiveMenuPanel->mScroller)
-    {
-      if(mMouseCellBounds == mActiveMenuPanel->mCellBounds.Get(0))
-      {
-        mActiveMenuPanel->ScrollUp();
-      }
-      else if (mMouseCellBounds == mActiveMenuPanel->mCellBounds.Get((mActiveMenuPanel->mCellBounds.GetSize()-1)))
-      {
-        mActiveMenuPanel->ScrollDown();
-      }
-    }
+  CalculateMenuPanels(x, y);
   
-  if (mMouseCellBounds != nullptr)
+  if(mActiveMenuPanel->mScroller)
   {
-    mPrevMouseCellBounds = *mMouseCellBounds;
+    if(mMouseCellBounds == mActiveMenuPanel->mCellBounds.Get(0))
+    {
+      mActiveMenuPanel->ScrollUp();
+    }
+    else if (mMouseCellBounds == mActiveMenuPanel->mCellBounds.Get((mActiveMenuPanel->mCellBounds.GetSize()-1)))
+    {
+      mActiveMenuPanel->ScrollDown();
+    }
   }
   
   SetDirty(false);
@@ -314,7 +303,7 @@ void IPopupMenuControl::DrawCalloutArrow(IGraphics& g, const IRECT& bounds, IBle
     default:
       break;
   }
-  g.FillTriangle(mCalloutArrowColor, ax, ay, bx, by, cx, cy, pBlend);
+  g.FillTriangle(mPanelBackgroundColor, ax, ay, bx, by, cx, cy, pBlend);
 }
 
 void IPopupMenuControl::DrawSubMenuCalloutArrow(IGraphics& g, const IRECT& bounds, IBlend* pBlend)
@@ -341,7 +330,7 @@ void IPopupMenuControl::DrawSubMenuCalloutArrow(IGraphics& g, const IRECT& bound
     cx = ax + trisize;
     cy = bounds.MH();
   }
-  g.FillTriangle(mCalloutArrowColor, ax, ay, bx, by, cx, cy, pBlend);
+  g.FillTriangle(mPanelBackgroundColor, ax, ay, bx, by, cx, cy, pBlend);
 }
 
 void IPopupMenuControl::DrawPanelBackground(IGraphics& g, MenuPanel* panel)
@@ -871,7 +860,6 @@ void IPopupMenuControl::CollapseEverything()
   
   GetUI()->SetControlValueAfterPopupMenu(pClickedMenu);
   
-  mPrevMouseCellBounds.Clear();
   mSubMenuOpened = false;
   mActiveMenuPanel = nullptr;
 

--- a/IGraphics/Controls/IPopupMenuControl.h
+++ b/IGraphics/Controls/IPopupMenuControl.h
@@ -95,6 +95,27 @@ public:
   virtual void DrawDownArrow(IGraphics& g, const IRECT& bounds, bool sel, IBlend* pBlend);
   /** Override this method to change the way a cell separator is drawn  */
   virtual void DrawSeparator(IGraphics& g, const IRECT& bounds, IBlend* pBlend);
+  
+  /** Call this to set the Callout Arrow color */
+  void SetCalloutArrowColor(IColor color) { mCalloutArrowColor = color; }
+  /** Call this to set the Panel color */
+  void SetPanelColor(IColor color) { mPanelBackgroundColor = color; }
+  /** Call this to set the Cell color when mouse is over it */
+  void SetCellBackgroundColor(IColor color) { mCellBackGroundColor = color; }
+  /** Call this to set the mouseover color for text, tick, and arrows on menu panels*/
+  void SetItemMouseoverColor(IColor color) { mItemMouseoverColor = color; }
+  /** Call this to set the color of enabled text items, ticks and arrows on menu panels*/
+  void SetItemColor(IColor color) { mItemColor = color; }
+  /** Call this to set the text color of disabled items on menu panels */
+  void SetDisabledItemColor(IColor color) { mDisabledItemColor = color; }
+  /** Call this to set the Separator color on menu panels */
+  void SetSeparatorColor(IColor color) { mSeparatorColor = color; }
+  /** Sets the amount the main menu is shifted to make room for submenus. This helps on small GUI's where submenus will intrude upon the main menu.
+   * This does not affect the positioning of menus that do not contain submenus.
+   * @param distance The distance in pixels to shift the main menu. Use negative numbers for shift to left - positive for shift to right. */
+  void SetShiftForSubmenus(float distance) { mMenuShift = distance; }
+  /** If set true, the menu (kNorth) is forced to appear below it's control(kSouth) when it would normally be above - only if there is room for it. */
+  void SetMenuForcedSouth(bool isForcedSouth) { mForcedSouth = isForcedSouth;}
 
   /** Call this to create a pop-up menu
    * @param menu Reference to a menu from which to populate this user interface control. NOTE: this object should not be a temporary, otherwise when the menu returns asynchronously, it may not exist.
@@ -187,12 +208,15 @@ private:
   int mMaxColumnItems = 0; // How long the list can get before adding a new column - 0 equals no limit
   bool mScrollIfTooBig = true; // If the menu is higher than the graphics context, should it scroll or should it start a new column
   bool mCallOut = false; // set true if popup should be outside of bounds (i.e. on a tablet touchscreen interface)
+  bool mMenuHasSubmenu = false; // Gets automatically set to true in CreatePopupMenu() if *mMenu contains any submenus... false if not.
+  bool mForcedSouth = false; // if set true, a menu in the lower half of the GUI will appear below it's control if there is enough room for it.
 
   float mCellGap = 2.f; // The gap between cells in pixels
   float mSeparatorSize = 2.; // The size in pixels of a separator. This could be width or height
   float mRoundness = 5.f; // The roundness of the corners of the menu panel backgrounds
   float mDropShadowSize = 10.f; // The size in pixels of the drop shadow
   float mOpacity = 0.95f; // The opacity of the menu panel backgrounds when fully faded in
+  float mMenuShift = 0.f; // The distance in pixels the main menu is shifted to make room for submenus (only if one exist). Set by SetShiftForSubmenus()
 
   const float TEXT_HPAD = 5.; // The amount of horizontal padding on either side of cell text in pixels
   const float TICK_SIZE = 10.; // The size of the area on the left of the cell where a tick mark appears on checked items - actual
@@ -204,6 +228,14 @@ private:
   IRECT mCalloutArrowBounds;
 
   IRECT mMaxBounds; // if view is only showing a part of the graphics context, we need to know because menus can't go there
+  
+  IColor mCalloutArrowColor = COLOR_WHITE;
+  IColor mPanelBackgroundColor = COLOR_WHITE;
+  IColor mCellBackGroundColor = COLOR_BLUE;
+  IColor mItemMouseoverColor = COLOR_WHITE;
+  IColor mItemColor = COLOR_BLACK;
+  IColor mDisabledItemColor = COLOR_GRAY;
+  IColor mSeparatorColor = COLOR_MID_GRAY;
 
 protected:
   IRECT mSpecifiedCollapsedBounds;

--- a/IGraphics/Controls/IPopupMenuControl.h
+++ b/IGraphics/Controls/IPopupMenuControl.h
@@ -75,8 +75,10 @@ public:
    @param y Mouse Y position */
   void CalculateMenuPanels(float x, float y);
 
-  /** Override this method to change the background of the pop-up menu panel */
+  /** Override this method to change the way Callout arrows are drawn*/
   virtual void DrawCalloutArrow(IGraphics& g, const IRECT& bounds, IBlend* pBlend);
+  /** Override this method to change the way Callout arrows for Submenus are drawn*/
+  virtual void DrawSubMenuCalloutArrow(IGraphics& g, const IRECT& bounds, IBlend* pBlend);
   /** Override this method to change the background of the pop-up menu panel */
   virtual void DrawPanelBackground(IGraphics& g, MenuPanel* panel);
   /** Override this method to change the shadow of the pop-up menu panel */
@@ -112,7 +114,8 @@ public:
   void SetSeparatorColor(IColor color) { mSeparatorColor = color; }
   /** Sets the amount the main menu is shifted to make room for submenus. This helps on small GUI's where submenus will intrude upon the main menu.
    * This does not affect the positioning of menus that do not contain submenus.
-   * @param distance The distance in pixels to shift the main menu. Use negative numbers for shift to left - positive for shift to right. */
+   * @param distance The distance in pixels to shift the main menu. Use only positive numbers. It will shift left if the center of the control that
+   * opens it is right of center of UI and to the right if otherwise. */
   void SetShiftForSubmenus(float distance) { mMenuShift = distance; }
   /** If set true, the menu (kNorth) is forced to appear below it's control(kSouth) when it would normally be above - only if there is room for it. */
   void SetMenuForcedSouth(bool isForcedSouth) { mForcedSouth = isForcedSouth;}
@@ -140,6 +143,12 @@ public:
 private:
   /** Get an IRECT represents the maximum dimensions of the longest text item in the menu */
   IRECT GetLargestCellRectForMenu(IPopupMenu& menu, float x, float y) const;
+  
+  /** Sets the values of two variables for the length and width of the specified menu panel.
+   * @param menu The menu to get dimensions of.
+   * @param width A pointer to set a variable with the value of the panels width.
+   * @param height A pointer to set a variable with the value of the panels height.*/
+  void GetPanelDimensions(IPopupMenu&menu, float* width, float* height) const;
 
   /** This method is called to expand the modal pop-up menu. It calculates the dimensions and wrapping, to keep the cells within the graphics context. It handles the dirtying of the graphics context, and modification of graphics behaviours such as tooltips and mouse cursor */
   void Expand(const IRECT& bounds);
@@ -202,7 +211,7 @@ private:
   MenuPanel* mAppearingMenuPanel = nullptr; // A pointer to a MenuPanel that's in the process of fading in
   EPopupState mState = kCollapsed; // The state of the pop-up, mainly used for animation
   IRECT* mMouseCellBounds = nullptr;
-  IRECT* mPrevMouseCellBounds = nullptr;
+  IRECT mPrevMouseCellBounds;// The cell bounds that last had the mouse over it.
   IPopupMenu* mMenu = nullptr; // Pointer to the main IPopupMenu, that this control is visualising. This control does not own the menu.
     
   int mMaxColumnItems = 0; // How long the list can get before adding a new column - 0 equals no limit
@@ -210,6 +219,8 @@ private:
   bool mCallOut = false; // set true if popup should be outside of bounds (i.e. on a tablet touchscreen interface)
   bool mMenuHasSubmenu = false; // Gets automatically set to true in CreatePopupMenu() if *mMenu contains any submenus... false if not.
   bool mForcedSouth = false; // if set true, a menu in the lower half of the GUI will appear below it's control if there is enough room for it.
+  bool mSubmenuOnRight = true; // If set true, the submenu will be drawn on the right of the parent menu.... on the left if false.
+  bool mSubMenuOpened = false; // Is set true when a submenu panel is open and false when menu is collapsed.
 
   float mCellGap = 2.f; // The gap between cells in pixels
   float mSeparatorSize = 2.; // The size in pixels of a separator. This could be width or height
@@ -225,7 +236,8 @@ private:
   const float CALLOUT_SPACE = 8; // The space between start bounds and callout
   IRECT mAnchorArea; // The area where the menu was triggered; menu will be adjacent, but won't occupy it.
   EArrowDir mCalloutArrowDir = kEast;
-  IRECT mCalloutArrowBounds;
+  IRECT mCalloutArrowBounds; // The rectangle in which the CallOut arrow is drawn.
+  IRECT mSubMenuCalloutArrowBounds; // The rectangle in which the CallOut arrow for a submenus is drawn.
 
   IRECT mMaxBounds; // if view is only showing a part of the graphics context, we need to know because menus can't go there
   

--- a/IGraphics/Controls/IPopupMenuControl.h
+++ b/IGraphics/Controls/IPopupMenuControl.h
@@ -98,8 +98,6 @@ public:
   /** Override this method to change the way a cell separator is drawn  */
   virtual void DrawSeparator(IGraphics& g, const IRECT& bounds, IBlend* pBlend);
   
-  /** Call this to set the Callout Arrow color */
-  void SetCalloutArrowColor(IColor color) { mCalloutArrowColor = color; }
   /** Call this to set the Panel color */
   void SetPanelColor(IColor color) { mPanelBackgroundColor = color; }
   /** Call this to set the Cell color when mouse is over it */
@@ -211,7 +209,6 @@ private:
   MenuPanel* mAppearingMenuPanel = nullptr; // A pointer to a MenuPanel that's in the process of fading in
   EPopupState mState = kCollapsed; // The state of the pop-up, mainly used for animation
   IRECT* mMouseCellBounds = nullptr;
-  IRECT mPrevMouseCellBounds;// The cell bounds that last had the mouse over it.
   IPopupMenu* mMenu = nullptr; // Pointer to the main IPopupMenu, that this control is visualising. This control does not own the menu.
     
   int mMaxColumnItems = 0; // How long the list can get before adding a new column - 0 equals no limit
@@ -241,7 +238,6 @@ private:
 
   IRECT mMaxBounds; // if view is only showing a part of the graphics context, we need to know because menus can't go there
   
-  IColor mCalloutArrowColor = COLOR_WHITE;
   IColor mPanelBackgroundColor = COLOR_WHITE;
   IColor mCellBackGroundColor = COLOR_BLUE;
   IColor mItemMouseoverColor = COLOR_WHITE;


### PR DESCRIPTION
This Pull Request:
- Improves the appearance of triangles.
- Keeps menu panels in bounds regardless of whether or not mCallOut  is true. In the case of larger menu panels on small gui's, the menu panel may cover the control/ anchorArea that opened it. In the case of submenus, there is a function to further shift the parent menu(only applies to menus with submenus) if necessary.
- Added some setter functions to customize appearance and behavior.
See comments in IPopupMenuControl.h for more detail.

Usage example........ in Plugin Constructor:

#ifndef OS_IOS
    pGraphics->AttachPopupMenuControl(IText(textprops));
    //pGraphics->GetPopupMenuControl()->SetCalloutArrowColor(<#IColor color#>);;
    pGraphics->GetPopupMenuControl()->SetPanelColor(IColor(150, 0, 0, 0));
    pGraphics->GetPopupMenuControl()->SetCellBackgroundColor(IColor(80, 0, 255, 255));
    pGraphics->GetPopupMenuControl()->SetItemMouseoverColor(COLOR_LIGHT_GRAY);
    pGraphics->GetPopupMenuControl()->SetItemColor(textcolor);
    //pGraphics->GetPopupMenuControl()->SetDisabledItemColor(<#IColor color#>);
    //pGraphics->GetPopupMenuControl()->SetSeparatorColor(<#IColor color#>);
    pGraphics->GetPopupMenuControl()->SetShiftForSubmenus(-30.f);
    pGraphics->GetPopupMenuControl()->SetMenuForcedSouth(true);
    
    //pGraphics->GetPopupMenuControl()->SetExpandedBounds(<#const IRECT &bounds#>);
    pGraphics->GetPopupMenuControl()->SetCallout(true);
    //pGraphics->GetPopupMenuControl()->SetMaxBounds(<#const IRECT &bounds#>);
#endif