### PR TITLE
Copy resources into .app bundle on macOS

### DIFF
--- a/Scripts/cmake/APP.cmake
+++ b/Scripts/cmake/APP.cmake
@@ -120,7 +120,7 @@ iplug_source_tree(iPlug2_APP)
 macro(iplug_configure_app target)
   iplug_target_add(${target} PUBLIC LINK iPlug2_APP)
 
-  set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}-app/resources")
+  set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.app/Contents/Resources")
 
   if (WIN32)
     set_target_properties(${target} PROPERTIES


### PR DESCRIPTION
Bundled application resources would previously be output into a separate folder called {PLUG_NAME}-app instead of the .app bundle, so the resulting .app bundle was not executable. I have changed the resource directory to {PLUG-NAME}.app/Resources/Contents, so that the app bundle is now executable and includes the icon and .nib required to run it.

Feel free to request edits if needed – I'm not sure whether changing the res_dir variable affects the Linux APP target or not. This *does* resolve the problem on macOS, though, so maybe a conditional should be used if it does affect Linux.