### PR TITLE
Windows: reduced flickering when resizing the plugin

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -363,7 +363,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       return 0;
 
     case WM_ERASEBKGND:
-      return 0;
+      return 1;
 
     case WM_RBUTTONDOWN:
     case WM_LBUTTONDOWN:
@@ -675,7 +675,12 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
       return 0;
     }
-
+    case WM_WINDOWPOSCHANGED:
+    {
+      if (!pGraphics->mIsResizingToSmallerSize)
+        Sleep(1000 / pGraphics->FPS());
+      return 0;
+    }
     case WM_CTLCOLOREDIT:
     {
       if(!pGraphics->mParamEditWnd)
@@ -886,6 +891,8 @@ void IGraphicsWin::PlatformResize(bool parentHasResized)
     GetWindowSize(mPlugWnd, &dlgW, &dlgH);
     int dw = (WindowWidth() * GetScreenScale()) - dlgW, dh = (WindowHeight()* GetScreenScale()) - dlgH;
       
+    mIsResizingToSmallerSize = (dw < 0 && dh < 0);
+    
     if (IsChildWindow(mPlugWnd))
     {
       pParent = GetParent(mPlugWnd);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -153,6 +153,8 @@ private:
   int mVBlankSkipUntil = 0; // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
   bool mVSYNCEnabled = false;
   
+  bool mIsResizingToSmallerSize = false;
+  
   const IParam* mEditParam = nullptr;
   IText mEditText;
   IRECT mEditRECT;


### PR DESCRIPTION
This PR reduces the flickering of the UI when resizing the app/plugin in Windows.

This fix is related to issue #866.