### PR TITLE
Set interpolation more suitably for skia CPU and other versions of skia

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -493,8 +493,12 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
   mCanvas->scale(scale1, scale1);
   mCanvas->translate(-srcX * scale2, -srcY * scale2);
   
-  auto samplingOptions = SkSamplingOptions(SkCubicResampler::CatmullRom());
-
+#ifdef IGRAPHICS_CPU
+  auto samplingOptions = SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+#else
+  auto samplingOptions = SkSamplingOptions(SkCubicResampler::Mitchell());
+#endif
+    
   if (image->mIsSurface)
     image->mSurface->draw(mCanvas, 0.0, 0.0, samplingOptions, &p);
   else


### PR DESCRIPTION
On some testing it seems that CatMullRom() was only fast for one speed. It is much slower on CPU than Mitchell() for other speeds. On Metal etc. the speed seems fine in any case, so I propose using bilinear resampling on CPU (which is fast) and Mitchell() on other versions of Skia.