### PR TITLE
IGraphics: Clipping with paths additional to rectangular clipping

### DIFF
--- a/IGraphics/Drawing/IGraphicsCanvas.cpp
+++ b/IGraphics/Drawing/IGraphicsCanvas.cpp
@@ -346,6 +346,18 @@ void IGraphicsCanvas::SetClipRegion(const IRECT& r)
   context.call<void>("beginPath");
 }
 
+void IGraphicsCanvas::SetClipPath(const IRECT& r)
+{
+  //TODO clipping with paths
+  val context = GetContext();
+  context.call<void>("restore");
+  context.call<void>("save");
+  context.call<void>("beginPath");
+  context.call<void>("rect", r.L, r.T, r.W(), r.H());
+  context.call<void>("clip");
+  context.call<void>("beginPath");
+}
+
 bool IGraphicsCanvas::BitmapExtSupported(const char* ext)
 {
   char extLower[32];

--- a/IGraphics/Drawing/IGraphicsCanvas.h
+++ b/IGraphics/Drawing/IGraphicsCanvas.h
@@ -95,6 +95,7 @@ private:
 
   void PathTransformSetMatrix(const IMatrix& m) override;
   void SetClipRegion(const IRECT& r) override;
+  void SetClipPath(const IRECT& r) override;
     
   void SetCanvasSourcePattern(val& context, const IPattern& pattern, const IBlend* pBlend = nullptr);
   void SetCanvasBlendMode(val& context, const IBlend* pBlend);

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -805,6 +805,11 @@ void IGraphicsNanoVG::SetClipRegion(const IRECT& r)
   nvgScissor(mVG, r.L, r.T, r.W(), r.H());
 }
 
+void IGraphicsNanoVG::SetClipPath()
+{
+  //TODO NanoVG Clip with MainPath
+}
+
 void IGraphicsNanoVG::DrawDottedLine(const IColor& color, float x1, float y1, float x2, float y2, const IBlend* pBlend, float thickness, float dashLen)
 {
   const float xd = x1 - x2;

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -805,9 +805,10 @@ void IGraphicsNanoVG::SetClipRegion(const IRECT& r)
   nvgScissor(mVG, r.L, r.T, r.W(), r.H());
 }
 
-void IGraphicsNanoVG::SetClipPath()
+void IGraphicsNanoVG::SetClipPath(const IRECT& r)
 {
   //TODO NanoVG Clip with MainPath
+  nvgScissor(mVG, r.L, r.T, r.W(), r.H());
 }
 
 void IGraphicsNanoVG::DrawDottedLine(const IColor& color, float x1, float y1, float x2, float y2, const IBlend* pBlend, float thickness, float dashLen)

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -151,6 +151,7 @@ private:
   void PrepareAndMeasureText(const IText& text, const char* str, IRECT& r, double& x, double & y) const;
   void PathTransformSetMatrix(const IMatrix& m) override;
   void SetClipRegion(const IRECT& r) override;
+  void SetClipPath() override;
   void UpdateLayer() override;
   void ClearFBOStack();
   

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -151,7 +151,7 @@ private:
   void PrepareAndMeasureText(const IText& text, const char* str, IRECT& r, double& x, double & y) const;
   void PathTransformSetMatrix(const IMatrix& m) override;
   void SetClipRegion(const IRECT& r) override;
-  void SetClipPath() override;
+  void SetClipPath(const IRECT& r) override;
   void UpdateLayer() override;
   void ClearFBOStack();
   

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -834,12 +834,13 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
   mCanvas->setMatrix(mFinalMatrix);
 }
 
-void IGraphicsSkia::SetClipPath()
+void IGraphicsSkia::SetClipPath(const IRECT& r)
 {
   mCanvas->restoreToCount(0);
   mCanvas->save();
   mCanvas->setMatrix(mClipMatrix);
-  mCanvas->clipPath(mMainPath);
+  mCanvas->clipPath(mMainPath, true);
+  mCanvas->clipRect(SkiaRect(r));
   mCanvas->setMatrix(mFinalMatrix);
 }
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -834,6 +834,15 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
   mCanvas->setMatrix(mFinalMatrix);
 }
 
+void IGraphicsSkia::SetClipPath()
+{
+  mCanvas->restoreToCount(0);
+  mCanvas->save();
+  mCanvas->setMatrix(mClipMatrix);
+  mCanvas->clipPath(mMainPath);
+  mCanvas->setMatrix(mFinalMatrix);
+}
+
 APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable)
 {
   sk_sp<SkSurface> surface;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -137,7 +137,8 @@ private:
 
   void PathTransformSetMatrix(const IMatrix& m) override;
   void SetClipRegion(const IRECT& r) override;
-    
+  void SetClipPath() override;
+  
   void RenderPath(SkPaint& paint);
     
   sk_sp<SkSurface> mSurface;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -137,7 +137,7 @@ private:
 
   void PathTransformSetMatrix(const IMatrix& m) override;
   void SetClipRegion(const IRECT& r) override;
-  void SetClipPath() override;
+  void SetClipPath(const IRECT& r) override;
   
   void RenderPath(SkPaint& paint);
     

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -2666,8 +2666,9 @@ void IGraphics::PathClipRegion(const IRECT r)
 }
 
 void IGraphics::PathClipPath() {
+  IRECT drawArea = mLayers.empty() ? mClipRECT : mLayers.top()->Bounds();
   PathTransformSetMatrix(IMatrix());
-  SetClipPath();
+  SetClipPath(drawArea);
   PathTransformSetMatrix(mTransform);
 }
 

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -2665,6 +2665,12 @@ void IGraphics::PathClipRegion(const IRECT r)
   PathTransformSetMatrix(mTransform);
 }
 
+void IGraphics::PathClipPath() {
+  PathTransformSetMatrix(IMatrix());
+  SetClipPath();
+  PathTransformSetMatrix(mTransform);
+}
+
 void IGraphics::DrawFittedBitmap(const IBitmap& bitmap, const IRECT& bounds, const IBlend* pBlend)
 {
   PathTransformSave();

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -731,6 +731,9 @@ public:
   /** Clip the current path to a particular region
    * @param r The rectangular region to clip */
   void PathClipRegion(const IRECT r = IRECT());
+
+    /** Clip the current path to the MainPath*/
+   void PathClipPath();
   
   virtual void PathTransformSetMatrix(const IMatrix& matrix) = 0;
 

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -770,7 +770,7 @@ private:
   virtual void CompleteRegion(const IRECT& bounds) {}
 
   virtual void SetClipRegion(const IRECT& r) = 0;
-  virtual void SetClipPath() = 0;
+  virtual void SetClipPath(const IRECT& r) = 0;
 
 public:
 #pragma mark - Platform implementation

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -767,6 +767,7 @@ private:
   virtual void CompleteRegion(const IRECT& bounds) {}
 
   virtual void SetClipRegion(const IRECT& r) = 0;
+  virtual void SetClipPath() = 0;
 
 public:
 #pragma mark - Platform implementation


### PR DESCRIPTION
IGraphics: Clipping with paths additional to rectangular clipping:

https://github.com/iPlug2/iPlug2/issues/864

this PR enables clipping with the mMainPath for skia . For NanoVg theres an empty function provided, but not yet a working implementation.


