### PR TITLE
Clap shaped parameters

### DIFF
--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -488,8 +488,8 @@ void IPlugCLAP::ProcessInputEvents(const clap_input_events *inputEvents) noexcep
           int paramIdx = paramValue->param_id;
           double value = paramValue->value;
           
-          GetParam(paramIdx)->Set(value);
-          SendParameterValueFromAPI(paramIdx, value, false);
+          GetParam(paramIdx)->SetNormalized(value);
+          SendParameterValueFromAPI(paramIdx, value, true);
           OnParamChange(paramIdx, EParamSource::kHost, event->time);
           break;
         }

--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -380,9 +380,9 @@ bool IPlugCLAP::paramsInfo(uint32_t paramIndex, clap_param_info *info) const noe
 
   // Values
   
-  info->min_value = pParam->GetMin();
-  info->max_value = pParam->GetMax();
-  info->default_value = pParam->GetDefault();
+  info->min_value = 0.0;
+  info->max_value = 1.0;
+  info->default_value = pParam->GetDefault(true);
   
   return true;
 }
@@ -390,7 +390,7 @@ bool IPlugCLAP::paramsInfo(uint32_t paramIndex, clap_param_info *info) const noe
 bool IPlugCLAP::paramsValue(clap_id paramId, double *value) noexcept
 {
   const IParam *pParam = GetParam(paramId);
-  *value = pParam->Value();
+  *value = pParam->GetNormalized();
   return true;
 }
 
@@ -399,7 +399,7 @@ bool IPlugCLAP::paramsValueToText(clap_id paramId, double value, char *display, 
   const IParam *pParam = GetParam(paramId);
   WDL_String str;
   
-  pParam->GetDisplay(value, false, str);
+  pParam->GetDisplay(value, true, str);
   
   // Add Label
   

--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -355,12 +355,12 @@ bool IPlugCLAP::stateLoad(const clap_istream *stream) noexcept
 
 // clap_plugin_params
 
-bool IPlugCLAP::paramsInfo(uint32_t paramIndex, clap_param_info *info) const noexcept
+bool IPlugCLAP::paramsInfo(uint32_t paramIdx, clap_param_info *info) const noexcept
 {
   assert(MAX_PARAM_NAME_LEN <= CLAP_NAME_SIZE && "iPlug parameter name size exceeds CLAP maximum");
   assert(MAX_PARAM_GROUP_LEN <= CLAP_PATH_SIZE && "iPlug group name size exceeds CLAP maximum");
 
-  const IParam *pParam = GetParam(paramIndex);
+  const IParam *pParam = GetParam(paramIdx);
   
   clap_param_info_flags flags = CLAP_PARAM_REQUIRES_PROCESS; // TO DO - check this with Alex B
   
@@ -369,7 +369,7 @@ bool IPlugCLAP::paramsInfo(uint32_t paramIndex, clap_param_info *info) const noe
   if (pParam->GetCanAutomate())
     flags |= CLAP_PARAM_IS_AUTOMATABLE;
   
-  info->id = paramIndex;
+  info->id = paramIdx;
   info->flags = flags;
   info->cookie = nullptr;
 
@@ -385,16 +385,16 @@ bool IPlugCLAP::paramsInfo(uint32_t paramIndex, clap_param_info *info) const noe
   return true;
 }
 
-bool IPlugCLAP::paramsValue(clap_id paramId, double *value) noexcept
+bool IPlugCLAP::paramsValue(clap_id paramIdx, double *value) noexcept
 {
-  const IParam *pParam = GetParam(paramId);
+  const IParam *pParam = GetParam(paramIdx);
   *value = pParam->GetNormalized();
   return true;
 }
 
-bool IPlugCLAP::paramsValueToText(clap_id paramId, double value, char *display, uint32_t size) noexcept
+bool IPlugCLAP::paramsValueToText(clap_id paramIdx, double value, char *display, uint32_t size) noexcept
 {
-  const IParam *pParam = GetParam(paramId);
+  const IParam *pParam = GetParam(paramIdx);
   WDL_String str;
   
   pParam->GetDisplay(value, true, str);
@@ -414,9 +414,9 @@ bool IPlugCLAP::paramsValueToText(clap_id paramId, double value, char *display, 
   return true;
 }
 
-bool IPlugCLAP::paramsTextToValue(clap_id paramId, const char *display, double *value) noexcept
+bool IPlugCLAP::paramsTextToValue(clap_id paramIdx, const char *display, double *value) noexcept
 {
-  const IParam *pParam = GetParam(paramId);
+  const IParam *pParam = GetParam(paramIdx);
   *value = pParam->StringToValue(display);
   return true;
 }

--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -53,7 +53,7 @@ IPlugCLAP::IPlugCLAP(const InstanceInfo& info, const Config& config)
 
 void IPlugCLAP::BeginInformHostOfParamChange(int idx)
 {
-  ParamToHost change { ParamToHost::Type::Begin, idx, GetParam(idx)->GetNormalized() };
+  ParamToHost change { ParamToHost::Type::Begin, idx, 0.0 };
   mParamInfoToHost.Push(change);
 }
 
@@ -65,7 +65,7 @@ void IPlugCLAP::InformHostOfParamChange(int idx, double normalizedValue)
 
 void IPlugCLAP::EndInformHostOfParamChange(int idx)
 {
-  ParamToHost change { ParamToHost::Type::End, idx, GetParam(idx)->GetNormalized() };
+  ParamToHost change { ParamToHost::Type::End, idx, 0.0 };
   mParamInfoToHost.Push(change);
 }
 

--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -53,21 +53,19 @@ IPlugCLAP::IPlugCLAP(const InstanceInfo& info, const Config& config)
 
 void IPlugCLAP::BeginInformHostOfParamChange(int idx)
 {
-  ParamToHost change { ParamToHost::Type::Begin, idx, GetParam(idx)->Value() };
+  ParamToHost change { ParamToHost::Type::Begin, idx, GetParam(idx)->GetNormalized() };
   mParamInfoToHost.Push(change);
 }
 
 void IPlugCLAP::InformHostOfParamChange(int idx, double normalizedValue)
 {
-  const IParam *pParam = GetParam(idx);
-  const double value = pParam->FromNormalized(normalizedValue);
-  ParamToHost change { ParamToHost::Type::Value, idx, value };
+  ParamToHost change { ParamToHost::Type::Value, idx, normalizedValue };
   mParamInfoToHost.Push(change);
 }
 
 void IPlugCLAP::EndInformHostOfParamChange(int idx)
 {
-  ParamToHost change { ParamToHost::Type::End, idx, GetParam(idx)->Value() };
+  ParamToHost change { ParamToHost::Type::End, idx, GetParam(idx)->GetNormalized() };
   mParamInfoToHost.Push(change);
 }
 

--- a/IPlug/CLAP/IPlugCLAP.h
+++ b/IPlug/CLAP/IPlugCLAP.h
@@ -140,14 +140,14 @@ private:
   bool implementsParams() const noexcept override { return true; }
   uint32_t paramsCount() const noexcept override { return NParams(); }
   
-  bool paramsInfo(uint32_t paramIndex, clap_param_info *info) const noexcept override;
+  bool paramsInfo(uint32_t paramIdx, clap_param_info *info) const noexcept override;
   
-  bool paramsValue(clap_id paramId, double *value) noexcept override;
-  bool paramsValueToText(clap_id paramId, double value, char *display, uint32_t size) noexcept override;
-  bool paramsTextToValue(clap_id paramId, const char *display, double *value) noexcept override;
+  bool paramsValue(clap_id paramIdx, double *value) noexcept override;
+  bool paramsValueToText(clap_id paramIdx, double value, char *display, uint32_t size) noexcept override;
+  bool paramsTextToValue(clap_id paramIdx, const char *display, double *value) noexcept override;
      
   void paramsFlush(const clap_input_events *input_parameter_changes, const clap_output_events *outputParamChanges) noexcept override;
-  bool isValidParamId(clap_id paramId) const noexcept override { return paramId < NParams(); }
+  bool isValidParamId(clap_id paramIdx) const noexcept override { return paramIdx < NParams(); }
     
   // clap_plugin_gui
 #if PLUG_HAS_UI


### PR DESCRIPTION
This PR concerns the correct implementation of shaped parameters (via automation and host GUI) for CLAP.

Unlike the previous implementation this version reports all double parameters as normalised (0-1) and then applies the correct transformations for shaping to occur. This will break any saved sessions or automations but is probably the neatest implantation that works (bools/enum/ints must be reported in their correct ranges, unlike for VST3 because otherwise they cannot be stepped as far as the host is concerned). Branching for only non-linearly shaped parameters will be more expensive if it is even possible) as it requires a dynamic_cast and so making the choice based on parameter type seems the cleanest way.

I'll review this with @olilarkin.

However, it's possible @Full-Bucket and/or @heebje might want to check this out and be aware of how this will break previous versions. Sorry about that, but this is pretty likely to get merged, as I think having correct parameter shaping from the host is important.