### PR TITLE
Support display scales other than 100%/200% on Windows. 

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -272,7 +272,7 @@ bool IGraphicsNanoVG::BitmapExtSupported(const char* ext)
 IBitmap IGraphicsNanoVG::LoadBitmap(const char* name, int nStates, bool framesAreHorizontal, int targetScale)
 {
   if (targetScale == 0)
-    targetScale = GetScreenScale();
+    targetScale = GetRoundedScreenScale();
 
   // NanoVG does not use the global static cache, since bitmaps are textures linked to a context
   StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -339,8 +339,8 @@ void IGraphicsSkia::OnViewDestroyed()
 
 void IGraphicsSkia::DrawResize()
 {
-  auto w = WindowWidth() * GetScreenScale();
-  auto h = WindowHeight() * GetScreenScale();
+  auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
+  auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
   
 #if defined IGRAPHICS_GL || defined IGRAPHICS_METAL
   if (mGrContext.get())
@@ -352,7 +352,7 @@ void IGraphicsSkia::DrawResize()
   #ifdef OS_WIN
     mSurface.reset();
    
-    const size_t bmpSize = sizeof(BITMAPINFOHEADER) + (WindowWidth() * GetScreenScale()) * (WindowHeight() * GetScreenScale()) * sizeof(uint32_t);
+    const size_t bmpSize = sizeof(BITMAPINFOHEADER) + (w * h * sizeof(uint32_t));
     mSurfaceMemory.Resize(bmpSize);
     BITMAPINFO* bmpInfo = reinterpret_cast<BITMAPINFO*>(mSurfaceMemory.Get());
     ZeroMemory(bmpInfo, sizeof(BITMAPINFO));

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -77,7 +77,7 @@ IGraphics::~IGraphics()
   svgStorage.Release();
 }
 
-void IGraphics::SetScreenScale(int scale)
+void IGraphics::SetScreenScale(float scale)
 {
   mScreenScale = scale;
   int windowWidth = WindowWidth() * GetPlatformWindowScale();
@@ -1490,8 +1490,8 @@ void IGraphics::OnDragResize(float x, float y)
 IBitmap IGraphics::GetScaledBitmap(IBitmap& src)
 {
   //TODO: bug with # frames!
-//  return LoadBitmap(src.GetResourceName().Get(), src.N(), src.GetFramesAreHorizontal(), (GetScreenScale() == 1 && GetDrawScale() > 1.) ? 2 : 0 /* ??? */);
-  return LoadBitmap(src.GetResourceName().Get(), src.N(), src.GetFramesAreHorizontal(), GetScreenScale());
+//  return LoadBitmap(src.GetResourceName().Get(), src.N(), src.GetFramesAreHorizontal(), (GetRoundedScreenScale() == 1 && GetDrawScale() > 1.) ? 2 : 0 /* ??? */);
+  return LoadBitmap(src.GetResourceName().Get(), src.N(), src.GetFramesAreHorizontal(), GetRoundedScreenScale());
 }
 
 void IGraphics::EnableTooltips(bool enable)
@@ -1691,7 +1691,7 @@ WDL_TypedBuf<uint8_t> IGraphics::LoadResource(const char* fileNameOrResID, const
 IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHorizontal, int targetScale)
 {
   if (targetScale == 0)
-    targetScale = GetScreenScale();
+    targetScale = GetRoundedScreenScale();
 
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
@@ -1753,7 +1753,7 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
 IBitmap IGraphics::LoadBitmap(const char *name, const void *pData, int dataSize, int nStates, bool framesAreHorizontal, int targetScale)
 {
   if (targetScale == 0)
-    targetScale = GetScreenScale();
+    targetScale = GetRoundedScreenScale();
 
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
@@ -1815,7 +1815,7 @@ void IGraphics::RetainBitmap(const IBitmap& bitmap, const char* cacheName)
 
 IBitmap IGraphics::ScaleBitmap(const IBitmap& inBitmap, const char* name, int scale)
 {
-  int screenScale = GetScreenScale();
+  int screenScale = GetRoundedScreenScale();
   float drawScale = GetDrawScale();
 
   mScreenScale = scale;
@@ -1955,7 +1955,7 @@ void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable)
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
+  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetRoundedScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
 }
 
 void IGraphics::ResumeLayer(ILayerPtr& layer)
@@ -2013,7 +2013,7 @@ bool IGraphics::CheckLayer(const ILayerPtr& layer)
     layer->Invalidate();
   }
 
-  return pBitmap && !layer->mInvalid && pBitmap->GetDrawScale() == GetDrawScale() && pBitmap->GetScale() == GetScreenScale();
+  return pBitmap && !layer->mInvalid && pBitmap->GetDrawScale() == GetDrawScale() && pBitmap->GetScale() == GetRoundedScreenScale();
 }
 
 void IGraphics::DrawLayer(const ILayerPtr& layer, const IBlend* pBlend)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -961,8 +961,8 @@ public:
   IGraphics& operator=(const IGraphics&) = delete;
     
   /** Called by the platform IGraphics class when moving to a new screen to set DPI
-   * @param scale The scale of the display, typically 2 on a macOS retina screen */
-  void SetScreenScale(int scale);
+   * @param scale The scale of the screen, typically 2 on a macOS retina screen, or 2 with 200% scaling on windows */
+  void SetScreenScale(float scale);
 
   /** Called by some platform IGraphics classes in order to translate the graphics context, in response to e.g. iOS onscreen keyboard appearing */
   void SetTranslation(float x, float y) { mXTranslation = x; mYTranslation = y; }
@@ -1047,11 +1047,11 @@ public:
    * @return A whole number representing the height of the graphics context in pixels on a 1:1 screen */
   int Height() const { return mHeight; }
 
-  /** Gets the width of the graphics context including scaling (not display scaling!)
+  /** Gets the width of the graphics context including draw scaling
    * @return A whole number representing the width of the graphics context with scaling in pixels on a 1:1 screen */
   int WindowWidth() const { return static_cast<int>(static_cast<float>(mWidth) * mDrawScale); }
 
-  /** Gets the height of the graphics context including scaling (not display scaling!)
+  /** Gets the height of the graphics context including draw scaling
    * @return A whole number representing the height of the graphics context with scaling in pixels on a 1:1 screen */
   int WindowHeight() const { return static_cast<int>(static_cast<float>(mHeight) * mDrawScale); }
 
@@ -1063,13 +1063,17 @@ public:
    * @return The scaling applied to the graphics context */
   float GetDrawScale() const { return mDrawScale; }
 
-  /** Gets the display scaling factor
+  /** Gets the screen/display scaling factor, e.g. 2 for a macOS retina screen, 1.5 on Windows when screen is scaled to 150%
     * @return The scale factor of the display on which this graphics context is currently located */
-  int GetScreenScale() const { return mScreenScale; }
+  float GetScreenScale() const { return mScreenScale; }
 
-  /** Gets the combined screen and display scaling factor
+  /** Gets the screen/display scaling factor, rounded up
+  * @return The scale factor of the screen/display on which this graphics context is currently located */
+  int GetRoundedScreenScale() const { return static_cast<int>(std::ceil(GetScreenScale())); }
+
+  /** Gets the combined draw and screen/display scaling factor
   * @return The draw scale * screen scale */
-  float GetTotalScale() const { return static_cast<float>(mDrawScale * static_cast<float>(mScreenScale)); }
+  float GetTotalScale() const { return mDrawScale * mScreenScale; }
 
   /** Gets the nearest backing pixel aligned rect to the input IRECT
     * @param r The IRECT to snap
@@ -1174,7 +1178,7 @@ public:
 
   /** Returns a scaling factor for resizing parent windows via the host/plugin API
    * @return A scaling factor for resizing parent windows */
-  virtual int GetPlatformWindowScale() const { return 1; }
+  virtual float GetPlatformWindowScale() const { return 1.f; }
 
 private:
   /* NO-OP to create ImGui when IGRAPHICS_IMGUI is defined */
@@ -1744,7 +1748,7 @@ private:
   int mWidth;
   int mHeight;
   int mFPS;
-  int mScreenScale = 1; // the scaling of the display that the UI is currently on e.g. 2 for retina
+  float mScreenScale = 1.f; // the scaling of the display that the UI is currently on e.g. 2 for retina
   float mDrawScale = 1.f; // scale deviation from  default width and height i.e stretching the UI by dragging bottom right hand corner
 
   int mIdleTicks = 0;

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -59,10 +59,10 @@ void IGEditorDelegate::CloseWindow()
   }
 }
 
-void IGEditorDelegate::SetScreenScale(double scale)
+void IGEditorDelegate::SetScreenScale(float scale)
 {
   if (GetUI())
-    mGraphics->SetScreenScale(static_cast<int>(std::round(scale)));
+    mGraphics->SetScreenScale(scale);
 }
 
 void IGEditorDelegate::SendControlValueFromDelegate(int ctrlTag, double normalizedValue)

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -40,7 +40,7 @@ public:
   //IEditorDelegate
   void* OpenWindow(void* pHandle) final;
   void CloseWindow() final;
-  void SetScreenScale(double scale) final;
+  void SetScreenScale(float scale) final;
   
   bool OnKeyDown(const IKeyPress& key) override;
   bool OnKeyUp(const IKeyPress& key) override;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -145,7 +145,7 @@ StaticStorage<IGraphicsWin::HFontHolder> IGraphicsWin::sHFontCache;
 
 #pragma mark - Mouse and tablet helpers
 
-extern int GetScaleForHWND(HWND hWnd);
+extern float GetScaleForHWND(HWND hWnd);
 
 inline IMouseInfo IGraphicsWin::GetMouseInfo(LPARAM lParam, WPARAM wParam)
 {
@@ -242,7 +242,7 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   }
 
   // TODO: move this... listen to the right messages in windows for screen resolution changes, etc.
-  int scale = GetScaleForHWND(mPlugWnd);
+  float scale = GetScaleForHWND(mPlugWnd);
   if (scale != GetScreenScale())
     SetScreenScale(scale);
 
@@ -1465,7 +1465,7 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT&
     }
     DestroyMenu(hMenu);
 
-    RECT r = { 0, 0, WindowWidth() * GetScreenScale(), WindowHeight() * GetScreenScale() };
+    RECT r = { 0, 0, static_cast<LONG>(WindowWidth() * GetScreenScale()), static_cast<LONG>(WindowHeight() * GetScreenScale()) };
     InvalidateRect(mPlugWnd, &r, FALSE);
 
     return result;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -34,7 +34,7 @@ public:
   void* GetWinModuleHandle() override { return mHInstance; }
 
   void ForceEndUserEdit() override;
-  int GetPlatformWindowScale() const override { return GetScreenScale(); }
+  float GetPlatformWindowScale() const override { return GetScreenScale(); }
 
   void PlatformResize(bool parentHasResized) override;
 

--- a/IPlug/APP/IPlugAPP_dialog.cpp
+++ b/IPlug/APP/IPlugAPP_dialog.cpp
@@ -534,7 +534,7 @@ static void ClientResize(HWND hWnd, int nWidth, int nHeight)
 }
 
 #ifdef OS_WIN 
-extern int GetScaleForHWND(HWND hWnd);
+extern float GetScaleForHWND(HWND hWnd);
 #endif
 
 //static
@@ -718,11 +718,11 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 #endif
 
 #ifdef OS_WIN 
-      int scale = GetScaleForHWND(hwndDlg);
-      mmi->ptMinTrackSize.x *= scale;
-      mmi->ptMinTrackSize.y *= scale;
-      mmi->ptMaxTrackSize.x *= scale;
-      mmi->ptMaxTrackSize.y *= scale;
+      float scale = GetScaleForHWND(hwndDlg);
+      mmi->ptMinTrackSize.x = static_cast<LONG>(static_cast<float>(mmi->ptMinTrackSize.x) * scale);
+      mmi->ptMinTrackSize.y = static_cast<LONG>(static_cast<float>(mmi->ptMinTrackSize.y) * scale);
+      mmi->ptMaxTrackSize.x = static_cast<LONG>(static_cast<float>(mmi->ptMaxTrackSize.x) * scale);
+      mmi->ptMaxTrackSize.y = static_cast<LONG>(static_cast<float>(mmi->ptMaxTrackSize.y) * scale);
 #endif
       
       return 0;
@@ -732,7 +732,7 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
     {
       WORD dpi = HIWORD(wParam);
       RECT* rect = (RECT*)lParam;
-      int scale = GetScaleForHWND(hwndDlg);
+      float scale = GetScaleForHWND(hwndDlg);
 
       POINT ptDiff;
       RECT rcClient;
@@ -779,11 +779,11 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
       {
         RECT r;
         GetClientRect(hwndDlg, &r);
-        int scale = 1;
+        float scale = 1.f;
         #ifdef OS_WIN 
         scale = GetScaleForHWND(hwndDlg);
         #endif
-        pPlug->OnParentWindowResize(r.right / scale, r.bottom / scale);
+        pPlug->OnParentWindowResize(static_cast<int>(r.right / scale), static_cast<int>(r.bottom / scale));
         return 1;
       }
       default:

--- a/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.cpp
+++ b/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.cpp
@@ -25,7 +25,7 @@ WebViewEditorDelegate::~WebViewEditorDelegate()
   CloseWindow();
 }
 
-extern int GetScaleForHWND(HWND hWnd);
+extern float GetScaleForHWND(HWND hWnd);
 
 void* WebViewEditorDelegate::OpenWindow(void* pParent)
 {

--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -345,7 +345,7 @@ public:
   
   /** Can be used by a host API to inform the editor of screen scale changes
    *@param scale The new screen scale*/
-  virtual void SetScreenScale(double scale) {}
+  virtual void SetScreenScale(float scale) {}
 
 protected:
   /** A list of IParam objects. This list is populated in the delegate constructor depending on the number of parameters passed as an argument to MakeConfig() in the plug-in class implementation constructor */

--- a/IPlug/IPlug_include_in_plug_src.h
+++ b/IPlug/IPlug_include_in_plug_src.h
@@ -35,7 +35,7 @@
 
   UINT(WINAPI *__GetDpiForWindow)(HWND);
 
-  int GetScaleForHWND(HWND hWnd)
+  float GetScaleForHWND(HWND hWnd)
   {
     if (!__GetDpiForWindow)
     {
@@ -47,8 +47,9 @@
     }
 
     int dpi = __GetDpiForWindow(hWnd);
+
     if (dpi != USER_DEFAULT_SCREEN_DPI)
-      return static_cast<int>(std::round(static_cast<double>(dpi) / USER_DEFAULT_SCREEN_DPI));
+      return static_cast<float>(dpi) / USER_DEFAULT_SCREEN_DPI;
 
     return 1;
   }


### PR DESCRIPTION
IGraphics::mScreenScale becomes a float

Without this change the plug-in was not the correct size on displays where the scaling was e.g. 150%, it was quantized
