### PR TITLE
Prevent crash on re-calling clap_deinit

### DIFF
--- a/IPlug/IPlug_include_in_plug_src.h
+++ b/IPlug/IPlug_include_in_plug_src.h
@@ -329,7 +329,11 @@ static bool clap_init(const char* pluginPath)
 static void clap_deinit(void)
 {
   gPluginPath.clear();
-  delete gPluginDesc;
+  if (gPluginDesc != nullptr)
+  {
+    delete gPluginDesc;
+    gPluginDesc = nullptr;
+  }
 }
 
 static uint32_t clap_get_plugin_count(const clap_plugin_factory_t *factory)


### PR DESCRIPTION
Prevent crash when trying to delete gPluginDesc on repeated calls of clap_deinit.
This happened with the latest v7.5 of host "Metro" by Sagan Technologies.