### PR TITLE
Correct iPlugVST3::SetLatency()

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -243,13 +243,16 @@ void IPlugVST3::SendParameterValueFromUI(int paramIdx, double normalisedValue)
 
 void IPlugVST3::SetLatency(int latency)
 {
+  // N.B. set the latency even if the handler is not yet set
+  
+  IPlugProcessor::SetLatency(latency);
+
   if (componentHandler)
   {
     FUnknownPtr<IComponentHandler> handler(componentHandler);
 
     if (handler)
     {
-      IPlugProcessor::SetLatency(latency);
       handler->restartComponent(kLatencyChanged);
     }
   }


### PR DESCRIPTION
Addresses #772.

This moves the call to super such that it always occurs, regardless of whether the component handler exists. This means that calls to set the latency in the constructor of a plugin will not be ignored.