### PR TITLE
Add IGraphics::DrawFastDropShadow() for NanoVG and Skia

### DIFF
--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -196,25 +196,7 @@ protected:
   void DrawDropShadow(IGraphics& g, const IRECT& r)
   {
   #ifdef IGRAPHICS_NANOVG
-    const float yDrop = 2.0;
-
-    auto NanoVGColor = [](const IColor& color, const IBlend* pBlend = nullptr) {
-      NVGcolor c;
-      c.r = (float) color.R / 255.0f;
-      c.g = (float) color.G / 255.0f;
-      c.b = (float) color.B / 255.0f;
-      c.a = (BlendWeight(pBlend) * color.A) / 255.0f;
-      return c;
-    };
-
-    NVGcontext* vg = (NVGcontext*) g.GetDrawContext();
-    NVGpaint shadowPaint = nvgBoxGradient(vg, r.L, r.T + yDrop, r.W(), r.H(), mRoundness * 2.f, 20.f, NanoVGColor(COLOR_BLACK_DROP_SHADOW, &mBlend), NanoVGColor(COLOR_TRANSPARENT));
-    nvgBeginPath(vg);
-    nvgRect(vg, mBubbleBounds.L, mBubbleBounds.T, mBubbleBounds.W(), mBubbleBounds.H());
-    nvgFillPaint(vg, shadowPaint);
-    nvgGlobalCompositeOperation(vg, NVG_SOURCE_OVER);
-    nvgFill(vg);
-    nvgBeginPath(vg); // Clear the paths
+    g.DrawFastDropShadow(r, mBubbleBounds, 2.0, mRoundness, 20.f, &mBlend);
   #else
 //    if (!g.CheckLayer(mShadowLayer))
 //    {

--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -257,11 +257,6 @@ protected:
       
     SetRECT(mRECT.Union(mBubbleBounds));
 
-//    #ifndef IGRAPHICS_NANOVG
-//    if(mShadowLayer)
-//      mShadowLayer->Invalidate();
-//    #endif
-    
     if(mState == kCollapsed)
     {
       Hide(false);
@@ -287,9 +282,6 @@ protected:
   IRECT mBubbleBounds;
   IControl* mCaller = nullptr;
   EArrowDir mArrowDir = EArrowDir::kWest;
-//  #ifndef IGRAPHICS_NANOVG
-//  ILayerPtr mShadowLayer;
-//  #endif
   WDL_String mStr;
   IBlend mBlend = { EBlend::Default, 0.f }; // blend for sub panels appearing
   float mRoundness = 5.f; // The roundness of the corners of the menu panel backgrounds

--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -195,7 +195,7 @@ protected:
   
   void DrawDropShadow(IGraphics& g, const IRECT& r)
   {
-    g.DrawFastDropShadow(r, mBubbleBounds, 2.0, mRoundness, 20.f, &mBlend);
+    g.DrawFastDropShadow(r, mBubbleBounds, 2.0, mRoundness, 10.f, &mBlend);
   }
 
   void ShowBubble(IControl* pCaller, float x, float y, const char* str, EDirection dir, IRECT minimumContentBounds, ITouchID touchID = 0)

--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -195,18 +195,7 @@ protected:
   
   void DrawDropShadow(IGraphics& g, const IRECT& r)
   {
-  #ifdef IGRAPHICS_NANOVG
     g.DrawFastDropShadow(r, mBubbleBounds, 2.0, mRoundness, 20.f, &mBlend);
-  #else
-//    if (!g.CheckLayer(mShadowLayer))
-//    {
-//      g.StartLayer(this, mBubbleBounds);
-//      g.FillRoundRect(COLOR_BLACK, r, mRoundness);
-//      mShadowLayer = g.EndLayer();
-//      g.ApplyLayerDropShadow(mShadowLayer, IShadow(COLOR_BLACK_DROP_SHADOW, 20.0, 0.0, yDrop, 1.0, true));
-//    }
-//    g.DrawLayer(mShadowLayer, &mBlend);
-  #endif
   }
 
   void ShowBubble(IControl* pCaller, float x, float y, const char* str, EDirection dir, IRECT minimumContentBounds, ITouchID touchID = 0)

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -342,28 +342,11 @@ void IPopupMenuControl::DrawPanelBackground(IGraphics& g, MenuPanel* panel)
 void IPopupMenuControl::DrawPanelShadow(IGraphics& g, MenuPanel* panel)
 {
 #if defined IGRAPHICS_NANOVG || ENABLE_SHADOW
-  const float yDrop = 2.0;
   IRECT inner = panel->mRECT.GetPadded(-mDropShadowSize);
 #endif
     
 #ifdef IGRAPHICS_NANOVG
-  auto NanoVGColor = [](const IColor& color, const IBlend* pBlend = nullptr) {
-    NVGcolor c;
-    c.r = (float)color.R / 255.0f;
-    c.g = (float)color.G / 255.0f;
-    c.b = (float)color.B / 255.0f;
-    c.a = (BlendWeight(pBlend) * color.A) / 255.0f;
-    return c;
-  };
-
-  NVGcontext* vg = (NVGcontext*) g.GetDrawContext();
-  NVGpaint shadowPaint = nvgBoxGradient(vg, inner.L, inner.T + yDrop, inner.W(), inner.H(), mRoundness * 2.f, 20.f, NanoVGColor(COLOR_BLACK_DROP_SHADOW, &panel->mBlend), NanoVGColor(COLOR_TRANSPARENT, nullptr));
-  nvgBeginPath(vg);
-  nvgRect(vg, panel->mRECT.L, panel->mRECT.T, panel->mRECT.W(), panel->mRECT.H());
-  nvgFillPaint(vg, shadowPaint);
-  nvgGlobalCompositeOperation(vg, NVG_SOURCE_OVER);
-  nvgFill(vg);
-  nvgBeginPath(vg); // Clear the paths
+  g.DrawFastDropShadow(inner, panel->mRECT, 2.0, mRoundness * 2.f, 10.f, &panel->mBlend);
 #elif ENABLE_SHADOW
   if (!g.CheckLayer(panel->mShadowLayer))
   {

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -16,11 +16,6 @@
 
 #include "IPopupMenuControl.h"
 
-// TODO: drop shadow on non-nanovg backends too slow
-#ifndef ENABLE_SHADOW
-  #define ENABLE_SHADOW 0
-#endif
-
 #ifdef IGRAPHICS_NANOVG
 #include "nanovg.h"
 #endif

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -341,22 +341,8 @@ void IPopupMenuControl::DrawPanelBackground(IGraphics& g, MenuPanel* panel)
 
 void IPopupMenuControl::DrawPanelShadow(IGraphics& g, MenuPanel* panel)
 {
-#if defined IGRAPHICS_NANOVG || ENABLE_SHADOW
   IRECT inner = panel->mRECT.GetPadded(-mDropShadowSize);
-#endif
-    
-#ifdef IGRAPHICS_NANOVG
   g.DrawFastDropShadow(inner, panel->mRECT, 2.0, mRoundness * 2.f, 10.f, &panel->mBlend);
-#elif ENABLE_SHADOW
-  if (!g.CheckLayer(panel->mShadowLayer))
-  {
-    g.StartLayer(this, panel->mRECT);
-    g.FillRoundRect(COLOR_BLACK, inner, mRoundness);
-    panel->mShadowLayer = g.EndLayer();
-    g.ApplyLayerDropShadow(panel->mShadowLayer, IShadow(COLOR_BLACK_DROP_SHADOW, 20.0, 0.0, yDrop, 1.0, true));
-  }
-  g.DrawLayer(panel->mShadowLayer, &panel->mBlend);
-#endif
 }
 
 void IPopupMenuControl::DrawCellBackground(IGraphics& g, const IRECT& bounds, const IPopupMenu::Item* pItem, bool sel, IBlend* pBlend)

--- a/IGraphics/Controls/IPopupMenuControl.cpp
+++ b/IGraphics/Controls/IPopupMenuControl.cpp
@@ -342,7 +342,7 @@ void IPopupMenuControl::DrawPanelBackground(IGraphics& g, MenuPanel* panel)
 void IPopupMenuControl::DrawPanelShadow(IGraphics& g, MenuPanel* panel)
 {
   IRECT inner = panel->mRECT.GetPadded(-mDropShadowSize);
-  g.DrawFastDropShadow(inner, panel->mRECT, 2.0, mRoundness * 2.f, 10.f, &panel->mBlend);
+  g.DrawFastDropShadow(inner, panel->mRECT, 2.0, mRoundness, 10.f, &panel->mBlend);
 }
 
 void IPopupMenuControl::DrawCellBackground(IGraphics& g, const IRECT& bounds, const IPopupMenu::Item* pItem, bool sel, IBlend* pBlend)

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -905,3 +905,14 @@ void IGraphicsNanoVG::ClearFBOStack()
     mFBOStack.pop();
   }
 }
+
+void IGraphicsNanoVG::DrawFastDropShadow(const IRECT& innerBounds, const IRECT& outerBounds, float xyDrop, float roundness, float blur, IBlend* pBlend)
+{
+  NVGpaint shadowPaint = nvgBoxGradient(mVG, innerBounds.L + xyDrop, innerBounds.T + xyDrop, innerBounds.W(), innerBounds.H(), roundness, blur, NanoVGColor(COLOR_BLACK_DROP_SHADOW, pBlend), NanoVGColor(COLOR_TRANSPARENT, nullptr));
+  nvgBeginPath(mVG);
+  nvgRect(mVG, outerBounds.L, outerBounds.T, outerBounds.W(), outerBounds.H());
+  nvgFillPaint(mVG, shadowPaint);
+  nvgGlobalCompositeOperation(mVG, NVG_SOURCE_OVER);
+  nvgFill(mVG);
+  nvgBeginPath(mVG);
+}

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -100,6 +100,8 @@ public:
   void DrawDottedLine(const IColor& color, float x1, float y1, float x2, float y2, const IBlend* pBlend, float thickness, float dashLen) override;
   void DrawDottedRect(const IColor& color, const IRECT& bounds, const IBlend* pBlend, float thickness, float dashLen) override;
 
+  void DrawFastDropShadow(const IRECT& innerBounds, const IRECT& outerBounds, float xyDrop = 5.f, float roundness = 0.f, float blur = 10.f, IBlend* pBlend = nullptr) override;
+  
   void PathClear() override;
   void PathClose() override;
   void PathArc(float cx, float cy, float r, float a1, float a2, EWinding winding) override;
@@ -120,7 +122,7 @@ public:
   bool BitmapExtSupported(const char* ext) override;
 
   void DeleteFBO(NVGframebuffer* pBuffer);
-    
+  
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
   APIBitmap* LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale) override;

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -909,22 +909,8 @@ void IGraphicsSkia::DrawFastDropShadow(const IRECT& innerBounds, const IRECT& ou
   
   SkPaint paint = SkiaPaint(COLOR_BLACK_DROP_SHADOW, pBlend);
   paint.setStyle(SkPaint::Style::kFill_Style);
-//  SkPoint points[2] =
-//  {
-//    SkPoint::Make(r.x(), r.top()),
-//    SkPoint::Make(r.right(), r.bottom())
-//  };
-//
-//  SkColor colors[2] =
-//  {
-//    SkiaColor(COLOR_BLACK_DROP_SHADOW, pBlend),
-//    SkiaColor(COLOR_TRANSPARENT, pBlend),
-//  };
-//
-//  SkScalar positions[2] = {0.f, 1.f};
   
-//  paint.setShader(SkGradientShader::MakeLinear(points, colors, positions, 2, SkTileMode::kDecal, 0, nullptr));
-  paint.setMaskFilter(SkMaskFilter::MakeBlur(kSolid_SkBlurStyle, blur));
+  paint.setMaskFilter(SkMaskFilter::MakeBlur(kSolid_SkBlurStyle, blur * 0.5)); // 0.5 seems to match nanovg
   mCanvas->drawRoundRect(r, roundness, roundness, paint);
 }
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -7,6 +7,7 @@
 #pragma warning( disable : 4244 )
 #include "SkDashPathEffect.h"
 #include "SkGradientShader.h"
+#include "SkMaskFilter.h"
 #include "SkFont.h"
 #include "SkFontMetrics.h"
 #include "SkTypeface.h"
@@ -900,6 +901,31 @@ void IGraphicsSkia::ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, const
     pCanvas->setMatrix(m);
     pCanvas->drawImage(foreground.get(), 0.0, 0.0);
   }
+}
+
+void IGraphicsSkia::DrawFastDropShadow(const IRECT& innerBounds, const IRECT& outerBounds, float xyDrop, float roundness, float blur, IBlend* pBlend)
+{
+  SkRect r = SkiaRect(innerBounds.GetTranslated(xyDrop, xyDrop));
+  
+  SkPaint paint = SkiaPaint(COLOR_BLACK_DROP_SHADOW, pBlend);
+  paint.setStyle(SkPaint::Style::kFill_Style);
+//  SkPoint points[2] =
+//  {
+//    SkPoint::Make(r.x(), r.top()),
+//    SkPoint::Make(r.right(), r.bottom())
+//  };
+//
+//  SkColor colors[2] =
+//  {
+//    SkiaColor(COLOR_BLACK_DROP_SHADOW, pBlend),
+//    SkiaColor(COLOR_TRANSPARENT, pBlend),
+//  };
+//
+//  SkScalar positions[2] = {0.f, 1.f};
+  
+//  paint.setShader(SkGradientShader::MakeLinear(points, colors, positions, 2, SkTileMode::kDecal, 0, nullptr));
+  paint.setMaskFilter(SkMaskFilter::MakeBlur(kSolid_SkBlurStyle, blur));
+  mCanvas->drawRoundRect(r, roundness, roundness, paint);
 }
 
 const char* IGraphicsSkia::GetDrawingAPIStr()

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -102,6 +102,7 @@ public:
   void FillEllipse(const IColor& color, const IRECT& bounds, const IBlend* pBlend) override;
   //void FillEllipse(const IColor& color, float x, float y, float r1, float r2, float angle, const IBlend* pBlend) override;
 #endif
+  void DrawFastDropShadow(const IRECT& innerBounds, const IRECT& outerBounds, float xyDrop, float roundness, float blur, IBlend* pBlend) override;
   
   IColor GetPoint(int x, int y) override;
   void* GetDrawContext() override { return (void*) mCanvas; }

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -60,7 +60,7 @@ void ShowBubbleHorizontalActionFunc(IControl* pCaller)
   IRECT bounds = pCaller->GetRECT();
   WDL_String display;
   pParam->GetDisplayWithLabel(display);
-  pGraphics->ShowBubbleControl(pCaller, bounds.R, bounds.MH(), display.Get(), EDirection::Horizontal, IRECT(0,0,50,30));
+  pGraphics->ShowBubbleControl(pCaller, bounds.R, bounds.MH(), display.Get(), EDirection::Horizontal, IRECT(0, 0, 50, 30));
 }
 
 void ShowBubbleVerticalActionFunc(IControl* pCaller)
@@ -70,7 +70,7 @@ void ShowBubbleVerticalActionFunc(IControl* pCaller)
   IRECT bounds = pCaller->GetRECT();
   WDL_String display;
   pParam->GetDisplayWithLabel(display);
-  pGraphics->ShowBubbleControl(pCaller, bounds.MW(), bounds.T, display.Get(), EDirection::Vertical, IRECT(0,0,50,30));
+  pGraphics->ShowBubbleControl(pCaller, bounds.MW(), bounds.T, display.Get(), EDirection::Vertical, IRECT(0, 0, 50, 30));
 }
 
 END_IGRAPHICS_NAMESPACE

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -392,6 +392,9 @@ public:
   /** Checks a file extension and reports whether this drawing API supports loading that extension */
   virtual bool BitmapExtSupported(const char* ext) = 0;
   
+  /** NanoVG only */
+  virtual void DrawFastDropShadow(const IRECT& innerBounds, const IRECT& outerBounds, float xyDrop = 5.f, float roundness = 0.f, float blur = 10.f, IBlend* pBlend = nullptr) { /* NO-OP*/ }
+  
 #pragma mark - Base implementation - drawing helpers
 
   /** Draws a bitmap into the graphics context. NOTE: this helper method handles multi-frame bitmaps, indexable via frame


### PR DESCRIPTION
Add rectangular drop shadow helper for nanovg and skia, used by popupmenu and bubble.