### PR TITLE
Graphics/parameter stepping

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -833,20 +833,7 @@ void IKnobControlBase::OnMouseDrag(float x, float y, float dX, float dY, const I
   const IParam* pParam = GetParam();
   
   if (pParam && pParam->GetStepped() && pParam->GetStep() > 0)
-  {
-    const double range = pParam->GetRange();
-    
-    if (range > 0.)
-    {
-      double l, h;
-      pParam->GetBounds(l, h);
-
-      v = l + mMouseDragValue * range;
-      v = v - std::fmod(v, pParam->GetStep());
-      v -= l;
-      v /= range;
-    }
-  }
+    v = pParam->ConstrainNormalized(mMouseDragValue);
 
   SetValue(v);
   SetDirty();
@@ -861,19 +848,13 @@ void IKnobControlBase::OnMouseWheel(float x, float y, const IMouseMod& mod, floa
   
   if (pParam && pParam->GetStepped() && pParam->GetStep() > 0)
   {
-    const double range = pParam->GetRange();
-
-    if (range > 0. && d != 0.f)
+    if (d != 0.f)
     {
-      double l, h;
-      pParam->GetBounds(l,h);
-      v = l + GetValue() * range;
       const double step = pParam->GetStep();
+
+      v = pParam->FromNormalized(v);
       v += d > 0 ? step : -step;
-      v = Clip(v, l, h);
-      v = v - std::fmod(v, step);
-      v -= l;
-      v /= range;
+      v = pParam->ToNormalized(v);
     }
   }
 
@@ -967,20 +948,7 @@ void ISliderControlBase::OnMouseDrag(float x, float y, float dX, float dY, const
   double v = mMouseDragValue;
   
   if (pParam && pParam->GetStepped() && pParam->GetStep() > 0)
-  {
-    const double range = pParam->GetRange();
-    
-    if (range > 0.)
-    {
-      double l, h;
-      pParam->GetBounds(l,h);
-
-      v = l + mMouseDragValue * range;
-      v = v - std::fmod(v, pParam->GetStep());
-      v -= l;
-      v /= range;
-    }
-  }
+    v = pParam->ConstrainNormalized(mMouseDragValue);
 
   SetValue(v);
   SetDirty(true);
@@ -995,19 +963,13 @@ void ISliderControlBase::OnMouseWheel(float x, float y, const IMouseMod& mod, fl
   
   if (pParam && pParam->GetStepped() && pParam->GetStep() > 0)
   {
-    const double range = pParam->GetRange();
-
-    if (range > 0. && d != 0.f)
+    if (d != 0.f)
     {
-      double l, h;
-      pParam->GetBounds(l,h);
-      v = l + GetValue() * range;
       const double step = pParam->GetStep();
+          
+      v = pParam->FromNormalized(v);
       v += d > 0 ? step : -step;
-      v = Clip(v, l, h);
-      v = v - std::fmod(v, step);
-      v -= l;
-      v /= range;
+      v = pParam->ToNormalized(v);
     }
   }
 

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -264,11 +264,22 @@ public:
    * @return double The real value */
   double StringToValue(const char* str) const;
 
-  /** Constrains the input value between \c mMin and \c mMax
+  /** Constrains the input value between \c mMin and \c mMax and apply stepping if relevant
    * @param value The input value to constrain
    * @return double The resulting constrained value */
-  inline double Constrain(double value) const { return Clip((mFlags & kFlagStepped ? round(value / mStep) * mStep : value), mMin, mMax); }
+  inline double Constrain(double value) const
+  {
+    return Clip((mFlags & kFlagStepped ? std::round(value / mStep) * mStep : value), mMin, mMax);
+  }
 
+  /** Constrains a normalised input value similarly to Constrain()
+   * @param value The normalised input value to constrain
+   * @return double The resulting constrained value */
+  inline double ConstrainNormalized(double normalizedValue) const
+  {
+    return ToNormalized(mShape->NormalizedToValue(normalizedValue, *this));
+  }
+  
   /** Convert a real value to normalized value for this parameter
    * @param nonNormalizedValue The real input value
    * @return The corresponding normalized value, for this parameter */


### PR DESCRIPTION
This PR adds a convenience method to IParam in order to allow normalised value to be constrained using stepping (for use in IControls).

It then also modifies OnMouseWheel() and OnMouseDrag() for sliders and knobs to correctly perform stepping using the parameter code - this reduces code, is simpler to read and fixes errors raised in two issues.

This should fix #690 and #712. It also replaces #713, which doesn't deal with parameter shapes correctly (the original code didn't either, so that is no fault of what was a useful PR to point at how to improve this).

I have tested this with drag and wheel for linear and non-linear parameters (knob and slider) and it appears to function correctly. A second look over it would be welcome.

