### PR TITLE
AUv2: Don't return zero channels when an invalid bus channel count is…

### DIFF
--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -1203,6 +1203,10 @@ OSStatus IPlugAU::SetProperty(AudioUnitPropertyID propID, AudioUnitScope scope, 
           SetSampleRate(pASBD->mSampleRate);
         }
       }
+      else
+      {
+        pBus->mNHostChannels = pBus->mNPlugChannels;
+      }
       AssessInputConnections();
       return (connectionOK ? noErr : (int) kAudioUnitErr_InvalidProperty); // casting to int avoids gcc error
     }


### PR DESCRIPTION
This fixes #846 and doesn't seem to have any bad effects elsewhere