### PR TITLE
macOS: Fix window dims when resizing notch macs, fixes #915

### DIFF
--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -52,12 +52,19 @@ bool IPlugAPP::EditorResize(int viewWidth, int viewHeight)
   if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
   {
     #ifdef OS_MAC
-    const int titleBarOffset = GetTitleBarOffset();
-    RECT r;
-    GetWindowRect(gHWND, &r);
-    SetWindowPos(gHWND, 0, r.left, r.bottom - viewHeight - titleBarOffset, viewWidth, viewHeight + titleBarOffset, 0);
+    RECT rcClient, rcWindow;
+    POINT ptDiff;
+    
+    GetClientRect(gHWND, &rcClient);
+    GetWindowRect(gHWND, &rcWindow);
+    
+    ptDiff.x = (rcWindow.right - rcWindow.left) - rcClient.right;
+    ptDiff.y = (rcWindow.bottom - rcWindow.top) - rcClient.bottom;
+    
+    SetWindowPos(gHWND, 0, rcWindow.left, rcWindow.bottom - viewHeight - ptDiff.y, viewWidth + ptDiff.x, viewHeight + ptDiff.y, 0);
     parentResized = true;
     #endif
+    
     SetEditorSize(viewWidth, viewHeight);
   }
   


### PR DESCRIPTION
When using the IGraphics corner resizer on M1 Pro/Max "notch" macs, the window size ended up wrong, since we were using the height of the macOS menu bar to adjust the client rect. On macs with no notch, this worked, but on macs with a notch the height of the menu bar is different to that of a windows title bar.