### PR TITLE
If needed show cursor when mouse is released (safely)

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -65,6 +65,10 @@ IGraphics::~IGraphics()
   mImGuiRenderer = nullptr;
 #endif
   
+  // N.B. - the OS levels have destructed, so we can't show/hide the cursor
+  // Thus, this prevents a call to a pure virtual in ReleaseMouseCapture
+    
+  mCursorHidden = false;
   RemoveAllControls();
     
   StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
@@ -1306,7 +1310,8 @@ void IGraphics::OnDrop(const char* str, float x, float y)
 void IGraphics::ReleaseMouseCapture()
 {
   mCapturedMap.clear();
-//  HideMouseCursor(false); // TODO: mac crash on quit with "calling pure virtual function"
+  if (mCursorHidden)
+    HideMouseCursor(false);
 }
 
 int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -657,6 +657,9 @@ void* IGraphicsWeb::OpenWindow(void* pHandle)
 
 void IGraphicsWeb::HideMouseCursor(bool hide, bool lock)
 {
+  if (mCursorHidden == hide)
+    return;
+    
   if (hide)
   {
 #ifdef IGRAPHICS_WEB_POINTERLOCK
@@ -666,6 +669,7 @@ void IGraphicsWeb::HideMouseCursor(bool hide, bool lock)
 #endif
       val::global("document")["body"]["style"].set("cursor", "none");
     
+    mCursorHidden = true;
     mCursorLock = lock;
   }
   else
@@ -675,8 +679,9 @@ void IGraphicsWeb::HideMouseCursor(bool hide, bool lock)
       emscripten_exit_pointerlock();
     else
 #endif
-      OnSetCursor();
+    OnSetCursor();
       
+    mCursorHidden = false;
     mCursorLock = false;
   }
 }


### PR DESCRIPTION
This PR is designed to make sure that the cursor is shown if hidden when programmatically releasing mouse capture.

It uses IGraphics::mCursorHidden to determine if this is necessary, and additionally in the base class destructor this is set false before removing all controls, which was previously causing a call to HideMouseControl as a pure virtual.

Consequently IGraphicsWeb has been updated to correctly set mCursorHidden. Something similar should be done on Linux.