### PR TITLE
set text and colors of IURLControl

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -449,7 +449,7 @@ ITextControl::ITextControl(const IRECT& bounds, const char* str, const IText& te
 , mSetBoundsBasedOnStr(setBoundsBasedOnStr)
 {
   mIgnoreMouse = true;
-  IControl::mText = text;
+  mText = text;
 }
 
 void ITextControl::OnInit()
@@ -504,7 +504,6 @@ IURLControl::IURLControl(const IRECT& bounds, const char* str, const char* urlSt
 , mOriginalColor(text.mFGColor)
 {
   mIgnoreMouse = false;
-  IControl::mText = text;
 }
 
 void IURLControl::Draw(IGraphics& g)
@@ -558,6 +557,22 @@ void IURLControl::OnMouseDown(float x, float y, const IMouseMod& mod)
   GetUI()->OpenURL(mURLStr.Get());
   GetUI()->ReleaseMouseCapture();
   mClicked = true;
+}
+
+void IURLControl::SetText(const IText& txt)
+{
+  mText = txt;
+  mOriginalColor = txt.mFGColor;
+}
+
+void IURLControl::SetMOColor(const IColor& color)
+{
+  mMOColor = color;
+}
+
+void IURLControl::SetCLColor(const IColor& color)
+{
+  mCLColor = color;
 }
 
 ITextToggleControl::ITextToggleControl(const IRECT& bounds, int paramIdx, const char* offText, const char* onText, const IText& text, const IColor& bgColor)

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -283,7 +283,7 @@ public:
 
   /** Set the Text object typically used to determine font/layout/size etc of the main text in a control
    * @param txt An IText struct with the desired formatting */
-  void SetText(const IText& txt) { mText = txt; }
+  virtual void SetText(const IText& txt) { mText = txt; }
 
   /** Set the Blend for this control. This can be used differently by different controls, or not at all.
    *  By default it is used to change the opacity of controls when they are disabled */
@@ -2004,6 +2004,10 @@ public:
   void OnMouseDown(float x, float y, const IMouseMod& mod) override;
   void OnMouseOver(float x, float y, const IMouseMod& mod) override { GetUI()->SetMouseCursor(ECursor::HAND); IControl::OnMouseOver(x, y, mod); };
   void OnMouseOut() override { GetUI()->SetMouseCursor(); IControl::OnMouseOut(); }
+  void SetText(const IText&) override;
+
+  void SetMOColor(const IColor&);
+  void SetCLColor(const IColor&);
 
 protected:
   WDL_String mURLStr;


### PR DESCRIPTION
This is just a small extension of `IURLControl` which did not provide means to update colors (useful for theming). I used the same logic as the constructor where the original color is set implicitly through the `IText` argument and the other colors are set explicitly.

I would usually also add a `SetDirty` but I guess this is the responsibility of the caller?