### PR TITLE
Address -Wreorder warnings

### DIFF
--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -50,9 +50,9 @@ public:
    * @param strokeColor The stroke color of the bubble */
   IBubbleControl(const IText& text = DEFAULT_TEXT.WithAlign(EAlign::Center), const IColor& fillColor = COLOR_WHITE, const IColor& strokeColor = COLOR_BLACK, float roundness = 5.f)
   : IControl(IRECT())
+  , mRoundness(roundness)
   , mFillColor(fillColor)
   , mStrokeColor(strokeColor)
-  , mRoundness(roundness)
   {
     mText = text;
     mHide = true;

--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -158,16 +158,16 @@ void IVSwitchControl::OnInit()
 
 IVToggleControl::IVToggleControl(const IRECT& bounds, int paramIdx, const char* label, const IVStyle& style, const char* offText, const char* onText)
 : IVSwitchControl(bounds, paramIdx, label, style, true)
-, mOnText(onText)
 , mOffText(offText)
+, mOnText(onText)
 {
   //TODO: assert boolean?
 }
 
 IVToggleControl::IVToggleControl(const IRECT& bounds, IActionFunction aF, const char* label, const IVStyle& style, const char* offText, const char* onText, bool initialState)
 : IVSwitchControl(bounds, aF, label, style, 2, true)
-, mOnText(onText)
 , mOffText(offText)
+, mOnText(onText)
 {
   SetValue((double) initialState);
 }
@@ -1204,9 +1204,9 @@ IVColorSwatchControl::IVColorSwatchControl(const IRECT& bounds, const char* labe
   const std::initializer_list<EVColor>& colorIDs, const std::initializer_list<const char*>& labelsForIDs)
 : IControl(bounds)
 , IVectorBase(style)
+, mColorChosenFunc(func)
 , mLayout(layout)
 , mColorIdForCells(colorIDs)
-, mColorChosenFunc(func)
 {
   assert(colorIDs.size() == labelsForIDs.size());
   

--- a/IGraphics/Controls/ICornerResizerControl.h
+++ b/IGraphics/Controls/ICornerResizerControl.h
@@ -28,8 +28,8 @@ class ICornerResizerControl : public IControl
 public:
   ICornerResizerControl(const IRECT& graphicsBounds, float size, const IColor& color = COLOR_TRANSLUCENT, const IColor& mouseOverColour = COLOR_BLACK, const IColor& dragColor = COLOR_BLACK)
   : IControl(graphicsBounds.GetFromBRHC(size, size).GetPadded(-1))
-  , mInitialGraphicsBounds(graphicsBounds)
   , mSize(size)
+  , mInitialGraphicsBounds(graphicsBounds)
   , mColor(color)
   , mMouseOverColor(mouseOverColour)
   , mDragColor(dragColor)

--- a/IGraphics/Controls/IVDisplayControl.h
+++ b/IGraphics/Controls/IVDisplayControl.h
@@ -32,11 +32,11 @@ public:
   IVDisplayControl(const IRECT& bounds, const char* label = "", const IVStyle& style = DEFAULT_STYLE, EDirection dir = EDirection::Horizontal, float lo = 0., float hi = 1.f, float defaultVal = 0., uint32_t bufferSize = 100, float strokeThickness = 2.f)
   : IControl(bounds)
   , IVectorBase(style)
+  , mBuffer(bufferSize, defaultVal)
   , mLoValue(lo)
   , mHiValue(hi)
-  , mBuffer(bufferSize, defaultVal)
-  , mDirection(dir)
   , mStrokeThickness(strokeThickness)
+  , mDirection(dir)
   {
     assert(bufferSize > 0 && bufferSize < MAX_BUFFER_SIZE);
 

--- a/IGraphics/Controls/IVKeyboardControl.h
+++ b/IGraphics/Controls/IVKeyboardControl.h
@@ -741,8 +741,8 @@ public:
    * @param cc A Midi CC to link, defaults to kNoCC which is interpreted as pitch bend */
   IWheelControl(const IRECT& bounds, IMidiMsg::EControlChangeMsg cc = IMidiMsg::EControlChangeMsg::kNoCC, int initBendRange = 12)
   : ISliderControlBase(bounds, kNoParameter, EDirection::Vertical, DEFAULT_GEARING, 40.f)
-  , mCC(cc)
   , mPitchBendRange(initBendRange)
+  , mCC(cc)
   {
     mMenu.AddItem("1 semitone");
     mMenu.AddItem("2 semitones");

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -492,9 +492,9 @@ void ITextControl::SetBoundsBasedOnStr()
 IURLControl::IURLControl(const IRECT& bounds, const char* str, const char* urlStr, const IText& text, const IColor& BGColor, const IColor& MOColor, const IColor& CLColor)
 : ITextControl(bounds, str, text, BGColor)
 , mURLStr(urlStr)
+, mOriginalColor(text.mFGColor)
 , mMOColor(MOColor)
 , mCLColor(CLColor)
-, mOriginalColor(text.mFGColor)
 {
   mIgnoreMouse = false;
   IControl::mText = text;
@@ -555,8 +555,8 @@ void IURLControl::OnMouseDown(float x, float y, const IMouseMod& mod)
 
 ITextToggleControl::ITextToggleControl(const IRECT& bounds, int paramIdx, const char* offText, const char* onText, const IText& text, const IColor& bgColor)
 : ITextControl(bounds, offText, text, bgColor)
-, mOnText(onText)
 , mOffText(offText)
+, mOnText(onText)
 {
   SetParamIdx(paramIdx);
   //TODO: assert boolean?
@@ -566,8 +566,8 @@ ITextToggleControl::ITextToggleControl(const IRECT& bounds, int paramIdx, const 
 
 ITextToggleControl::ITextToggleControl(const IRECT& bounds, IActionFunction aF, const char* offText, const char* onText, const IText& text, const IColor& bgColor)
 : ITextControl(bounds, offText, text, bgColor)
-, mOnText(onText)
 , mOffText(offText)
+, mOnText(onText)
 {
   SetActionFunction(aF);
   mDblAsSingleClick = true;

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -1252,8 +1252,8 @@ public:
   IVTrackControlBase(const IRECT& bounds, const char* label, const IVStyle& style, int maxNTracks = 1, int nSteps = 0, EDirection dir = EDirection::Horizontal, std::initializer_list<const char*> trackNames = {})
   : IControl(bounds)
   , IVectorBase(style)
-  , mNSteps(nSteps)
   , mDirection(dir)
+  , mNSteps(nSteps)
   {
     SetNVals(maxNTracks);
     mTrackBounds.Resize(maxNTracks);
@@ -1279,8 +1279,8 @@ public:
   IVTrackControlBase(const IRECT& bounds, const char* label, const IVStyle& style, int lowParamidx, int maxNTracks = 1, int nSteps = 0, EDirection dir = EDirection::Horizontal, std::initializer_list<const char*> trackNames = {})
   : IControl(bounds)
   , IVectorBase(style)
-  , mNSteps(nSteps)
   , mDirection(dir)
+  , mNSteps(nSteps)
   {
     SetNVals(maxNTracks);
     mTrackBounds.Resize(maxNTracks);
@@ -1306,8 +1306,8 @@ public:
   IVTrackControlBase(const IRECT& bounds, const char* label, const IVStyle& style, const std::initializer_list<int>& params, int nSteps = 0, EDirection dir = EDirection::Horizontal, std::initializer_list<const char*> trackNames = {})
   : IControl(bounds)
   , IVectorBase(style)
-  , mNSteps(nSteps)
   , mDirection(dir)
+  , mNSteps(nSteps)
   {
     int maxNTracks = static_cast<int>(params.size());
     SetNVals(maxNTracks);
@@ -1907,8 +1907,8 @@ class ISVGControl : public IControl
 public:
   ISVGControl(const IRECT& bounds, const ISVG& svg, bool useLayer = false)
   : IControl(bounds)
-  , mSVG(svg)
   , mUseLayer(useLayer)
+  , mSVG(svg)
   {}
 
   virtual ~ISVGControl() {}

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -44,13 +44,13 @@ static StaticStorage<APIBitmap> sBitmapCache;
 static StaticStorage<SVGHolder> sSVGCache;
 
 IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
-: mDelegate(&dlg)
-, mWidth(w)
+: mWidth(w)
 , mHeight(h)
+, mFPS(fps)
 , mDrawScale(scale)
 , mMinScale(scale / 2)
 , mMaxScale(scale * 2)
-, mFPS(fps)
+, mDelegate(&dlg)
 {
   StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
   bitmapStorage.Retain();

--- a/IGraphics/IGraphicsLiveEdit.h
+++ b/IGraphics/IGraphicsLiveEdit.h
@@ -33,8 +33,8 @@ class IGraphicsLiveEdit : public IControl
 public:
   IGraphicsLiveEdit(bool mouseOversEnabled)
   : IControl(IRECT())
+  , mMouseOversEnabled(mouseOversEnabled)
   , mGridSize(10)
-  , mMouseOversEnabled(mouseOversEnabled) 
   {
     mTargetRECT = mRECT;
   }

--- a/IGraphics/IGraphicsPopupMenu.h
+++ b/IGraphics/IGraphicsPopupMenu.h
@@ -61,8 +61,8 @@ public:
     }
     
     Item (const char* str, IPopupMenu* pSubMenu)
-    : mFlags(kNoFlags)
-    , mSubmenu(pSubMenu)
+    : mSubmenu(pSubMenu)
+    , mFlags(kNoFlags)
     {
       SetText(str);
     }

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -580,8 +580,8 @@ struct IFillOptions
   bool mPreserve { false };
 
   IFillOptions(bool preserve = false, EFillRule fillRule = EFillRule::Winding)
-  : mPreserve(preserve)
-  , mFillRule(fillRule)
+  : mFillRule(fillRule)
+  , mPreserve(preserve)
   {
   }
    
@@ -596,8 +596,8 @@ struct IStrokeOptions
   public:
     /** Create a new empty DashOptions */
     DashOptions()
-    : mCount(0)
-    , mOffset(0)
+    : mOffset(0)
+    , mCount(0)
     {}
 
     /** Create a new DashOptions
@@ -681,11 +681,11 @@ struct IText
         const IColor& TEFGColor = DEFAULT_TEXTENTRY_FGCOLOR)
     : mSize(size)
     , mFGColor(color)
-    , mAlign(align)
-    , mVAlign(valign)
-    , mAngle(angle)
     , mTextEntryBGColor(TEBGColor)
     , mTextEntryFGColor(TEFGColor)
+    , mAngle(angle)
+    , mAlign(align)
+    , mVAlign(valign)
   {
     strcpy(mFont, (fontID ? fontID : DEFAULT_FONT));
   }
@@ -770,7 +770,7 @@ struct IRECT
    * @param r Right
    * @param b Bottom */
   IRECT(float l, float t, float r, float b)
-  : L(l), R(r), T(t), B(b)
+  : L(l), T(t), R(r), B(b)
   {}
   
   /** Construct a new IRECT at the given position and with the same size as the bitmap
@@ -2524,12 +2524,9 @@ struct IVStyle
           float shadowOffset = DEFAULT_SHADOW_OFFSET,
           float widgetFrac = DEFAULT_WIDGET_FRAC,
           float angle = DEFAULT_WIDGET_ANGLE)
-  : showLabel(showLabel)
+  : hideCursor(hideCursor)
+  , showLabel(showLabel)
   , showValue(showValue)
-  , colorSpec(colors)
-  , labelText(labelText)
-  , valueText(valueText)
-  , hideCursor(hideCursor)
   , drawFrame(drawFrame)
   , drawShadows(drawShadows)
   , emboss(emboss)
@@ -2538,6 +2535,9 @@ struct IVStyle
   , shadowOffset(shadowOffset)
   , widgetFrac(widgetFrac)
   , angle(angle)
+  , colorSpec(colors)
+  , labelText(labelText)
+  , valueText(valueText)
   {
   }
   

--- a/IPlug/IPlugMidi.h
+++ b/IPlug/IPlugMidi.h
@@ -546,8 +546,8 @@ struct ISysEx
    * @param size Size of the data in bytes */
   ISysEx(int offset = 0, const uint8_t* pData = nullptr, int size = 0)
   : mOffset(offset)
-  , mData(pData)
   , mSize(size)
+  , mData(pData)
   {}
   
   /** Clear the data pointer and size (does not modify the external data!)  */

--- a/IPlug/IPlugProcessor.cpp
+++ b/IPlug/IPlugProcessor.cpp
@@ -22,11 +22,11 @@
 using namespace iplug;
 
 IPlugProcessor::IPlugProcessor(const Config& config, EAPI plugAPI)
-: mLatency(config.latency)
-, mPlugType((EIPlugPluginType) config.plugType)
+: mPlugType((EIPlugPluginType) config.plugType)
 , mDoesMIDIIn(config.plugDoesMidiIn)
 , mDoesMIDIOut(config.plugDoesMidiOut)
 , mDoesMPE(config.plugDoesMPE)
+, mLatency(config.latency)
 {
   int totalNInBuses, totalNOutBuses;
   int totalNInChans, totalNOutChans;


### PR DESCRIPTION
Hey,

Here's the first PR suppressing some of the compiler warnings enabled by `-Wall`.

I'm only compiling VST3 at the moment, so I can't guarantee I've covered all instances, but it's a start.

`-Wreorder` is a pretty minor complaint from the compiler: it prefers that the member initialiser lists match the initialisation order (feels more like a pedantic style issue if I'm being honest!).

I'm hoping at the end of this it'll also be possible to enable `-Wall` in the Xcode projects, if that's something considered desirable.

Thanks,
Ciarán :)