### PR TITLE
fix Prepare_resources-mac.py for python3 for new macOs 12.3 update

### DIFF
--- a/Examples/IPlugSideChain/scripts/prepare_resources-mac.py
+++ b/Examples/IPlugSideChain/scripts/prepare_resources-mac.py
@@ -30,7 +30,7 @@ def main():
   CSResourcesFileMapped = True
   LSMinimumSystemVersion = xcconfig['DEPLOYMENT_TARGET']
 
-  print "Copying resources ..."
+  print("Copying resources ...")
 
   if config['PLUG_SHARED_RESOURCES']:
     dst = os.path.expanduser("~") + "/Music/" + config['BUNDLE_NAME'] + "/Resources"
@@ -38,21 +38,21 @@ def main():
     dst = os.environ["TARGET_BUILD_DIR"] + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
 
   if os.path.exists(dst) == False:
-    os.makedirs(dst + "/", 0755 )
+    os.makedirs(dst + "/", 0o755 )
 
   if os.path.exists(projectpath + "/resources/img/"):
     imgs = os.listdir(projectpath + "/resources/img/")
     for img in imgs:
-      print "copying " + img + " to " + dst
+      print("copying " + img + " to " + dst)
       shutil.copy(projectpath + "/resources/img/" + img, dst)
 
   if os.path.exists(projectpath + "/resources/fonts/"):
     fonts = os.listdir(projectpath + "/resources/fonts/")
     for font in fonts:
-      print "copying " + font + " to " + dst
+      print("copying " + font + " to " + dst)
       shutil.copy(projectpath + "/resources/fonts/" + font, dst)
 
-  print "Processing Info.plist files..."
+  print("Processing Info.plist files...")
 
 # VST3
 


### PR DESCRIPTION
converted py3

Problem on MacOs 12.3 https://iplug2.discourse.group/t/macos-12-3-build/592

Also

![Screenshot 2022-03-16 at 19 36 22](https://user-images.githubusercontent.com/101744616/158664814-2e535389-d413-48e9-bf31-21c39e6e5aa8.png)


I'm not good at helping, but these fixes solve the build problem on the new mac Os 12.3 update. The bottom line is that after the update, the build stopped happening. If this is important, then you can translate all the files to Python3
