### PR TITLE
Typo fixed (line 36)

### DIFF
--- a/Documentation/structure.md
+++ b/Documentation/structure.md
@@ -33,7 +33,7 @@ TODO: explain
 | makedist-mac.command                      | macOS script to build all binaries and package them in an installer with accompanying files                             |
 | makedist-win.bat                          | Windows script to build all binaries and package them in an installer with accompanying files                           |
 | manual/IPlugEffect_manual.pdf             | Dummy PDF manual that will be included by the installer scripts                                                         |
-| resource.h                                | Source code - plugin's characteristices                                                                                 |
+| resource.h                                | Source code - plugin's characteristics                                                                                 |
 | resources/English.lproj/                  | Interface Builder folder for macOS standalone menu                                                                      |
 | resources/English.lproj/InfoPlist.strings | Interface Builder file for macOS standalone menu                                                                        |
 | resources/English.lproj/MainMenu.xib      | Interface Builder file for macOS standalone menu                                                                        |


### PR DESCRIPTION
Typo fixed in line 36. This file belongs to the  `documentation` folder
