### PR TITLE
Don't redefine macro if it is already defined

### DIFF
--- a/IPlug/Extras/Easing.h
+++ b/IPlug/Extras/Easing.h
@@ -16,7 +16,9 @@
  * See here for visualizations: http://easings.net/
  */
 
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include "IPlugPlatform.h"
 


### PR DESCRIPTION
This PR silences a warning on MSVC if _USE_MATH_DEFINES is already defined by guarding the definition with a check