### PR TITLE
Add basic legato support to MidiSynth and VoiceAllocator

### DIFF
--- a/IPlug/Extras/Synth/MidiSynth.h
+++ b/IPlug/Extras/Synth/MidiSynth.h
@@ -154,6 +154,8 @@ public:
    * @return \c true if the synth is silent */
   bool ProcessBlock(sample** inputs, sample** outputs, int nInputs, int nOutputs, int nFrames);
 
+  void SetLegato(bool isLegatoEnabled) { mVoiceAllocator.SetLegato(isLegatoEnabled); }
+
 private:
 
   // maintain the state for one MIDI channel including RPN receipt state and pitch bend range.

--- a/IPlug/Extras/Synth/VoiceAllocator.cpp
+++ b/IPlug/Extras/Synth/VoiceAllocator.cpp
@@ -411,7 +411,7 @@ void VoiceAllocator::NoteOn(VoiceInputEvent e, int64_t sampleTime)
     case kPolyModeMono:
     {
       // TODO retrig / legato
-      bool retrig = false;
+      bool retrig = mHeldKeys.size() == 0 || mLegato == false;
 
       // trigger all voices in zone
       StartVoices(VoicesMatchingAddress({e.mAddress.mZone, kAllChannels, kAllKeys, 0}), channel, key, pitch, velocity, offset, sampleTime, retrig);
@@ -512,7 +512,7 @@ void VoiceAllocator::NoteOff(VoiceInputEvent e, int64_t sampleTime)
       // trigger the queued key for all voices in the zone at the minimum held velocity.
       // alternatively the release velocity of the note off could be used here.
       float pitch = mKeyToPitchFn(queuedKey + static_cast<int>(mPitchOffset));
-      bool retrig = false;
+      bool retrig = mLegato == false;
 
       StartVoices(VoicesMatchingAddress({e.mAddress.mZone, kAllChannels, kAllKeys, 0}), channel, queuedKey, pitch, mMinHeldVelocity, offset, sampleTime, retrig);
     }

--- a/IPlug/Extras/Synth/VoiceAllocator.h
+++ b/IPlug/Extras/Synth/VoiceAllocator.h
@@ -140,6 +140,7 @@ public:
   size_t GetNVoices() const {return mVoicePtrs.size();}
   SynthVoice* GetVoice(int voiceIndex) const {return mVoicePtrs[voiceIndex];}
   void SetPitchOffset(float offset) { mPitchOffset = offset; }
+  void SetLegato(bool isLegatoEnabled) { mLegato = isLegatoEnabled; }
 
 private:
   using VoiceBitsArray = std::bitset<UCHAR_MAX>;
@@ -186,6 +187,7 @@ private:
   bool mSustainPedalDown{false};
   float mModWheel{0.f};
   float mMinHeldVelocity{1.f};
+  bool mLegato{false};
 
 public:
   EPolyMode mPolyMode {kPolyModePoly};


### PR DESCRIPTION
Adding a basic legato support in MidiSynth.
The VoiceAllocator will not retrig voices when legato is enabled. This only affects kPolyModeMono.