### PR TITLE
Workaround for window resize loop bug per Justin Frankel @ Cockos, In…

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -242,9 +242,12 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   }
 
   // TODO: move this... listen to the right messages in windows for screen resolution changes, etc.
-  float scale = GetScaleForHWND(mPlugWnd);
-  if (scale != GetScreenScale())
-    SetScreenScale(scale);
+  if (!GetCapture()) // workaround Windows issues with window sizing during mouse move
+  {
+    float scale = GetScaleForHWND(mPlugWnd);
+    if (scale != GetScreenScale())
+      SetScreenScale(scale);
+  }
 
   // TODO: this is far too aggressive for slow drawing animations and data changing.  We need to
   // gate the rate of updates to a certain percentage of the wall clock time.


### PR DESCRIPTION
…c. - when resizing on multimonitor Windows, only resize when mouse released of window drag.

Fixes #734 

Here are some instructions for a good PR

* [create an issue](https://github.com/iPlug2/iPlug2/issues/new/choose) first to outline the problem, to reference in this PR - Done
* clearly describe the problem that the PR fixes - works around multiple monitor resizing loop described in #734 by only resizing once when mouse is released
* each PR should address one thing. It can include multiple commits, but you should try and tidy up work done into logical units if possible. - Done
* pay attention to [iplug2 coding style](https://github.com/iPlug2/iPlug2/blob/master/Documentation/codingstyle.md)
* If it applies to an option e.g. IGRAPHICS_NANOVG or VST3 plug-ins, try to provide fixes for all options (e.g. all graphics backends or all plug-in formats)

If you follow these rules, it is more likely we will consider your PR, but please don't be upset if we decide we don't want to merge your work.

thanks, we like PRs!

oli & alex