### PR TITLE
Repair IGEditorDelegate::SerializeEditorSize() 

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -149,10 +149,10 @@ bool IGEditorDelegate::SerializeEditorSize(IByteChunk& data) const
   int height = mGraphics ? mGraphics->Height() : mLastHeight;
   float scale = mGraphics ? mGraphics->GetDrawScale() : mLastScale;
     
-  savedOK &= data.Put(&width);
-  savedOK &= data.Put(&height);
-  savedOK &= data.Put(&scale);
-    
+  savedOK &= (data.Put(&width) > 0);
+  savedOK &= (data.Put(&height) > 0);
+  savedOK &= (data.Put(&scale) > 0);
+
   return savedOK;
 }
 


### PR DESCRIPTION
In IGEditorDelegate::SerializeEditorSize() we find:

```
  savedOK &= data.Put(&width);
  savedOK &= data.Put(&height);
  savedOK &= data.Put(&scale);
```

savedOk is a `bool`, but data.Put() returns an `int`. It is always dangerous to write `a &= b` instead of` a = a && b`, just for the reason that  C++ has no `&&=` :-). This works if we have good old ANSI C, where we have no `bool `, but use an `int` instead. Unfortunately in C++ `true` is not every value != 0, i.e. `(true & 88) != true` (compiler depended). Therefore we have to convert our integer to a bool **before** the operator:

```
  savedOK &= (data.Put(&width) > 0);
  savedOK &= (data.Put(&height) > 0);
  savedOK &= (data.Put(&scale) > 0);
```

[Problem appeared when compiling with Visual Studio Version 16.11.9, might have worked with earlier versions...]