### PR TITLE
Allow paths to RPP files to contain spaces

### DIFF
--- a/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugChunks/projects/IPlugChunks-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugCocoaUI/projects/IPlugCocoaUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -57,7 +57,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugControls/projects/IPlugControls-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -57,7 +57,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugConvoEngine/projects/IPlugConvoEngine-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -55,7 +55,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugDrumSynth/projects/IPlugDrumSynth-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugEffect/projects/IPlugEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -57,7 +57,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugFaustDSP/projects/IPlugFaustDSP-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugInstrument/projects/IPlugInstrument-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -57,7 +57,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugMidiEffect/projects/IPlugMidiEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugResponsiveUI/projects/IPlugResponsiveUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugSOUL/projects/IPlugSOUL-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugSideChain/projects/IPlugSideChain-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugSurroundEffect/projects/IPlugSurroundEffect-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -57,7 +57,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -58,7 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugSwiftUI/projects/IPlugSwiftUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -55,7 +55,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Tests/IGraphicsStressTest/projects/IGraphicsStressTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Tests/IGraphicsTest/projects/IGraphicsTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
+++ b/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST2.xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
+++ b/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3 (Distributed).xcscheme
@@ -60,7 +60,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
+++ b/Tests/MetaParamTest/projects/MetaParamTest-macOS.xcodeproj/xcshareddata/xcschemes/macOS-VST3.xcscheme
@@ -59,7 +59,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "$(SRCROOT)/../$(PRODUCT_NAME).RPP"
+            argument = "&quot;$(SRCROOT)/../$(PRODUCT_NAME).RPP&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
If iPlug2 is checked out in a directory whose path contains spaces, the Reaper projects don't open unless you quote the paths in the Xcode workspaces (see changes, same single line change applied to 48 files).