### PR TITLE
Mouseup resize issue fix

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1039,7 +1039,7 @@ void IGraphics::OnMouseUp(const std::vector<IMouseInfo>& points)
             GetDelegate()->EndInformHostOfParamChangeFromUI(pCapturedControl->GetParamIdx(v));
         }
         
-        mCapturedMap.erase(itr);
+        mCapturedMap.erase(mod.touchID);
       }
     }
   }


### PR DESCRIPTION
This PR address #684 by safely deleting the control during mouseup even if it's been deleted from the capture map by a resize operation.

I have tested it for resizing, and also that it correctly deletes the control, so it should be fairly trivial to pull in but a second tester on this would be helpful as this is obviously a fairly frequent codepath for UI work.