### PR TITLE
fixed bug: ISVGControl prevents termination of the plugin (Skia/OGL/Win)

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -1855,7 +1855,10 @@ public:
   , mUseLayer(useLayer)
   {}
 
-  virtual ~ISVGControl() {}
+  ~ISVGControl()
+  {
+    mLayer.release();
+  }
 
   void Draw(IGraphics& g) override
   {


### PR DESCRIPTION
The ILayerPtr has to be released in the destructor of the ISVGControl, otherwise, the Skia destructor fails.