### PR TITLE
Use CatmullRom() interpolation

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -493,8 +493,8 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
   mCanvas->scale(scale1, scale1);
   mCanvas->translate(-srcX * scale2, -srcY * scale2);
   
-  auto samplingOptions = SkSamplingOptions(SkCubicResampler::Mitchell());
-  
+  auto samplingOptions = SkSamplingOptions(SkCubicResampler::CatmullRom());
+
   if (image->mIsSurface)
     image->mSurface->draw(mCanvas, 0.0, 0.0, samplingOptions, &p);
   else


### PR DESCRIPTION
This cubic interpolator is far faster than the one we were using before on skia cpu and still looks good to me.