### PR TITLE
Add flag (IGRAPHICS_NO_SKIA_SVG)

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1452,7 +1452,7 @@ void IGraphics::EnableLiveEdit(bool enable)
 }
 
 // Skia has its own implementation for SVGs. On all other platforms we use NanoSVG, because it works.
-#ifdef IGRAPHICS_SKIA
+#ifdef SVG_USE_SKIA
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
   StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
@@ -2740,7 +2740,7 @@ IPattern IGraphics::GetSVGPattern(const NSVGpaint& paint, float opacity)
 
 void IGraphics::DoDrawSVG(const ISVG& svg, const IBlend* pBlend)
 {
-#ifdef IGRAPHICS_SKIA
+#ifdef SVG_USE_SKIA
   SkCanvas* canvas = static_cast<SkCanvas*>(GetDrawContext());
   svg.mSVGDom->render(canvas); //TODO: blend
 #else

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -25,7 +25,11 @@
 #include "ptrlist.h"
 #include "heapbuf.h"
 
-#ifdef IGRAPHICS_SKIA
+#if defined IGRAPHICS_SKIA && !defined IGRAPHICS_NO_SKIA_SVG
+#define SVG_USE_SKIA
+#endif
+
+#ifdef SVG_USE_SKIA
   #pragma warning( push )
   #pragma warning( disable : 4244 )
   #pragma warning( disable : 5030 )
@@ -442,7 +446,7 @@ protected:
 
 using PlatformFontPtr = std::unique_ptr<PlatformFont>;
 
-#ifdef IGRAPHICS_SKIA
+#ifdef SVG_USE_SKIA
 struct SVGHolder
 {
   SVGHolder(sk_sp<SkSVGDOM> svgDom)
@@ -628,7 +632,6 @@ struct IVec2
   IVec2 operator-(const IVec2 b) { return IVec2{x-b.x, y-b.y}; }
   IVec2 operator+(const IVec2 b) { return IVec2{x+b.x, y+b.y}; }
 };
-
 
 END_IGRAPHICS_NAMESPACE
 END_IPLUG_NAMESPACE

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -160,7 +160,7 @@ private:
 /** User-facing SVG abstraction that you use to manage SVG data
  * ISVG doesn't actually own the image data */
 
-#ifdef IGRAPHICS_SKIA
+#ifdef SVG_USE_SKIA
 struct ISVG
 {
   ISVG(sk_sp<SkSVGDOM> svgDom)


### PR DESCRIPTION
Skia Mac binaries have over 20Mb of SVG support. This adds a flag to turn that off (using NanoSVG instead) and reduce binary size (particularly if no SVG support is required).