### PR TITLE
Load plugin CMake code on-demand instead of all at once, and remove the need to specify OBJCXX

### DIFF
--- a/Examples/IPlugInstrument/CMakeLists.txt
+++ b/Examples/IPlugInstrument/CMakeLists.txt
@@ -11,11 +11,11 @@ cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 # To build the VST3 version:
 #   cmake --build build-linux --target IPlugInstrument-vst3
 
-project(IPlugInstrument VERSION 1.0.0 LANGUAGES C CXX)
+project(IPlugInstrument VERSION 1.0.0)
 
 set(IPLUG2_DIR ${CMAKE_SOURCE_DIR}/../..)
 include(${IPLUG2_DIR}/iPlug2.cmake)
-find_package(iPlug2 REQUIRED COMPONENTS APP VST2 VST3 AU)
+find_package(iPlug2 REQUIRED)
 
 set(dir "${CMAKE_SOURCE_DIR}")
 set(SRC_FILES
@@ -30,6 +30,9 @@ set(RES_FILES
 )
 source_group(TREE "${dir}/resources" PREFIX Resources FILES ${RES_FILES})
 
+# Disable compiler-dependent C++ extension features (optional, but recommended for code portability)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # While not required, creating a base interface for includes and settings seems like a good idea.
 add_library(_base INTERFACE)
 # iplug_target_add() is a shorthand function for adding sources and include dirs,
@@ -37,13 +40,9 @@ add_library(_base INTERFACE)
 iplug_target_add(_base INTERFACE
   INCLUDE ${dir} ${dir}/resources
   LINK iPlug2_Synth iPlug2_NANOVG iPlug2_GL2)
+# Use C++ 14 standard
+target_compile_features(_base INTERFACE cxx_std_14)
 
-# For whatever reason setting CXX_STANDARD doesn't seem to work properly, so set it explicitly.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(_base INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:/std:c++14>")
-else()
-  target_compile_options(_base INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-std=c++14>")
-endif()
 
 add_executable(App WIN32 MACOSX_BUNDLE ${SRC_FILES} ${RES_FILES})
 iplug_target_add(App PUBLIC LINK _base RESOURCE ${RES_FILES})

--- a/Scripts/cmake/FindiPlug2.cmake
+++ b/Scripts/cmake/FindiPlug2.cmake
@@ -334,34 +334,6 @@ iplug_target_add(iPlug2_Core INTERFACE DEFINE ${_def} INCLUDE ${_inc} SOURCE ${_
 # We include this first because APP requires LICE.
 include("${IPLUG2_CMAKE_DIR}/IGraphics.cmake")
 
-##################
-# Plugin Formats #
-##################
-
-if (AAX IN_LIST iPlug2_FIND_COMPONENTS)
-  include("${IPLUG2_CMAKE_DIR}/AAX.cmake")
-endif()
-
-if (APP IN_LIST iPlug2_FIND_COMPONENTS)
-  include("${IPLUG2_CMAKE_DIR}/APP.cmake")
-endif()
-
-if ((AU IN_LIST iPlug2_FIND_COMPONENTS) AND APPLE)
-  include("${IPLUG2_CMAKE_DIR}/AudioUnit.cmake")
-endif()
-
-if (VST2 IN_LIST iPlug2_FIND_COMPONENTS)
-  include("${IPLUG2_CMAKE_DIR}/VST2.cmake")
-endif()
-
-if (VST3 IN_LIST iPlug2_FIND_COMPONENTS)
-  include("${IPLUG2_CMAKE_DIR}/VST3.cmake")
-endif()
-
-if (WEB IN_LIST iPlug2_FIND_COMPONENTS)
-  include("${IPLUG2_CMAKE_DIR}/WEB.cmake")
-endif()
-
 ####################
 # Reaper Extension #
 ####################
@@ -443,26 +415,52 @@ function(iplug_configure_target target target_type)
 
   endif()
   
-  
-  if ("${target_type}" STREQUAL "app")
-    iplug_configure_app(${target})
-  elseif ("${target_type}" STREQUAL "aax")
+  if ("${target_type}" STREQUAL "aax")
+    if (NOT TARGET iPlug2_AAX)
+      include("${IPLUG2_CMAKE_DIR}/AAX.cmake")
+    endif()
     iplug_configure_aax(${target})
+  elseif ("${target_type}" STREQUAL "app")
+    if (NOT TARGET iPlug2_APP)
+      include("${IPLUG2_CMAKE_DIR}/APP.cmake")
+    endif()
+    iplug_configure_app(${target})
   elseif ("${target_type}" STREQUAL "au2")
+    if (NOT TARGET iPlug2_AUv2)
+      include("${IPLUG2_CMAKE_DIR}/AudioUnit.cmake")
+    endif()
     iplug_configure_au2(${target})
   elseif ("${target_type}" STREQUAL "au3")
+    if (NOT TARGET iPlug2_AUv3)
+      include("${IPLUG2_CMAKE_DIR}/AudioUnit.cmake")
+    endif()
     iplug_configure_au3(${target})
   elseif ("${target_type}" STREQUAL "lv2")
+    if (NOT TARGET iPlug2_LV2)
+      include("${IPLUG2_CMAKE_DIR}/LV2.cmake")
+    endif()
     iplug_configure_lv2(${target})
   # elseif ("${target_type}" STREQUAL "reaper")
   #   iplug_conifgure_reaper(${target})
   elseif ("${target_type}" STREQUAL "vst2")
+    if (NOT TARGET iPlug2_VST2)
+      include("${IPLUG2_CMAKE_DIR}/VST2.cmake")
+    endif()
     iplug_configure_vst2(${target})
   elseif ("${target_type}" STREQUAL "vst3")
+    if (NOT TARGET iPlug2_VST3)
+      include("${IPLUG2_CMAKE_DIR}/VST3.cmake")
+    endif()
     iplug_configure_vst3(${target})
   elseif ("${target_type}" STREQUAL "web")
+    if (NOT TARGET iPlug2_WEB)
+      include("${IPLUG2_CMAKE_DIR}/WEB.cmake")
+    endif()
     iplug_configure_web(${target})
   elseif ("${target_type}" STREQUAL "wam")
+    if (NOT TARGET iPlug2_WAM)
+      include("${IPLUG2_CMAKE_DIR}/WEB.cmake")
+    endif()
     iplug_configure_wam(${target})
   else()
     message("Unknown target type \'${target_type}\' for target '${target}'" FATAL_ERROR)

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -2,6 +2,11 @@
 # This file should be included in your main CMakeLists.txt file. #
 #
 
+
+if (APPLE)
+  enable_language(OBJCXX)
+endif()
+
 # We need this so we can find call FindFaust.cmake
 set(IPLUG2_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR}/Scripts/cmake)
 list(APPEND CMAKE_MODULE_PATH ${IPLUG2_CMAKE_DIR})


### PR DESCRIPTION
What it says in the description. This reduces the redundant information (you don't have to say which types of plugins you're making before you make them). The OBJCXX part hides some differences between Makefiles and Xcode on MacOS, and doesn't require users to know specifically enable OBJCXX on Apple platforms only (CMake throws errors if you try to enable OBJCXX on GCC or MSVC).

This also makes another change recommended by @kmturley in the #39 discussion in regards to using a more standard way to set the C++ version.