### PR TITLE
Fix memcpy not found error in some cases

### DIFF
--- a/WDL/heapbuf.h
+++ b/WDL/heapbuf.h
@@ -43,6 +43,7 @@
 #endif
 
 #include "wdltypes.h"
+#include <cstring>
 
 class WDL_HeapBuf
 {


### PR DESCRIPTION
This is a one-liner that fixes a problem I came across while playing around with trying to get iPlug to build via CMake. An error came up for me about "memcpy" not being declared, because it's a function in `<cstring>` which is never included. I was using a newer CXX standard (CXX20) so it might be related to this. I'm still new to CMake and C++ in general, so I'm not entirely sure what's going on here, but I felt this would be worth pointing out anyway.