### PR TITLE
Include config.h in IGraphicsConstants.h to allow setting DEFAULT_FONT

### DIFF
--- a/IGraphics/IGraphicsConstants.h
+++ b/IGraphics/IGraphicsConstants.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "IPlugPlatform.h"
+#include "config.h"
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE


### PR DESCRIPTION
This allows setting DEFAULT_FONT in one location for convenience.

Fixes https://github.com/iPlug2/iPlug2/issues/919
