### PR TITLE
Fix CommCtrl.h issue with clang-cl

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -22,6 +22,11 @@
 #include <wininet.h>
 #include <VersionHelpers.h>
 
+#if defined __clang__
+#undef CCSIZEOF_STRUCT
+#define CCSIZEOF_STRUCT(structname, member) (__builtin_offsetof(structname, member) + sizeof(((structname*)0)->member))
+#endif
+
 using namespace iplug;
 using namespace igraphics;
 


### PR DESCRIPTION
This fix allows compilation of IGraphicsWin.cpp with clang-cl