### PR TITLE
Fix IGraphics build of freetype on Mac OS Monterey

### DIFF
--- a/Dependencies/IGraphics/build-igraphics-libs-mac.sh
+++ b/Dependencies/IGraphics/build-igraphics-libs-mac.sh
@@ -102,6 +102,8 @@ buildFreetype()
   
   export MACOSX_DEPLOYMENT_TARGET=$DEPLOYMENT_TARGET
 
+  export CPATH="$(xcrun --show-sdk-path)/usr/include"
+
   # TODO: for some reason these exports cause x86 build to fail
   if [[ $ARCH == "arm64" ]]; then
     export CC="$(xcrun -sdk macosx -find clang)"


### PR DESCRIPTION
When building freetype, the configure script was unable to find the stdlib headers (stdio.h, string.h) and the build fails.

To resolve this, it is necessary to set the CPATH env variable to the correct location for the standard headers.
