### PR TITLE
Link ICoreWebView2 statically

### DIFF
--- a/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
+++ b/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
@@ -60,7 +60,7 @@ IPlugOSCEditor::IPlugOSCEditor(const InstanceInfo& info)
     
     pGraphics->AttachControl(new IWebViewControl(bottomRow, true, [](IWebViewControl* pWebView){
       pWebView->LoadHTML("OSC Console");
-      }, nullptr, R"(C:\Users\oli\Dev\iPlug2\Examples\IPlugOSCEditor\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\x64\WebView2Loader.dll)", R"(C:\Users\oli\Dev\iPlug2\Examples\IPlugOSCEditor\)"), kCtrlTagWebView);
+      }, nullptr), kCtrlTagWebView);
     
   };
 #endif

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-aax.vcxproj
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-aax.vcxproj
@@ -518,11 +518,24 @@
     <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
     <None Include="..\config\IPlugOSCEditor-web.mk" />
     <None Include="..\config\IPlugOSCEditor-win.props" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-aax.vcxproj.filters
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-aax.vcxproj.filters
@@ -321,5 +321,6 @@
     <None Include="..\config\IPlugOSCEditor-mac.xcconfig">
       <Filter>config</Filter>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj
@@ -392,13 +392,8 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets')" />
-  </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj
@@ -387,13 +387,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\config\IPlugOSCEditor-ios.xcconfig" />
-    <None Include="..\config\IPlugOSCEditor-web.mk" />
-    <None Include="..\config\IPlugOSCEditor-win.props">
-      <SubType>Designer</SubType>
-    </None>
     <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
+    <None Include="..\config\IPlugOSCEditor-web.mk" />
+    <None Include="..\config\IPlugOSCEditor-win.props" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
@@ -401,7 +404,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj.filters
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-app.vcxproj.filters
@@ -372,8 +372,6 @@
     <None Include="..\config\IPlugOSCEditor-win.props">
       <Filter>config</Filter>
     </None>
-    <None Include="packages.config" />
-    <None Include="$(MSBuildThisFileDirectory)$(EffectivePlatform)\WebView2Loader.dll" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\resources\IPlugOSCEditor.ico">

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-vst2.vcxproj
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-vst2.vcxproj
@@ -352,14 +352,27 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\config\IPlugOSCEditor-ios.xcconfig" />
+    <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
     <None Include="..\config\IPlugOSCEditor-web.mk" />
     <None Include="..\config\IPlugOSCEditor-win.props" />
-    <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-vst3.vcxproj
+++ b/Examples/IPlugOSCEditor/projects/IPlugOSCEditor-vst3.vcxproj
@@ -414,14 +414,25 @@
     <None Include="..\config\IPlugOSCEditor-ios.xcconfig" />
     <None Include="..\config\IPlugOSCEditor-mac.xcconfig" />
     <None Include="..\config\IPlugOSCEditor-web.mk" />
-    <None Include="..\config\IPlugOSCEditor-win.props">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="..\config\IPlugOSCEditor-win.props" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugOSCEditor/projects/packages.config
+++ b/Examples/IPlugOSCEditor/projects/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Web.WebView2" version="1.0.1587.40" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230202.1" targetFramework="native" />
+</packages>

--- a/Examples/IPlugOSCEditor/projects/packages.config
+++ b/Examples/IPlugOSCEditor/projects/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.1462.37" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
-</packages>

--- a/Examples/IPlugWebUI/IPlugWebUI.cpp
+++ b/Examples/IPlugWebUI/IPlugWebUI.cpp
@@ -7,12 +7,6 @@ IPlugWebUI::IPlugWebUI(const InstanceInfo& info)
   GetParam(kGain)->InitGain("Gain", -70., -70, 0.);
 
   // Hard-coded paths must be modified!
-#ifdef OS_WIN
-  SetWebViewPaths(R"(C:\Users\oli\Dev\iPlug2\Examples\IPlugWebUI\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\x64\WebView2Loader.dll)",
-    R"(C:\Users\oli\Dev\iPlug2\Examples\IPlugWebUI)");
-#endif
-
-
   mEditorInitFunc = [&]() {
 #ifdef OS_WIN
     LoadFile(R"(C:\Users\oli\Dev\iPlug2\Examples\IPlugWebUI\resources\web\index.html)", nullptr);

--- a/Examples/IPlugWebUI/README.md
+++ b/Examples/IPlugWebUI/README.md
@@ -1,8 +1,2 @@
 # IPlugWebUI
 A basic volume control effect plug-in which uses a platform web view to host an HTML/CSS GUI
-
-### NOTES
-
-This is somewhat experimental, especially on Windows.
-
-On Windows you will have to have downloaded and installed the latest edge chromium and you will have to right click the Visual Studio Solution/individual projects and install the nuget packages for ICoreWebView2 and the Windows Implementation Library. Then you will have to edit some hard-coded paths In IPlugWebUI.cpp, since your plugin needs to be able to load the WebView2Loader.dll and it needs to have a temporary folder that it can write to. This does not set that up for you, so if you wanted to use this in a way that would work on computers other than your own, you would need to add some logic to the installer to find a dedicated path to install WebView2Loader.dll and for the temp dir and the web root folder. On macOS and iOS the web root folder is copied into the application bundle, but on Windows you need to pass a hardcoded path.

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-aax.vcxproj
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-aax.vcxproj
@@ -59,10 +59,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
-  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(SolutionDir)\config\IPlugWebUI-win.props" />
@@ -467,7 +463,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+  <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-app.vcxproj
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-app.vcxproj
@@ -75,10 +75,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(SolutionDir)\config\IPlugWebUI-win.props" />
@@ -341,7 +337,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1462.37\build\native\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+  <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-vst2.vcxproj
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-vst2.vcxproj
@@ -75,10 +75,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.781-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.781-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(SolutionDir)\config\IPlugWebUI-win.props" />
@@ -297,10 +293,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.200902.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.200902.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-  </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
@@ -308,7 +300,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-vst2.vcxproj.filters
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-vst2.vcxproj.filters
@@ -136,6 +136,5 @@
       <Filter>config</Filter>
     </None>
     <None Include="packages.config" />
-    <None Include="$(MSBuildThisFileDirectory)$(EffectivePlatform)\WebView2Loader.dll" />
   </ItemGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-vst3.vcxproj
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-vst3.vcxproj
@@ -75,10 +75,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.781-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.781-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(SolutionDir)\config\IPlugWebUI-win.props" />
@@ -360,10 +356,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.200902.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.200902.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-  </ImportGroup>
   <Target Name="AfterBuild">
     <PaceFixLogs Condition="Exists('$(PACE_FUSION_HOME)PaceFusionUi2013.dll')" LogDirectory="$(IntDir)" />
   </Target>
@@ -371,7 +363,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.824-prerelease\build\native\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230202.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.1587.40\build\native\Microsoft.Web.WebView2.targets')" />
+  <PropertyGroup>
+    <WebView2LoaderPreference>Static</WebView2LoaderPreference>
+  </PropertyGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-vst3.vcxproj.filters
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-vst3.vcxproj.filters
@@ -334,6 +334,5 @@
       <Filter>config</Filter>
     </None>
     <None Include="packages.config" />
-    <None Include="$(MSBuildThisFileDirectory)$(EffectivePlatform)\WebView2Loader.dll" />
   </ItemGroup>
 </Project>

--- a/Examples/IPlugWebUI/projects/packages.config
+++ b/Examples/IPlugWebUI/projects/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.1462.37" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1587.40" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230202.1" targetFramework="native" />
 </packages>

--- a/IGraphics/Controls/IWebViewControl.h
+++ b/IGraphics/Controls/IWebViewControl.h
@@ -40,10 +40,8 @@ public:
    * @param bounds The control's bounds
    * @param opaque Should the web view background be opaque
    * @param readyFunc A function conforming to onReadyFunc, that will be called asyncronously when the webview has been initialized
-   * @param msgFunc A function conforming to onMessageFunc, that will be called when messages are posted from the webview
-   * @param dllPath (Windows only) an absolute path to the WebView2Loader.dll that is required to use the WebView2 on windows
-   * @param tmpPath (Windows only) an absolute path to the folder that should be used */
-  IWebViewControl(const IRECT& bounds, bool opaque, OnReadyFunc readyFunc, OnMessageFunc msgFunc = nullptr, const char* dllPath = "", const char* tmpPath = "")
+   * @param msgFunc A function conforming to onMessageFunc, that will be called when messages are posted from the webview */
+  IWebViewControl(const IRECT& bounds, bool opaque, OnReadyFunc readyFunc, OnMessageFunc msgFunc = nullptr)
   : IControl(bounds)
   , IWebView(opaque)
   , mOnReadyFunc(readyFunc)
@@ -51,10 +49,6 @@ public:
   {
     // The IControl should not receive mouse messages
     mIgnoreMouse = true;
-    
-#ifdef OS_WIN
-    SetWebViewPaths(dllPath, tmpPath);
-#endif
   }
   
   ~IWebViewControl()

--- a/IPlug/Extras/OSC/IPlugOSC_msg.h
+++ b/IPlug/Extras/OSC/IPlugOSC_msg.h
@@ -22,6 +22,7 @@
 BEGIN_IPLUG_NAMESPACE
 
 #define MAX_OSC_MSG_LEN 1024
+#undef GetMessage 
 
 static void OSC_BSWAPINTMEM(void *buf)
 {

--- a/IPlug/Extras/WebView/IPlugWebView.cpp
+++ b/IPlug/Extras/WebView/IPlugWebView.cpp
@@ -12,6 +12,7 @@ See LICENSE.txt for  more info.
 #include "IPlugPaths.h"
 #include <string>
 #include <windows.h>
+#include <shlobj.h>
 #include <cassert>
 
 using namespace iplug;
@@ -41,74 +42,67 @@ void* IWebView::OpenWebView(void* pParent, float x, float y, float w, float h, f
   w *= scale;
   h *= scale;
 
-  assert(mDLLPath.GetLength() > 0);
+  WDL_String cachePath;
+  WebViewCachePath(cachePath);
+  WCHAR cachePathWide[IPLUG_WIN_MAX_WIDE_PATH];
+  UTF8ToUTF16(cachePathWide, cachePath.Get(), IPLUG_WIN_MAX_WIDE_PATH);
 
-  mDLLHandle = LoadLibraryA(mDLLPath.Get());
+  CreateCoreWebView2EnvironmentWithOptions(
+    nullptr, cachePathWide, nullptr,
+  Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+    [&, hWnd, x, y, w, h](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
+      env->CreateCoreWebView2Controller(hWnd,
+        Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+          [&, hWnd, x, y, w, h](HRESULT result, ICoreWebView2Controller* controller) -> HRESULT {
+            if (controller != nullptr) {
+              mWebViewCtrlr = controller;
+              mWebViewCtrlr->get_CoreWebView2(&mWebViewWnd);
+            }
 
-  TCCWebView2EnvWithOptions handle = (TCCWebView2EnvWithOptions) GetProcAddress(mDLLHandle, "CreateCoreWebView2EnvironmentWithOptions");
+            ICoreWebView2Settings* Settings;
+            mWebViewWnd->get_Settings(&Settings);
+            Settings->put_IsScriptEnabled(TRUE);
+            Settings->put_AreDefaultScriptDialogsEnabled(TRUE);
+            Settings->put_IsWebMessageEnabled(TRUE);
 
-  if (handle != NULL)
-  {
-    WCHAR tmpPathWide[IPLUG_WIN_MAX_WIDE_PATH];
-    UTF8ToUTF16(tmpPathWide, mTmpPath.Get(), IPLUG_WIN_MAX_WIDE_PATH);
+            // this script adds a function IPlugSendMsg that is used to call the platform webview messaging function in JS
+            mWebViewWnd->AddScriptToExecuteOnDocumentCreated(L"function IPlugSendMsg(m) {window.chrome.webview.postMessage(m)};",
+              Callback<ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler>(
+                [this](HRESULT error, PCWSTR id) -> HRESULT {
+                  return S_OK;
+                }).Get());
 
-    HRESULT  v = handle(nullptr, tmpPathWide, nullptr,
+            mWebViewWnd->add_WebMessageReceived(
+              Callback<ICoreWebView2WebMessageReceivedEventHandler>(
+                [this](ICoreWebView2* sender, ICoreWebView2WebMessageReceivedEventArgs* args) {
+                  wil::unique_cotaskmem_string jsonString;
+                  args->get_WebMessageAsJson(&jsonString);
+                  std::wstring jsonWString = jsonString.get();
+                  WDL_String cStr;
+                  UTF16ToUTF8(cStr, jsonWString.c_str());
+                  OnMessageFromWebView(cStr.Get());
+                  return S_OK;
+                }).Get(), &mWebMessageReceivedToken);
 
-      Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
-        [&, hWnd, x, y, w, h](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
-          env->CreateCoreWebView2Controller(hWnd,
-            Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
-              [&, hWnd, x, y, w, h](HRESULT result, ICoreWebView2Controller* controller) -> HRESULT {
-                if (controller != nullptr) {
-                  mWebViewCtrlr = controller;
-                  mWebViewCtrlr->get_CoreWebView2(&mWebViewWnd);
-                }
+            mWebViewWnd->add_NavigationCompleted(
+              Callback<ICoreWebView2NavigationCompletedEventHandler>(
+                [this](ICoreWebView2* sender, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
+                  BOOL success;
+                  args->get_IsSuccess(&success);
+                  if (success)
+                  {
+                    OnWebContentLoaded();
+                  }
+                  return S_OK;
+                })
+              .Get(), &mNavigationCompletedToken);
 
-                ICoreWebView2Settings* Settings;
-                mWebViewWnd->get_Settings(&Settings);
-                Settings->put_IsScriptEnabled(TRUE);
-                Settings->put_AreDefaultScriptDialogsEnabled(TRUE);
-                Settings->put_IsWebMessageEnabled(TRUE);
-
-                // this script adds a function IPlugSendMsg that is used to call the platform webview messaging function in JS
-                mWebViewWnd->AddScriptToExecuteOnDocumentCreated(L"function IPlugSendMsg(m) {window.chrome.webview.postMessage(m)};",
-                  Callback<ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler>(
-                    [this](HRESULT error, PCWSTR id) -> HRESULT {
-                      return S_OK;
-                    }).Get());
-
-                mWebViewWnd->add_WebMessageReceived(
-                  Callback<ICoreWebView2WebMessageReceivedEventHandler>(
-                    [this](ICoreWebView2* sender, ICoreWebView2WebMessageReceivedEventArgs* args) {
-                      wil::unique_cotaskmem_string jsonString;
-                      args->get_WebMessageAsJson(&jsonString);
-                      std::wstring jsonWString = jsonString.get();
-                      WDL_String cStr;
-                      UTF16ToUTF8(cStr, jsonWString.c_str());
-                      OnMessageFromWebView(cStr.Get());
-                      return S_OK;
-                    }).Get(), &mWebMessageReceivedToken);
-
-                mWebViewWnd->add_NavigationCompleted(
-                  Callback<ICoreWebView2NavigationCompletedEventHandler>(
-                    [this](ICoreWebView2* sender, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
-                      BOOL success;
-                      args->get_IsSuccess(&success);
-                      if (success)
-                      {
-                        OnWebContentLoaded();
-                      }
-                      return S_OK;
-                    })
-                  .Get(), &mNavigationCompletedToken);
-
-                mWebViewCtrlr->put_Bounds({ (LONG)x, (LONG)y, (LONG)(x + w), (LONG)(y + h) });
-                OnWebViewReady();
-                return S_OK;
-              }).Get());
-          return S_OK;
-        }).Get());
-  }
+            mWebViewCtrlr->put_Bounds({ (LONG)x, (LONG)y, (LONG)(x + w), (LONG)(y + h) });
+            OnWebViewReady();
+            return S_OK;
+          }).Get());
+      return S_OK;
+    }).Get());
 
   return nullptr;
 }

--- a/IPlug/Extras/WebView/IPlugWebView.h
+++ b/IPlug/Extras/WebView/IPlugWebView.h
@@ -72,13 +72,6 @@ public:
   
   /** When a script in the web view posts a message, it will arrive as a UTF8 json string here */
   virtual void OnMessageFromWebView(const char* json) {}
-
-#if defined OS_WIN
-  /** Set the paths required for the Windows ICoreWebView2 component
-   * @param dllPath (Windows only) an absolute path to the WebView2Loader.dll that is required to use the WebView2 on windows
-   * @param tmpPath (Windows only) an absolute path to the folder that should be used */
-  void SetWebViewPaths(const char* dllPath, const char* tmpPath) { mDLLPath.Set(dllPath); mTmpPath.Set(tmpPath); }
-#endif
   
 private:
   bool mOpaque = true;
@@ -91,8 +84,6 @@ private:
   wil::com_ptr<ICoreWebView2> mWebViewWnd;
   EventRegistrationToken mWebMessageReceivedToken;
   EventRegistrationToken mNavigationCompletedToken;
-  WDL_String mDLLPath;
-  WDL_String mTmpPath;
   HMODULE mDLLHandle = nullptr;
 #endif
 };

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -143,6 +143,12 @@ void INIPath(WDL_String& path, const char * pluginName)
   path.AppendFormatted(MAX_WIN32_PATH_LEN, "\\%s", pluginName);
 }
 
+void WebViewCachePath(WDL_String& path)
+{
+  GetKnownFolder(path, CSIDL_APPDATA);
+  path.Append("\\iPlug2\\WebViewCache"); // tmp
+}
+
 static BOOL EnumResNameProc(HANDLE module, LPCTSTR type, LPTSTR name, LONG_PTR param)
 {
   if (IS_INTRESOURCE(name)) return true; // integer resources not wanted

--- a/IPlug/IPlugPaths.h
+++ b/IPlug/IPlugPaths.h
@@ -71,6 +71,9 @@ extern void VST3PresetsPath(WDL_String& path, const char* mfrName, const char* p
  * @param pluginName CString to specify the plug-in name (BUNDLE_NAME from config.h can be used here) */
 extern void INIPath(WDL_String& path, const char* pluginName);
 
+/** Get the path to the folder where the Plug-in's ICoreWebView2 userdata folder should be (Windows WebView only)*/
+extern void WebViewCachePath(WDL_String& path);
+
 /** Find the absolute path of a resource based on it's file name (e.g. “background.png”) and type (e.g. “png”), or in the case of windows,
  * confirm the existence of a particular resource in the binary. If it fails to find the resource with the binary it will test the fileNameOrResID argument
  * as an absolute path, to see if the file exists in that place.


### PR DESCRIPTION
This PR changes the example projects using the MS ICoreWebView2 to link statically. It adapts the IWebView and IWebViewControl interfaces so that they are not passed paths to the dll or tmp folder.