### PR TITLE
Fix panels

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -850,9 +850,9 @@ public:
    * @param fileName Non const WDL_String reference specifying the file name. Set this prior to calling the method for save dialogs, to provide a default file name. For file-open dialogs, on successful selection of a file this will get set to the file’s name.
    * @param path WDL_String reference where the path will be put on success or empty string on failure/user cancelled
    * @param action Determines whether this is an file-open dialog or a file-save dialog
-   * @param extensions A space separated CString list of file extensions to filter in the dialog (e.g. “.wav .aif”
+   * @param ext A space separated CString list of file extensions to filter in the dialog (e.g. “.wav .aif”
    * @param completionHandler an IFileDialogCompletionHandlerFunc that will be called when a file is selected or the dialog is cancelled */
-  virtual void PromptForFile(WDL_String& fileName, WDL_String& path, EFileAction action = EFileAction::Open, const char* extensions = 0, IFileDialogCompletionHandlerFunc completionHandler = nullptr) = 0;
+  virtual void PromptForFile(WDL_String& fileName, WDL_String& path, EFileAction action = EFileAction::Open, const char* ext = "", IFileDialogCompletionHandlerFunc completionHandler = nullptr) = 0;
 
   /** Create a platform file prompt dialog to choose a directory path for opening/saving a directory. NOTE: this method will block the main thread
    * @param dir Non const WDL_String reference specifying the directory path. Set this prior to calling the method for save dialogs, to provide a default path. For load dialogs, on successful selection of a directory this will get set to the full path.

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -202,9 +202,13 @@ void IGraphicsIOS::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
 
   if (fileName.GetLength())
     pDefaultFileName = [NSString stringWithCString:fileName.Get() encoding:NSUTF8StringEncoding];
-
+  else
+    pDefaultFileName = @"";
+  
   if (path.GetLength())
     pDefaultPath = [NSString stringWithCString:path.Get() encoding:NSUTF8StringEncoding];
+  else
+    pDefaultPath = @"";
 
   fileName.Set(""); // reset it
 

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -418,9 +418,13 @@ void IGraphicsMac::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
 
   if (fileName.GetLength())
     pDefaultFileName = [NSString stringWithCString:fileName.Get() encoding:NSUTF8StringEncoding];
-
+  else
+    pDefaultFileName = @"";
+  
   if (path.GetLength())
     pDefaultPath = [NSString stringWithCString:path.Get() encoding:NSUTF8StringEncoding];
+  else
+    pDefaultPath = @"";
 
   fileName.Set(""); // reset it
 


### PR DESCRIPTION
Fix a regression where empty strings in IGraphics::PromptForFile()'s arguments caused a crash
