### PR TITLE
Fix IPlugQueue::Peek()

### DIFF
--- a/IPlug/IPlugQueue.h
+++ b/IPlug/IPlugQueue.h
@@ -20,6 +20,8 @@
 
 #include "heapbuf.h"
 
+#include "IPlugPlatform.h"
+
 BEGIN_IPLUG_NAMESPACE
 
 /** A lock-free SPSC queue used to transfer data between threads
@@ -95,7 +97,7 @@ public:
   const T& Peek()
   {
     const auto currentReadIndex = mReadIndex.load(std::memory_order_relaxed);
-    return mData[currentReadIndex];
+    return mData.Get()[currentReadIndex];
   }
 
   /** \todo 


### PR DESCRIPTION
Hey,

Just a small fix: `Peek()` was missing a call to `Get()` before indexing, leading to `error: type 'WDL_TypedBuf<T>' does not provide a subscript operator`.

I also added an include for `IPlugPlatform.h` to bring the namespace macros into scope for include-order independence.

Thanks,
Ciarán :)