### PR TITLE
fix GetControlWithTag

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -441,11 +441,11 @@ void IGraphics::ShowFPSDisplay(bool enable)
 
 IControl* IGraphics::GetControlWithTag(int ctrlTag) const
 {
-  IControl* pControl = mCtrlTags.at(ctrlTag);
-  
-  if(pControl != nullptr)
+  const auto it = mCtrlTags.find(ctrlTag);
+
+  if (it != mCtrlTags.end())
   {
-    return pControl;
+    return it->second;
   }
   else
   {


### PR DESCRIPTION
The `at()` function of `std::unordered_map` does not return a nullptr if the element does not exist. It throws. I am very sure the intended way was to use `find()` and check the result. That's what the API suggests.