### PR TITLE
Sort mousing to do with web and text entry

### DIFF
--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -560,9 +560,4 @@ void ITextEntryControl::SetStr(const char* str)
 {
   mCharWidths.Resize(0, false);
   mEditString = StringConvert{}.from_bytes(std::string(str));
-
-  if (mEditState.select_start != mEditState.select_end)
-  {
-    SelectAll();
-  }
 }

--- a/IGraphics/Controls/ITextEntryControl.h
+++ b/IGraphics/Controls/ITextEntryControl.h
@@ -60,11 +60,12 @@ public:
   void DismissEdit();
   void CommitEdit();
 
-  void SetStr(const char* str);
-
   void CreateTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str);
 
 private:
+    
+  void SetStr(const char* str);
+
   template<typename Proc>
   bool CallSTB(Proc proc);
   void OnStateChanged();

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1149,8 +1149,13 @@ void IGraphics::OnMouseDrag(const std::vector<IMouseInfo>& points)
 
   if (mResizingInProcess && points.size() == 1)
     OnDragResize(points[0].x, points[0].y);
-  else if (ControlIsCaptured() && !GetControlInTextEntry())
+  else if (ControlIsCaptured() && !IsInPlatformTextEntry())
   {
+    IControl *textEntry = nullptr;
+      
+    if (GetControlInTextEntry())
+      textEntry = mTextEntryControl.get();
+      
     for (auto& point : points)
     {
       float x = point.x;
@@ -1161,11 +1166,14 @@ void IGraphics::OnMouseDrag(const std::vector<IMouseInfo>& points)
       
       auto itr = mCapturedMap.find(mod.touchID);
       
-      if(itr != mCapturedMap.end())
+      if (itr != mCapturedMap.end())
       {
         IControl* pCapturedControl = itr->second;
 
-        if(pCapturedControl && (dX != 0 || dY != 0))
+        if (textEntry && pCapturedControl != textEntry)
+            pCapturedControl = nullptr;
+          
+        if (pCapturedControl && (dX != 0 || dY != 0))
         {
           pCapturedControl->OnMouseDrag(x, y, dX, dY, mod);
         }

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -352,20 +352,27 @@ static EM_BOOL outside_mouse_callback(int eventType, const EmscriptenMouseEvent*
   info.y = (pEvent->targetY - rect["top"].as<double>()) / pGraphics->GetDrawScale();
   info.dX = pEvent->movementX;
   info.dY = pEvent->movementY;
-  info.ms = {pEvent->buttons == 1, pEvent->buttons == 2, static_cast<bool>(pEvent->shiftKey), static_cast<bool>(pEvent->ctrlKey), static_cast<bool>(pEvent->altKey)};
+  info.ms = {(pEvent->buttons & 1) != 0, (pEvent->buttons & 2) != 0, static_cast<bool>(pEvent->shiftKey), static_cast<bool>(pEvent->ctrlKey), static_cast<bool>(pEvent->altKey)};
   std::vector<IMouseInfo> list {info};
   
   switch (eventType)
   {
     case EMSCRIPTEN_EVENT_MOUSEUP:
+    {
+      // Get button states based on what caused the mouse up (nothing in buttons)
+      list[0].ms.L = pEvent->button == 0;
+      list[0].ms.R = pEvent->button == 2;
       pGraphics->OnMouseUp(list);
       emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, pGraphics, 1, nullptr);
       emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, pGraphics, 1, nullptr);
       break;
+    }
     case EMSCRIPTEN_EVENT_MOUSEMOVE:
+    {
       if(pEvent->buttons != 0 && !pGraphics->IsInPlatformTextEntry())
         pGraphics->OnMouseDrag(list);
       break;
+    }
     default:
       break;
   }
@@ -385,8 +392,8 @@ static EM_BOOL mouse_callback(int eventType, const EmscriptenMouseEvent* pEvent,
   info.y = pEvent->targetY / pGraphics->GetDrawScale();
   info.dX = pEvent->movementX;
   info.dY = pEvent->movementY;
-  info.ms = {pEvent->buttons == 1,
-             pEvent->buttons == 2,
+  info.ms = {(pEvent->buttons & 1) != 0,
+             (pEvent->buttons & 2) != 0,
              static_cast<bool>(pEvent->shiftKey),
              static_cast<bool>(pEvent->ctrlKey),
              static_cast<bool>(pEvent->altKey)};
@@ -414,7 +421,14 @@ static EM_BOOL mouse_callback(int eventType, const EmscriptenMouseEvent* pEvent,
       
       break;
     }
-    case EMSCRIPTEN_EVENT_MOUSEUP: pGraphics->OnMouseUp(list); break;
+    case EMSCRIPTEN_EVENT_MOUSEUP:
+    {
+      // Get button states based on what caused the mouse up (nothing in buttons)
+      list[0].ms.L = pEvent->button == 0;
+      list[0].ms.R = pEvent->button == 2;
+      pGraphics->OnMouseUp(list);
+      break;
+    }
     case EMSCRIPTEN_EVENT_MOUSEMOVE:
     {
       gFirstClick = false;
@@ -454,7 +468,7 @@ static EM_BOOL wheel_callback(int eventType, const EmscriptenWheelEvent* pEvent,
 {
   IGraphics* pGraphics = (IGraphics*) pUserData;
   
-  IMouseMod modifiers(0, 0, pEvent->mouse.shiftKey, pEvent->mouse.ctrlKey, pEvent->mouse.altKey);
+  IMouseMod modifiers(false, false, pEvent->mouse.shiftKey, pEvent->mouse.ctrlKey, pEvent->mouse.altKey);
   
   double x = pEvent->mouse.targetX;
   double y = pEvent->mouse.targetY;


### PR DESCRIPTION
This PR fixes three mousing issues:

1 - the lack of mouse drags reaching mTextEntryControl (#513)
2 - web button identification being done using == on a bitmask (which could fail if multiple buttons are down)
3 - web button identification failing for mouse ups as buttons will always be zero 

Fixes are:

1 - use a different filtering scheme for mouse drags
2 - use bit mask testing instead (a & b != 0)
3 - use the button field (not *buttons*) to determine the button causing mouseup events