### PR TITLE
In VST3 when the UI changes parameter values it should align the  visible value with the iPlug value

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -227,6 +227,9 @@ bool IPlugVST3::EditorResize(int viewWidth, int viewHeight)
 
 void IPlugVST3::DirtyParametersFromUI()
 {
+  for (int i = 0; i < NParams(); i++)
+    IPlugVST3ControllerBase::SetVST3ParamNormalized(i, GetParam(i)->GetNormalized());
+  
   startGroupEdit();
   IPlugAPIBase::DirtyParametersFromUI();
   finishGroupEdit();

--- a/IPlug/VST3/IPlugVST3_Controller.cpp
+++ b/IPlug/VST3/IPlugVST3_Controller.cpp
@@ -158,6 +158,9 @@ bool IPlugVST3Controller::EditorResize(int viewWidth, int viewHeight)
 
 void IPlugVST3Controller::DirtyParametersFromUI()
 {
+  for (int i = 0; i < NParams(); i++)
+    IPlugVST3ControllerBase::SetVST3ParamNormalized(i, GetParam(i)->GetNormalized());
+
   startGroupEdit();
   IPlugAPIBase::DirtyParametersFromUI();
   finishGroupEdit();


### PR DESCRIPTION
There isn't an issue for this, but at the moment calling DirtyParametersFromUI() (e.g. for a custom preset manager) doesn't align the state with the state that the host can see. This can cause issues with the host setting parameter values incorrectly (this happens in Cubase).