### PR TITLE
makeRasterImage() needed whether CPU or GPU rendering

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -78,9 +78,7 @@ IGraphicsSkia::Bitmap::Bitmap(const char* path, double sourceScale)
   
   auto image = SkImage::MakeFromEncoded(data);
   
-#ifdef IGRAPHICS_CPU
   image = image->makeRasterImage();
-#endif
   
   mDrawable.mImage = image;
   
@@ -93,9 +91,7 @@ IGraphicsSkia::Bitmap::Bitmap(const void* pData, int size, double sourceScale)
   auto data = SkData::MakeWithoutCopy(pData, size);
   auto image = SkImage::MakeFromEncoded(data);
   
-#ifdef IGRAPHICS_CPU
   image = image->makeRasterImage();
-#endif
   
   mDrawable.mImage = image;
 
@@ -105,11 +101,7 @@ IGraphicsSkia::Bitmap::Bitmap(const void* pData, int size, double sourceScale)
 
 IGraphicsSkia::Bitmap::Bitmap(sk_sp<SkImage> image, double sourceScale)
 {
-#ifdef IGRAPHICS_CPU
   mDrawable.mImage = image->makeRasterImage();
-#else
-  mDrawable.mImage = image;
-#endif
 
   SetBitmap(&mDrawable, mDrawable.mImage->width(), mDrawable.mImage->height(), sourceScale, 1.f);
 }


### PR DESCRIPTION
There appears to be an especially-large performance hit on GPU if controls overlap on screen.

Here are some instructions for a good PR

* [create an issue](https://github.com/iPlug2/iPlug2/issues/new/choose) first to outline the problem, to reference in this PR
This PR fixes problem described in #955 
* clearly describe the problem that the PR fixes
Performance is impacted when drawing bitmaps, especially controls with bitmap stacks, and even more especially if controls overlap (with associated extra draws/redraws)
* each PR should address one thing. It can include multiple commits, but you should try and tidy up work done into logical units if possible.
This is the smallest possible PR to address this bug - we literally just stop conditionally rasterizing only for CPU rendering.
* pay attention to [iplug2 coding style](https://github.com/iPlug2/iPlug2/blob/master/Documentation/codingstyle.md)
* If it applies to an option e.g. IGRAPHICS_NANOVG or VST3 plug-ins, try to provide fixes for all options (e.g. all graphics backends or all plug-in formats)

If you follow these rules, it is more likely we will consider your PR, but please don't be upset if we decide we don't want to merge your work.

thanks, we like PRs!

oli & alex