### PR TITLE
add quotes around b64 javascript string (otherwise it's a js error)

### DIFF
--- a/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.h
+++ b/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.h
@@ -49,7 +49,7 @@ public:
     std::vector<char> base64;
     base64.resize(GetBase64Length(dataSize));
     wdl_base64encode(reinterpret_cast<const unsigned char*>(pData), base64.data(), dataSize);
-    str.SetFormatted(mMaxJSStringLength, "SCMFD(%i, %i, %i, %s)", ctrlTag, msgTag, dataSize, base64.data());
+    str.SetFormatted(mMaxJSStringLength, "SCMFD(%i, %i, %i, '%s')", ctrlTag, msgTag, dataSize, base64.data());
     EvaluateJavaScript(str.Get());
   }
 


### PR DESCRIPTION
WebView callbacks don't work because the base64 strings in the EvaluateJavascript() function need to be surrounded in quotes (because they're strings).