### PR TITLE
Enabled self managed host bypass

### DIFF
--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -1732,7 +1732,7 @@ OSStatus IPlugAU::RenderProc(void* pPlug, AudioUnitRenderActionFlags* pFlags, co
       _this->SetChannelConnections(ERoute::kOutput, nConnected, totalNumChans - nConnected, false); // this will disconnect the channels that are on the unconnected buses
     }
 
-    if (_this->GetBypassed())
+    if (_this->GetBypassed() && !_this->GetWillHandleBypass())
     {
       _this->PassThroughBuffers((AudioSampleType) 0, nFrames);
     }

--- a/IPlug/IPlugProcessor.h
+++ b/IPlug/IPlugProcessor.h
@@ -112,6 +112,9 @@ public:
   /** @return \c true if the plugin is currently bypassed */
   bool GetBypassed() const { return mBypassed; }
 
+  /** @return \c true if ProcessBlock should be called even if the plugin is currently bypassed*/
+  bool GetWillHandleBypass() const { return mWillHandleBypass; }
+
   /** @return \c true if the plugin is currently rendering off-line */
   bool GetRenderingOffline() const { return mRenderingOffline; };
 
@@ -240,6 +243,10 @@ public:
    * @param tailSize the new tailsize in samples*/
   void SetTailSize(int tailSize) { mTailSize = tailSize; }
 
+  /** Call this method if your ProcessBlock() method will handle bypass (defined by GetBypassed()) by itself.
+   * @param handle if true, ProcessBlock() respects GetBypassed() */
+  void SetWillHandleBypass(bool handle) { mWillHandleBypass = handle; }
+
   /** A static method to parse the config.h channel I/O string.
    * @param IOStr Space separated cstring list of I/O configurations for this plug-in in the format ninchans-noutchans.
    * A hypen character \c(-) deliminates input-output. Supports multiple buses, which are indicated using a period \c(.) character.
@@ -293,6 +300,8 @@ private:
   int mTailSize = 0;
   /** \c true if the plug-in is bypassed */
   bool mBypassed = false;
+  /** \c true if the plug-in should call ProcessBlock even if bypassed */
+  bool mWillHandleBypass = false;
   /** \c true if the plug-in is rendering off-line*/
   bool mRenderingOffline = false;
   /** A list of IOConfig structures populated by ParseChannelIOStr in the IPlugProcessor constructor */

--- a/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
+++ b/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
@@ -398,7 +398,7 @@ void IPlugVST3ProcessorBase::ProcessAudio(ProcessData& data, ProcessSetup& setup
       chanOffset += busChannels;
     }
     
-    if (GetBypassed())
+    if (GetBypassed() && !GetWillHandleBypass())
     {
       if (sampleSize == kSample32)
         PassThroughBuffers(0.f, data.numSamples); // single precision


### PR DESCRIPTION
iPlug2 manages the host bypass (VST3 and AUv2) by itself, preventing ProcessBlock() to be called.

Sometime one wants to mange the bypass by oneself, e.g. to support a click free bypass or to update some GUI elements like a spectroscope.

Therefore we should enable the iPlug2 user to specify that ProcessBlock() should be called, regardless of the GetPypassed() state. If enabled ProcessBlock() has to call GetBypassed() and provide some code to bypass the processing.

Resolves #714