### PR TITLE
set mMouseOutDuringDrag to false when drag-entering

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -1218,6 +1218,8 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 {
   NSPasteboard *pPasteBoard = [sender draggingPasteboard];
 
+  mMouseOutDuringDrag = false;
+
   if ([[pPasteBoard types] containsObject:NSFilenamesPboardType])
     return NSDragOperationGeneric;
   else


### PR DESCRIPTION
Fixes #757 

The variable is already set to false within `mouseEntered`, but it should also (instead?) be set to false within `draggingEntered`.