### PR TITLE
Capitalize Accelerate include

### DIFF
--- a/IPlug/ISender.h
+++ b/IPlug/ISender.h
@@ -23,7 +23,7 @@
 #include <array>
 
 #if defined OS_IOS || defined OS_MAC
-#include <accelerate/accelerate.h>
+#include <Accelerate/Accelerate.h>
 #endif
 
 BEGIN_IPLUG_NAMESPACE


### PR DESCRIPTION
This PR fixes https://github.com/iPlug2/iPlug2/issues/899 by changing the Accelerate include to be capitalized