### PR TITLE
Add support for fractional screen scaling with layers

### DIFF
--- a/IGraphics/Drawing/IGraphicsCanvas.cpp
+++ b/IGraphics/Drawing/IGraphicsCanvas.cpp
@@ -387,7 +387,7 @@ APIBitmap* IGraphicsCanvas::LoadAPIBitmap(const char* name, const void* pData, i
   return new Bitmap(canvas, name, scale);
 }
 
-APIBitmap* IGraphicsCanvas::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
+APIBitmap* IGraphicsCanvas::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable)
 {
   return new Bitmap(width, height, scale, drawScale);
 }

--- a/IGraphics/Drawing/IGraphicsCanvas.h
+++ b/IGraphics/Drawing/IGraphicsCanvas.h
@@ -61,7 +61,7 @@ public:
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
   APIBitmap* LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -76,8 +76,8 @@ class IGraphicsNanoVG::Bitmap : public APIBitmap
 {
 public:
   Bitmap(NVGcontext* pContext, const char* path, double sourceScale, int nvgImageID, bool shared = false);
-  Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, int scale, float drawScale);
-  Bitmap(NVGcontext* pContext, int width, int height, const uint8_t* pData, int scale, float drawScale);
+  Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale);
+  Bitmap(NVGcontext* pContext, int width, int height, const uint8_t* pData, float scale, float drawScale);
   virtual ~Bitmap();
   NVGframebuffer* GetFBO() const { return mFBO; }
 private:
@@ -99,7 +99,7 @@ IGraphicsNanoVG::Bitmap::Bitmap(NVGcontext* pContext, const char* path, double s
   SetBitmap(nvgImageID, w, h, sourceScale, 1.f);
 }
 
-IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, int scale, float drawScale)
+IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale)
 {
   mGraphics = pGraphics;
   mVG = pContext;
@@ -120,7 +120,7 @@ IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext
   SetBitmap(mFBO->image, width, height, scale, drawScale);
 }
 
-IGraphicsNanoVG::Bitmap::Bitmap(NVGcontext* pContext, int width, int height, const uint8_t* pData, int scale, float drawScale)
+IGraphicsNanoVG::Bitmap::Bitmap(NVGcontext* pContext, int width, int height, const uint8_t* pData, float scale, float drawScale)
 {
   int idx = nvgCreateImageRGBA(pContext, width, height, 0, pData);
   mVG = pContext;
@@ -369,7 +369,7 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* name, const void* pData, i
   return pBitmap;
 }
 
-APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
+APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable)
 {
   if (mInDraw)
   {

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -126,7 +126,7 @@ public:
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
   APIBitmap* LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -50,7 +50,7 @@ extern std::map<std::string, MTLTexturePtr> gTextureMap;
 class IGraphicsSkia::Bitmap : public APIBitmap
 {
 public:
-  Bitmap(sk_sp<SkSurface> surface, int width, int height, int scale, float drawScale);
+  Bitmap(sk_sp<SkSurface> surface, int width, int height, float scale, float drawScale);
   Bitmap(const char* path, double sourceScale);
   Bitmap(const void* pData, int size, double sourceScale);
   Bitmap(sk_sp<SkImage>, double sourceScale);
@@ -59,7 +59,7 @@ private:
   SkiaDrawable mDrawable;
 };
   
-IGraphicsSkia::Bitmap::Bitmap(sk_sp<SkSurface> surface, int width, int height, int scale, float drawScale)
+IGraphicsSkia::Bitmap::Bitmap(sk_sp<SkSurface> surface, int width, int height, float scale, float drawScale)
 {
   mDrawable.mSurface = surface;
   mDrawable.mIsSurface = true;
@@ -899,7 +899,7 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
   mCanvas->setMatrix(mFinalMatrix);
 }
 
-APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable)
+APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable)
 {
   sk_sp<SkSurface> surface;
   

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -116,7 +116,7 @@ public:
   int AlphaChannel() const override { return 3; }
   bool FlippedBitmap() const override { return false; }
 
-  APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) override;
 
   void GetLayerBitmapData(const ILayerPtr& layer, RawBitmapData& data) override;
   void ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, const IShadow& shadow) override;

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1958,7 +1958,7 @@ void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable)
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetRoundedScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
+  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
 }
 
 void IGraphics::ResumeLayer(ILayerPtr& layer)
@@ -2016,7 +2016,7 @@ bool IGraphics::CheckLayer(const ILayerPtr& layer)
     layer->Invalidate();
   }
 
-  return pBitmap && !layer->mInvalid && pBitmap->GetDrawScale() == GetDrawScale() && pBitmap->GetScale() == GetRoundedScreenScale();
+  return pBitmap && !layer->mInvalid && pBitmap->GetDrawScale() == GetDrawScale() && pBitmap->GetScale() == GetScreenScale();
 }
 
 void IGraphics::DrawLayer(const ILayerPtr& layer, const IBlend* pBlend)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1650,7 +1650,7 @@ protected:
    * @param drawScale \todo
    * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances
    * @return APIBitmap* The new API Bitmap */
-  virtual APIBitmap* CreateAPIBitmap(int width, int height, int scale, double drawScale, bool cacheable = false) = 0;
+  virtual APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) = 0;
 
   /** Drawing API method to load a font from a PlatformFontPtr, called internally
    * @param fontID A CString that will be used to reference the font

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -94,7 +94,7 @@ public:
   * @param h The height of the bitmap
   * @param scale An integer representing the scale of this bitmap in relation to a 1:1 pixel screen, e.g. 2 for an @2x bitmap
   * @param drawScale The draw scale at which this API bitmap was created (used in the context of layers) */
-  APIBitmap(BitmapData pBitmap, int w, int h, int scale, float drawScale)
+  APIBitmap(BitmapData pBitmap, int w, int h, float scale, float drawScale)
   : mBitmap(pBitmap)
   , mWidth(w)
   , mHeight(h)
@@ -119,9 +119,9 @@ public:
    * @param pBitmap pointer or integer index (NanoVG) to the image data
    * @param w The width of the bitmap
    * @param h The height of the bitmap
-   * @param scale An integer representing the scale of this bitmap in relation to a 1:1 pixel screen, e.g. 2 for an @2x bitmap
+   * @param scale The scale of this bitmap in relation to a 1:1 pixel screen, e.g. 2 for an @2x bitmap
    * @param drawScale The draw scale at which this API bitmap was created (used in the context of layers) */
-  void SetBitmap(BitmapData pBitmap, int w, int h, int scale, float drawScale)
+  void SetBitmap(BitmapData pBitmap, int w, int h, float scale, float drawScale)
   {
     mBitmap = pBitmap;
     mWidth = w;
@@ -140,7 +140,7 @@ public:
   int GetHeight() const { return mHeight; }
 
   /** @return the scale of the bitmap */
-  int GetScale() const { return mScale; }
+  float GetScale() const { return mScale; }
   
   /** @return the draw scale of the bitmap */
   float GetDrawScale() const { return mDrawScale; }
@@ -149,7 +149,7 @@ private:
   BitmapData mBitmap; // for most drawing APIs BitmapData is a pointer. For Nanovg it is an integer index
   int mWidth;
   int mHeight;
-  int mScale;
+  float mScale;
   float mDrawScale;
 };
 

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -91,8 +91,8 @@ public:
    @param name Resource name for the bitmap */
   IBitmap(APIBitmap* pAPIBitmap, int n, bool framesAreHorizontal, const char* name = "")
   : mAPIBitmap(pAPIBitmap)
-  , mW(pAPIBitmap->GetWidth() / pAPIBitmap->GetScale())
-  , mH(pAPIBitmap->GetHeight() / pAPIBitmap->GetScale())
+  , mW(static_cast<int>(pAPIBitmap->GetWidth() / pAPIBitmap->GetScale()))
+  , mH(static_cast<int>(pAPIBitmap->GetHeight() / pAPIBitmap->GetScale()))
   , mN(n)
   , mFramesAreHorizontal(framesAreHorizontal)
   , mResourceName(name, static_cast<int>(strlen(name)))
@@ -124,7 +124,7 @@ public:
   int N() const { return mN; }
   
   /** @return the scale of the bitmap */
-  int GetScale() const { return mAPIBitmap->GetScale(); }
+  float GetScale() const { return mAPIBitmap->GetScale(); }
 
   /** @return the draw scale of the bitmap */
   float GetDrawScale() const { return mAPIBitmap->GetDrawScale(); }


### PR DESCRIPTION
This PR fixes issue #716, allowing APIBitmaps to have float scaling and therefore making IGraphics Layers work on Windows when the screen scale is e.g. 150%. Thanks to Hermann Vogt for the original work.
