### PR TITLE
implement OnMIDIPortStatusChange to handle MIDI hot swapping for standalong apps (issue #665)

### DIFF
--- a/Examples/IPlugInstrument/IPlugInstrument.cpp
+++ b/Examples/IPlugInstrument/IPlugInstrument.cpp
@@ -150,4 +150,10 @@ bool IPlugInstrument::OnMessage(int msgTag, int ctrlTag, int dataSize, const voi
   
   return false;
 }
+
+void IPlugInstrument::OnMIDIPortStatusChange()
+{
+  EMsgBoxResult popupResult = this->GetUI()->ShowMessageBox("The number of MIDI IN/OUT devices has changed.",
+    "MIDI Port Status Changed", EMsgBoxType::kMB_OK);
+}
 #endif

--- a/Examples/IPlugInstrument/IPlugInstrument.h
+++ b/Examples/IPlugInstrument/IPlugInstrument.h
@@ -53,7 +53,7 @@ public:
   void OnParamChange(int paramIdx) override;
   void OnIdle() override;
   bool OnMessage(int msgTag, int ctrlTag, int dataSize, const void* pData) override;
-
+  void OnMIDIPortStatusChange() override;
 private:
   IPlugInstrumentDSP<sample> mDSP {16};
   IPeakSender<2> mMeterSender;

--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -148,3 +148,10 @@ void IPlugAPP::AppProcess(double** inputs, double** outputs, int nFrames)
   ProcessBuffers(0.0, GetBlockSize());
   LEAVE_PARAMS_MUTEX
 }
+
+void IPlugAPP::OnTimer(Timer& t)
+{
+  IPlugAPIBase::OnTimer(t);
+  if (mAppHost->ProbeMidiIO())
+    OnMIDIPortStatusChange();
+}

--- a/IPlug/APP/IPlugAPP.h
+++ b/IPlug/APP/IPlugAPP.h
@@ -55,6 +55,9 @@ public:
   //IPlugAPP
   void AppProcess(double** inputs, double** outputs, int nFrames);
 
+protected:
+  virtual void OnTimer(Timer& t) override;
+
 private:
   IPlugAPPHost* mAppHost = nullptr;
   IPlugQueue<IMidiMsg> mMidiMsgsFromCallback {MIDI_TRANSFER_SIZE};

--- a/IPlug/APP/IPlugAPP_host.cpp
+++ b/IPlug/APP/IPlugAPP_host.cpp
@@ -301,39 +301,93 @@ void IPlugAPPHost::ProbeAudioIO()
   }
 }
 
-void IPlugAPPHost::ProbeMidiIO()
+bool IPlugAPPHost::ProbeMidiIO()
 {
-  if ( !mMidiIn || !mMidiOut )
-    return;
+  bool midiInChanged = false;
+  bool midiOutChanged = false;
+  if (!mMidiIn || !mMidiOut)
+    return false;
   else
   {
     int nInputPorts = mMidiIn->getPortCount();
-
-    mMidiInputDevNames.push_back(OFF_TEXT);
-
 #ifdef OS_MAC
-    mMidiInputDevNames.push_back("virtual input");
-#endif
-
-    for (int i=0; i<nInputPorts; i++ )
+    if (mMidiInputDevNames.size() != nInputPorts + 2)
     {
-      mMidiInputDevNames.push_back(mMidiIn->getPortName(i));
+#else
+    if (mMidiInputDevNames.size() != nInputPorts + 1)
+    {
+#endif
+      midiInChanged = true;
+      mMidiInputDevNames.clear();
+      mMidiInputDevNames.push_back(OFF_TEXT);
+#ifdef OS_MAC
+      mMidiInputDevNames.push_back("virtual input");
+#endif
+      for (int i = 0; i < nInputPorts; i++)
+      {
+        mMidiInputDevNames.push_back(mMidiIn->getPortName(i));
+    }
+  }
+    else
+    {
+      for (int i = 0; i < nInputPorts; i++)
+      {
+        if (mMidiInputDevNames.at(i + 1) != mMidiIn->getPortName(i))
+        {
+          midiInChanged = true;
+          mMidiInputDevNames.at(i + 1) = mMidiIn->getPortName(i);
+        }
+#ifdef OS_MAC
+        if (mMidiInputDevNames.at(i + 2) != mMidiIn->getPortName(i))
+        {
+          midiInChanged = true;
+          mMidiInputDevNames.at(i + 2) = mMidiIn->getPortName(i);
+        }
+#endif
+      }
     }
 
     int nOutputPorts = mMidiOut->getPortCount();
-
-    mMidiOutputDevNames.push_back(OFF_TEXT);
+#ifdef OS_MAC
+    if (mMidiOutputDevNames.size() != nOutputPorts + 2)
+    {
+#else
+    if (mMidiOutputDevNames.size() != nOutputPorts + 1)
+    {
+#endif
+      mMidiOutputDevNames.clear();
+      mMidiOutputDevNames.push_back(OFF_TEXT);
 
 #ifdef OS_MAC
-    mMidiOutputDevNames.push_back("virtual output");
+      mMidiOutputDevNames.push_back("virtual output");
 #endif
 
-    for (int i=0; i<nOutputPorts; i++ )
-    {
-      mMidiOutputDevNames.push_back(mMidiOut->getPortName(i));
-      //This means the virtual output port wont be added as an input
+      for (int i = 0; i < nOutputPorts; i++)
+      {
+        mMidiOutputDevNames.push_back(mMidiOut->getPortName(i));
+        //This means the virtual output port wont be added as an input
+      }
     }
-  }
+    else
+    {
+      for (int i = 0; i < nOutputPorts; i++)
+      {
+        if (mMidiOutputDevNames.at(i + 1) != mMidiOut->getPortName(i))
+        {
+          midiOutChanged = true;
+          mMidiOutputDevNames.at(i + 1) = mMidiOut->getPortName(i);
+        }
+#ifdef OS_MAC
+        if (mMidiInputDevNames.at(i + 2) != mMidiOut->getPortName(i))
+        {
+          midiOutChanged = true;
+          mMidiOutputDevNames.at(i + 2) = mMidiOut->getPortName(i);
+        }
+#endif
+      }
+    }
+    }
+  return midiInChanged || midiOutChanged;
 }
 
 bool IPlugAPPHost::AudioSettingsInStateAreEqual(AppState& os, AppState& ns)

--- a/IPlug/APP/IPlugAPP_host.h
+++ b/IPlug/APP/IPlugAPP_host.h
@@ -195,7 +195,7 @@ public:
   
   /** find out which devices have input channels & which have output channels, add their ids to the lists */
   void ProbeAudioIO();
-  void ProbeMidiIO();
+  bool ProbeMidiIO();
   bool InitMidi();
   void CloseAudio();
   bool InitAudio(uint32_t inId, uint32_t outId, uint32_t sr, uint32_t iovs);

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -103,8 +103,11 @@ public:
 #endif
   }
 
-  /** Override this method to get an "idle"" call on the main thread */
+  /** Override this method to get an "idle" call on the main thread */
   virtual void OnIdle() {}
+
+  /** Override this method to handle a change in the MIDI port status */
+  virtual void OnMIDIPortStatusChange() {}
     
 #pragma mark - Methods you can call - some of which have custom implementations in the API classes, some implemented in IPlugAPIBase.cpp
   /** SetParameterValue is called from the UI in the middle of a parameter change gesture (possibly via delegate) in order to update a parameter's value.
@@ -206,9 +209,9 @@ private:
   /** \todo */
   virtual void TransmitSysExDataFromProcessor(const SysExData& data) {}
 
-  void OnTimer(Timer& t);
-
 protected:
+  virtual void OnTimer(Timer& t);
+
   WDL_String mParamDisplayStr;
   std::unique_ptr<Timer> mTimer;
   

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -21,7 +21,7 @@ using namespace iplug;
 
 IPluginBase::IPluginBase(int nParams, int nPresets)
 : EDITOR_DELEGATE_CLASS(nParams)
-{  
+{
   for (int i = 0; i < nPresets; ++i)
     mPresets.Add(new IPreset());
 }


### PR DESCRIPTION
This adds a function to detect a change in the MIDI port status (IN or OUT) which can be used by the application to gracefully handle hot swapping. 

IPlugAPPHost::ProbeMidiIO() is modified to check for changes in the input/output status. The return type is changed from void to bool, where true indicates a change in the status. ProbeMidiIO is called periodically in OnTimer, which was a private method in IPlugAPIBase. This has been changed to a protected virtual method. This allows IPlugAPP to override the method and periodically call ProbeMidiIO (). 

IPlugAPP calls OnMIDIPortStatusChange when ProbeMidiIO returns true. Note that OnMIDIPortStatusChange is the method to be overriden by the app. Hence, it can't be declared in IPlugAPP because this does not exist for other hosts (e.g. VST3). Instead it is declared in IPlugAPIBase.

Incidentally this also updates the values in the preferences dialog when there is a change in the MIDI devices, which means the app doesn't have to be restarted if you hot swap devices. A similar change could be made for audio devices (e.g. USB audio device plugged in).
