### PR TITLE
add BGColor to IEditableTextControl

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -1921,8 +1921,8 @@ protected:
 class IEditableTextControl : public ITextControl
 {
 public:
-  IEditableTextControl(const IRECT& bounds, const char* str, const IText& text = DEFAULT_TEXT)
-  : ITextControl(bounds, str, text)
+  IEditableTextControl(const IRECT& bounds, const char* str, const IText& text = DEFAULT_TEXT, const IColor& BGColor = DEFAULT_BGCOLOR)
+  : ITextControl(bounds, str, text, BGColor)
   {
     mIgnoreMouse = false;
   }


### PR DESCRIPTION
Issue:
- Currently IEditableTextControl does not provide an option to set the BGColor in the constructor. 
- Since IEditableTextControl inherits ITextControl and the constructor for ITextControl sets the BGColor to the default BGColor, the default background color will always be used in IEditableTextControl. 

Fix:
- Adding BGColor to the constructor and setting a default is a non-breaking change and allows users to change the BGColor.