### PR TITLE
Changes for OpenGL 3 and Skia master

### DIFF
--- a/Dependencies/IGraphics/build-skia-win.sh
+++ b/Dependencies/IGraphics/build-skia-win.sh
@@ -57,7 +57,6 @@ if [ "$#" -eq 2 ]; then
   skia_enable_skparagraph = true
   skia_enable_sksl_interpreter = true
   skia_enable_svg = true
-  skia_enable_tools = false
   cc = "clang"
   cxx = "clang++"
   clang_win = "C:\Program Files\LLVM"
@@ -66,8 +65,8 @@ if [ "$#" -eq 2 ]; then
   if [ $CONFIG_STR = "Debug" ]; then
     echo 'extra_cflags = [ "/MTd" ]' >> ../../tmp/skia/$DIR_ARCH_STR/$CONFIG_STR/args.gn
 
-    echo 'is_debug = false' >> ../../tmp/skia/$DIR_ARCH_STR/$CONFIG_STR/args.gn
-    echo 'is_official_build = true' >> ../../tmp/skia/$DIR_ARCH_STR/$CONFIG_STR/args.gn
+    # tools currently fails to build with an SkPDF error
+    echo 'skia_enable_tools = false' >> ../../tmp/skia/$DIR_ARCH_STR/$CONFIG_STR/args.gn
 
     # disabled due to massive binaries
     # echo 'is_debug = true' >> ../../tmp/skia/$DIR_ARCH_STR/$CONFIG_STR/args.gn

--- a/Dependencies/IGraphics/build-skia-win.sh
+++ b/Dependencies/IGraphics/build-skia-win.sh
@@ -56,7 +56,6 @@ if [ "$#" -eq 2 ]; then
   skia_enable_gpu = true
   skia_enable_skparagraph = true
   skia_enable_sksl_interpreter = true
-  skia_enable_svg = true
   cc = "clang"
   cxx = "clang++"
   clang_win = "C:\Program Files\LLVM"

--- a/Dependencies/IGraphics/build-skia-win.sh
+++ b/Dependencies/IGraphics/build-skia-win.sh
@@ -27,8 +27,9 @@ if [ "$#" -eq 2 ]; then
   if [ ! -d $DEPOT_TOOLS_PATH ]; then
     echo "checking out Depot Tools..."
     git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' $DEPOT_TOOLS_PATH
-    export PATH="${PWD}/$DEPOT_TOOLS_PATH:${PATH}"
   fi
+
+  export PATH="${PWD}/$DEPOT_TOOLS_PATH:${PATH}"
 
   cd ../Build/src/skia
 
@@ -49,12 +50,15 @@ if [ "$#" -eq 2 ]; then
   skia_use_expat = true
   skia_use_icu = true
   skia_use_sfntly = false
+  skia_use_gl = true
   skia_enable_skottie = true
   skia_enable_pdf = false
   skia_enable_particles = true
   skia_enable_gpu = true
   skia_enable_skparagraph = true
   skia_enable_sksl_interpreter = true
+  skia_enable_svg = true
+  skia_enable_tools = false
   cc = "clang"
   cxx = "clang++"
   clang_win = "C:\Program Files\LLVM"

--- a/Dependencies/IGraphics/build-skia-win.sh
+++ b/Dependencies/IGraphics/build-skia-win.sh
@@ -50,7 +50,6 @@ if [ "$#" -eq 2 ]; then
   skia_use_expat = true
   skia_use_icu = true
   skia_use_sfntly = false
-  skia_use_gl = true
   skia_enable_skottie = true
   skia_enable_pdf = false
   skia_enable_particles = true

--- a/Dependencies/IGraphics/download-igraphics-libs.sh
+++ b/Dependencies/IGraphics/download-igraphics-libs.sh
@@ -16,8 +16,7 @@ PIXMAN_VERSION=pixman-0.34.0
 EXPAT_VERSION=expat-2.2.5
 PNG_VERSION=v1.6.35
 ZLIB_VERSION=zlib-1.2.11
-SKIA_VERSION=chrome/m83
-# SKIA_VERSION=master
+SKIA_VERSION=master
 
 # URLs where tarballs of releases can be downloaded - no trailing slash
 #CAIRO tarball is compressed using xz which is not available on git-bash shell, so checkout tag via git

--- a/Dependencies/IGraphics/download-igraphics-libs.sh
+++ b/Dependencies/IGraphics/download-igraphics-libs.sh
@@ -16,7 +16,7 @@ PIXMAN_VERSION=pixman-0.34.0
 EXPAT_VERSION=expat-2.2.5
 PNG_VERSION=v1.6.35
 ZLIB_VERSION=zlib-1.2.11
-SKIA_VERSION=master
+SKIA_VERSION=chrome/m87
 
 # URLs where tarballs of releases can be downloaded - no trailing slash
 #CAIRO tarball is compressed using xz which is not available on git-bash shell, so checkout tag via git

--- a/Examples/IPlugEffect/config/IPlugEffect-win.props
+++ b/Examples/IPlugEffect/config/IPlugEffect-win.props
@@ -3,7 +3,7 @@
   <PropertyGroup Label="UserMacros">
     <IPLUG2_ROOT>$(ProjectDir)..\..\..</IPLUG2_ROOT>
     <BINARY_NAME>IPlugEffect</BINARY_NAME>
-    <EXTRA_ALL_DEFS>IGRAPHICS_NANOVG;IGRAPHICS_GL2</EXTRA_ALL_DEFS>
+    <EXTRA_ALL_DEFS>IGRAPHICS_SKIA;IGRAPHICS_GL3</EXTRA_ALL_DEFS>
     <EXTRA_DEBUG_DEFS />
     <EXTRA_RELEASE_DEFS />
     <EXTRA_TRACER_DEFS />
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(EXTRA_INC_PATHS);$(IPLUG_INC_PATHS);$(IGRAPHICS_INC_PATHS);$(GLAD_GL2_PATHS);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(EXTRA_INC_PATHS);$(IPLUG_INC_PATHS);$(IGRAPHICS_INC_PATHS);$(GLAD_GL3_PATHS);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>$(EXTRA_ALL_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>

--- a/Examples/IPlugEffect/config/IPlugEffect-win.props
+++ b/Examples/IPlugEffect/config/IPlugEffect-win.props
@@ -3,7 +3,7 @@
   <PropertyGroup Label="UserMacros">
     <IPLUG2_ROOT>$(ProjectDir)..\..\..</IPLUG2_ROOT>
     <BINARY_NAME>IPlugEffect</BINARY_NAME>
-    <EXTRA_ALL_DEFS>IGRAPHICS_SKIA;IGRAPHICS_GL3</EXTRA_ALL_DEFS>
+    <EXTRA_ALL_DEFS>IGRAPHICS_NANOVG;IGRAPHICS_GL2</EXTRA_ALL_DEFS>
     <EXTRA_DEBUG_DEFS />
     <EXTRA_RELEASE_DEFS />
     <EXTRA_TRACER_DEFS />
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(EXTRA_INC_PATHS);$(IPLUG_INC_PATHS);$(IGRAPHICS_INC_PATHS);$(GLAD_GL3_PATHS);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(EXTRA_INC_PATHS);$(IPLUG_INC_PATHS);$(IGRAPHICS_INC_PATHS);$(GLAD_GL2_PATHS);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>$(EXTRA_ALL_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -8,6 +8,10 @@
 #define SK_METAL
 #endif
 
+#if defined IGRAPHICS_GL
+#define SK_GL
+#endif
+
 #pragma warning( push )
 #pragma warning( disable : 4244 )
 #include "SkSurface.h"
@@ -148,7 +152,7 @@ private:
 #endif
   
 #ifndef IGRAPHICS_CPU
-  sk_sp<GrContext> mGrContext;
+  sk_sp<GrDirectContext> mGrContext;
   sk_sp<SkSurface> mScreenSurface;
 #endif
   

--- a/IGraphics/IGraphicsLiveEdit.h
+++ b/IGraphics/IGraphicsLiveEdit.h
@@ -282,7 +282,7 @@ public:
       g.DrawDottedRect(COLOR_WHITE, mSelectedControls.Get(i)->GetRECT());
     }
     
-    if(!mDragRegion.Empty())
+    if(!mDragRegion.ZeroArea())
     {
       g.DrawDottedRect(COLOR_RED, mDragRegion);
     }

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -29,7 +29,7 @@
   #pragma warning( push )
   #pragma warning( disable : 4244 )
   #pragma warning( disable : 5030 )
-  #include "experimental/svg/model/SkSVGDOM.h"
+  #include "modules/svg/include/SkSVGDOM.h"
   #include "include/core/SkCanvas.h"
   #include "include/core/SkStream.h"
   #include "src/xml/SkDOM.h"

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -29,7 +29,7 @@
   #pragma warning( push )
   #pragma warning( disable : 4244 )
   #pragma warning( disable : 5030 )
-  #include "modules/svg/include/SkSVGDOM.h"
+  #include "experimental/svg/model/SkSVGDOM.h"
   #include "include/core/SkCanvas.h"
   #include "include/core/SkStream.h"
   #include "src/xml/SkDOM.h"

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -812,6 +812,9 @@ struct IRECT
   /** @return float the area of this IRECT  */
   inline float Area() const { return W() * H(); }
   
+  /** @return bool true if this rect has 0 area  */
+  inline float ZeroArea() const { return R <= L || T >= B; }
+
   /** Create a new IRECT that is a union of this IRECT and `rhs`.
    * The resulting IRECT will have the minimim L and T values and maximum R and B values of the inputs.
    * @param rhs another IRECT

--- a/common-win.props
+++ b/common-win.props
@@ -20,7 +20,7 @@
     <AGG_PATH>$(IGRAPHICS_DEPS_PATH)\AGG\agg-2.4</AGG_PATH>
     <AGG_INC_PATHS>$(AGG_PATH)\include;$(AGG_PATH)\font_freetype;$(AGG_PATH)\include\util;$(AGG_PATH)\include\platform\win32;$(AGG_PATH)\src;$(AGG_PATH)\src\platform\win32</AGG_INC_PATHS>
     <SKIA_PATH>$(DEPS_PATH)\Build\src\skia</SKIA_PATH>
-    <SKIA_INC_PATHS>$(SKIA_PATH);$(SKIA_PATH)\include\core;$(SKIA_PATH)\include\effects;$(SKIA_PATH)\include\config;$(SKIA_PATH)\include\utils;$(SKIA_PATH)\include\gpu;$(SKIA_PATH)\modules\svg\src;$(SKIA_PATH)\third_party\externals\icu\source\common</SKIA_INC_PATHS>
+    <SKIA_INC_PATHS>$(SKIA_PATH);$(SKIA_PATH)\include\core;$(SKIA_PATH)\include\effects;$(SKIA_PATH)\include\config;$(SKIA_PATH)\include\utils;$(SKIA_PATH)\include\gpu;$(SKIA_PATH)\experimental\svg\model;$(SKIA_PATH)\third_party\externals\icu\source\common</SKIA_INC_PATHS>
     <GLAD_GL2_PATHS>$(IGRAPHICS_DEPS_PATH)\glad_GL2\include;$(IGRAPHICS_DEPS_PATH)\glad_GL2\src</GLAD_GL2_PATHS>
     <GLAD_GL3_PATHS>$(IGRAPHICS_DEPS_PATH)\glad_GL3\include;$(IGRAPHICS_DEPS_PATH)\glad_GL3\src</GLAD_GL3_PATHS>
     <PNG_PATH>$(WDL_PATH)\libpng</PNG_PATH>

--- a/common-win.props
+++ b/common-win.props
@@ -20,7 +20,7 @@
     <AGG_PATH>$(IGRAPHICS_DEPS_PATH)\AGG\agg-2.4</AGG_PATH>
     <AGG_INC_PATHS>$(AGG_PATH)\include;$(AGG_PATH)\font_freetype;$(AGG_PATH)\include\util;$(AGG_PATH)\include\platform\win32;$(AGG_PATH)\src;$(AGG_PATH)\src\platform\win32</AGG_INC_PATHS>
     <SKIA_PATH>$(DEPS_PATH)\Build\src\skia</SKIA_PATH>
-    <SKIA_INC_PATHS>$(SKIA_PATH);$(SKIA_PATH)\include\core;$(SKIA_PATH)\include\effects;$(SKIA_PATH)\include\config;$(SKIA_PATH)\include\utils;$(SKIA_PATH)\include\gpu;$(SKIA_PATH)\experimental\svg\model;$(SKIA_PATH)\third_party\externals\icu\source\common</SKIA_INC_PATHS>
+    <SKIA_INC_PATHS>$(SKIA_PATH);$(SKIA_PATH)\include\core;$(SKIA_PATH)\include\effects;$(SKIA_PATH)\include\config;$(SKIA_PATH)\include\utils;$(SKIA_PATH)\include\gpu;$(SKIA_PATH)\modules\svg\src;$(SKIA_PATH)\third_party\externals\icu\source\common</SKIA_INC_PATHS>
     <GLAD_GL2_PATHS>$(IGRAPHICS_DEPS_PATH)\glad_GL2\include;$(IGRAPHICS_DEPS_PATH)\glad_GL2\src</GLAD_GL2_PATHS>
     <GLAD_GL3_PATHS>$(IGRAPHICS_DEPS_PATH)\glad_GL3\include;$(IGRAPHICS_DEPS_PATH)\glad_GL3\src</GLAD_GL3_PATHS>
     <PNG_PATH>$(WDL_PATH)\libpng</PNG_PATH>
@@ -81,7 +81,7 @@
       <PreprocessorDefinitions>$(ALL_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4250;4018;4267;4068;</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(WDL_PATH);$(IPLUG_PATH);$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>


### PR DESCRIPTION
This PR updates the Skia dependency to master, and fixes some problems I ran into with OpenGL 3.

Skia changes:
- `GrContext` changed to `GrDirectContext`
- The `svg` module moved
- Deprecated `SkMatrix` functions were removed
- There was a problem with the destruction order of the `SkSurface`. The OpenGL context was destroyed before the surface was deleted, and it would end up spin looping on `glGetError` in `GrGLGpu::clearErrorsAndCheckForOOM`. Since there was no context, it would return `GL_INVALID_OPERATION` and never exit the loop. Changed to destroy the surface/canvas/context in OnViewDestroyed.
- C++ standard changed to C++17, due to a mandatory RVO, see https://groups.google.com/g/skia-discuss/c/IAsnL2use7E/m/0Smg0vRPBgAJ

OpenGL 3 Changes;
- `GL_STENCIL_BITS` is undefined with the 3.3 core profile, changed to use `glGetFramebufferAttachmentParameteriv`
 
Windows changes
- Include the `wglCreateContextAttribsARB` extension
- Create a 3.3 core profile context if possible

I tested these changes on MSVC 2019, Skia master (4691b0f82bd00e799386a9d4327282d0a2c074ca), using IPlugEffect changed to use IGRAPHICS_SKIA and IGRAPHICS_GL3.