### PR TITLE
Enable CALayer::drawsAsynchronously on macOS

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -388,6 +388,7 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   mMouseOutDuringDrag = false;
 
   self.wantsLayer = YES;
+  self.layer.drawsAsynchronously = YES;
   self.layer.opaque = YES;
   self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
   


### PR DESCRIPTION
This speeds up drawing with SKIACPU mode significantly. Should work on 10.8 +, improve #766 

https://developer.apple.com/documentation/quartzcore/calayer/1410974-drawsasynchronously

https://1014.org/?article=802

https://www.kvraudio.com/forum/viewtopic.php?t=521827

https://forum.juce.com/t/slow-frame-rates-on-2017-macs/35813/22