### PR TITLE
Rework controller base to make sure when state is recalled it is loaded

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -29,6 +29,7 @@ using namespace Vst;
 IPlugVST3::IPlugVST3(const InstanceInfo& info, const Config& config)
 : IPlugAPIBase(config, kAPIVST3)
 , IPlugVST3ProcessorBase(config, *this)
+, IPlugVST3ControllerBase(parameters)
 , mView(nullptr)
 {
   CreateTimer();
@@ -45,7 +46,7 @@ tresult PLUGIN_API IPlugVST3::initialize(FUnknown* context)
   if (SingleComponentEffect::initialize(context) == kResultOk)
   {
     IPlugVST3ProcessorBase::Initialize(this);
-    IPlugVST3ControllerBase::Initialize(this, parameters, IsInstrument(), DoesMIDIIn());
+    IPlugVST3ControllerBase::Initialize(this, IsInstrument(), DoesMIDIIn());
 
     IPlugVST3GetHost(this, context);
     OnHostIdentified();
@@ -123,12 +124,12 @@ tresult PLUGIN_API IPlugVST3::getState(IBStream* pState)
 #pragma mark IEditController overrides
 ParamValue PLUGIN_API IPlugVST3::getParamNormalized(ParamID tag)
 {
-  return IPlugVST3ControllerBase::GetParamNormalized(parameters, tag);
+  return IPlugVST3ControllerBase::GetParamNormalized(tag);
 }
 
 tresult PLUGIN_API IPlugVST3::setParamNormalized(ParamID tag, ParamValue value)
 {
-  if (IPlugVST3ControllerBase::SetParamNormalized(this, parameters, tag, value))
+  if (IPlugVST3ControllerBase::SetParamNormalized(this, tag, value))
     return kResultTrue;
   else
     return kResultFalse;
@@ -233,7 +234,7 @@ void IPlugVST3::DirtyParametersFromUI()
 
 void IPlugVST3::SendParameterValueFromUI(int paramIdx, double normalisedValue)
 {
-  IPlugVST3ControllerBase::SetVST3ParamNormalized(parameters, paramIdx, normalisedValue);
+  IPlugVST3ControllerBase::SetVST3ParamNormalized(paramIdx, normalisedValue);
   IPlugAPIBase::SendParameterValueFromUI(paramIdx, normalisedValue);
 }
 

--- a/IPlug/VST3/IPlugVST3_Common.h
+++ b/IPlug/VST3/IPlugVST3_Common.h
@@ -77,11 +77,8 @@ struct IPlugVST3State
     
     IPlugVST3ControllerBase* pController = dynamic_cast<IPlugVST3ControllerBase*>(pPlug);
     
-    if(pController)
-    {
-      if (pController->mBypassParameter)
-        pController->mBypassParameter->setNormalized(savedBypass);
-    }
+    if (pController)
+      pController->UpdateParams(pPlug, savedBypass);
     
     pPlug->OnRestoreState();
     

--- a/IPlug/VST3/IPlugVST3_Controller.cpp
+++ b/IPlug/VST3/IPlugVST3_Controller.cpp
@@ -26,6 +26,7 @@ IPlugVST3Controller::IPlugVST3Controller(const InstanceInfo& info, const Config&
 , mPlugIsInstrument(config.plugType == kInstrument)
 , mDoesMidiIn(config.plugDoesMidiIn)
 , mProcessorGUID(info.mOtherGUID)
+, IPlugVST3ControllerBase(parameters)
 {
   CreateTimer();
 }
@@ -40,7 +41,7 @@ tresult PLUGIN_API IPlugVST3Controller::initialize(FUnknown* context)
 {
   if (EditControllerEx1::initialize(context) == kResultTrue)
   {
-    Initialize(this, parameters, mPlugIsInstrument, mDoesMidiIn);
+    Initialize(this, mPlugIsInstrument, mDoesMidiIn);
     IPlugVST3GetHost(this, context);
     OnHostIdentified();
     OnParamReset(kReset);
@@ -86,12 +87,12 @@ tresult PLUGIN_API IPlugVST3Controller::getState(IBStream* pState)
 
 ParamValue PLUGIN_API IPlugVST3Controller::getParamNormalized(ParamID tag)
 {
-  return IPlugVST3ControllerBase::GetParamNormalized(parameters, tag);
+  return IPlugVST3ControllerBase::GetParamNormalized(tag);
 }
 
 tresult PLUGIN_API IPlugVST3Controller::setParamNormalized(ParamID tag, ParamValue value)
 {
-  if (IPlugVST3ControllerBase::SetParamNormalized(this, parameters, tag, value))
+  if (IPlugVST3ControllerBase::SetParamNormalized(this, tag, value))
     return kResultTrue;
   else
     return kResultFalse;
@@ -285,6 +286,6 @@ void IPlugVST3Controller::SendArbitraryMsgFromUI(int msgTag, int ctrlTag, int da
 
 void IPlugVST3Controller::SendParameterValueFromUI(int paramIdx, double normalisedValue)
 {
-  IPlugVST3ControllerBase::SetVST3ParamNormalized(parameters, paramIdx, normalisedValue);
+  IPlugVST3ControllerBase::SetVST3ParamNormalized(paramIdx, normalisedValue);
   IPlugAPIBase::SendParameterValueFromUI(paramIdx, normalisedValue);
 }


### PR DESCRIPTION
VST3 was not recalling state correctly in terms of making sure the parameters were visible to the host through the controller (this was the result of the changes in f1a108e498e252a4927feff651a18eaf4e3a9a77). This PR pushes the parameters through to the host visible values when state is set in order to fix this issue.