### PR TITLE
Add IContainerBase for child IControls

### DIFF
--- a/Examples/IPlugControls/IPlugControls.cpp
+++ b/Examples/IPlugControls/IPlugControls.cpp
@@ -203,7 +203,7 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
     pGraphics->AttachControl(new IVDisplayControl(nextCell(), "IVDisplayControl", style, EDirection::Vertical, -1., 1., 0., 512), kCtrlTagDisplay, "vcontrols");
     pGraphics->AttachControl(new IVLabelControl(nextCell().SubRectVertical(3, 0).GetMidVPadded(10.f), "IVLabelControl"), kNoTag, "vcontrols");
     pGraphics->AttachControl(new IVColorSwatchControl(sameCell().SubRectVertical(3, 1), "IVColorSwatchControl", [](int, IColor){}, style, IVColorSwatchControl::ECellLayout::kHorizontal, {kX1, kX2, kX3}, {"", "", ""}), kNoTag, "vcontrols");
-    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(3, 2), kParamGain, nullptr, "IVNumberBoxControl", style), kNoTag, "vcontrols");
+    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(3, 2), kParamGain, nullptr, "IVNumberBoxControl", style, true, 50.f, 1.f, 100.f, "%0.0f", false), kNoTag, "vcontrols");
     pGraphics->AttachControl(new IVPlotControl(nextCell(), {{COLOR_RED,  [](double x){ return std::sin(x * 6.2);} },
                                                             {COLOR_BLUE, [](double x){ return std::cos(x * 6.2);} },
                                                             {COLOR_GREEN, [](double x){ return x > 0.5;} }
@@ -429,7 +429,7 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
       });
     };
     
-    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(5, 3), kNoParameter, setLabelTextSize, "Label Text Size", style, (double) style.labelText.mSize, 12., 100.));
+    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(5, 3).FracRectHorizontal(0.5f), kNoParameter, setLabelTextSize, "Label", style, false, (double) style.labelText.mSize, 12., 100.));
     
     auto setValueTextSize = [pGraphics](IControl* pCaller) {
       float newSize = (float) pCaller->As<IVNumberBoxControl>()->GetRealValue();
@@ -443,7 +443,7 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
       });
     };
     
-    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(5, 4), kNoParameter, setValueTextSize, "Value Text Size", style, (double) style.valueText.mSize, 12., 100.));
+    pGraphics->AttachControl(new IVNumberBoxControl(sameCell().SubRectVertical(5, 3).FracRectHorizontal(0.5f, true), kNoParameter, setValueTextSize, "Value", style, false, (double) style.valueText.mSize, 12., 100.));
 
     auto promptLabelFont = [pGraphics](IControl* pCaller) {
       auto completionHandler = [pGraphics](const WDL_String& fileName, const WDL_String& path) {
@@ -466,7 +466,7 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
       pGraphics->PromptForFile(fileName, path, EFileAction::Open, "ttf", completionHandler);
     };
     
-    pGraphics->AttachControl(new IVButtonControl(nextCell().SubRectVertical(5, 1), SplashClickActionFunc, "Choose label font...", style))->SetAnimationEndActionFunction(promptLabelFont);
+    pGraphics->AttachControl(new IVButtonControl(sameCell().SubRectVertical(5, 4).FracRectHorizontal(0.5f), SplashClickActionFunc, "font...", style.WithDrawShadows(false)))->SetAnimationEndActionFunction(promptLabelFont);
     
     auto promptValueFont = [pGraphics](IControl* pCaller) {
       auto completionHandler = [pGraphics](const WDL_String& fileName, const WDL_String& path){
@@ -490,7 +490,7 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
       pGraphics->PromptForFile(fileName, path, EFileAction::Open, "ttf", completionHandler);
     };
     
-    pGraphics->AttachControl(new IVButtonControl(sameCell().SubRectVertical(5, 2), SplashClickActionFunc, "Choose value font...", style))->SetAnimationEndActionFunction(promptValueFont);
+    pGraphics->AttachControl(new IVButtonControl(sameCell().SubRectVertical(5, 4).FracRectHorizontal(0.5f, true), SplashClickActionFunc, "font...", style.WithDrawShadows(false)))->SetAnimationEndActionFunction(promptValueFont);
   };
 #endif
 }

--- a/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
+++ b/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
@@ -45,11 +45,11 @@ IPlugOSCEditor::IPlugOSCEditor(const InstanceInfo& info)
     pGraphics->AttachControl(new IVLabelControl(topRow.SubRectHorizontal(3, 0).GetPadded(-10.f), "Send IP", DEFAULT_STYLE.WithValueText(DEFAULT_LABEL_TEXT).WithDrawShadows(false)));
     pGraphics->AttachControl(new IEditableTextControl(topRow.SubRectHorizontal(3, 0).GetPadded(-10.f).GetFromBottom(44.f), "127.0.0.1"), kCtrlTagSendIP)->SetActionFunction(setSendIPAndPort)->SetTextEntryLength(32);
     
-    pGraphics->AttachControl(new IVNumberBoxControl(topRow.SubRectHorizontal(3, 1).GetPadded(-10.f), kNoParameter, setSendIPAndPort, "Send Port", DEFAULT_STYLE, 8001, 4000, 10000), kCtrlTagSendPort);
+    pGraphics->AttachControl(new IVNumberBoxControl(topRow.SubRectHorizontal(3, 1).GetPadded(-10.f), kNoParameter, setSendIPAndPort, "Send Port", DEFAULT_STYLE, true, 8001, 4000, 10000, "%0.0f", false), kCtrlTagSendPort);
     
     pGraphics->AttachControl(new IVNumberBoxControl(topRow.SubRectHorizontal(3, 2).GetPadded(-10.f), kNoParameter, [&](IControl* pCaller){
       SetReceivePort(static_cast<int>(pCaller->As<IVNumberBoxControl>()->GetRealValue()));
-    }, "Receive Port", DEFAULT_STYLE, 8000, 4000, 10000));
+    }, "Receive Port", DEFAULT_STYLE, true, 8000, 4000, 10000, "%0.0f", false));
     
     pGraphics->AttachControl(new IVKnobControl(b.GetCentredInside(100), [&](IControl* pCaller) {
                                                 OscMessageWrite msg;

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -424,12 +424,12 @@ protected:
 };
 
 /** A panel control which can be styled with emboss etc. */
-class IVPanelControl : public IControl
+class IVPanelControl : public IContainerBase
                      , public IVectorBase
 {
 public:
   IVPanelControl(const IRECT& bounds, const char* label = "", const IVStyle& style = DEFAULT_STYLE.WithColor(kFG, COLOR_TRANSLUCENT).WithEmboss(true))
-  : IControl(bounds)
+  : IContainerBase(bounds)
   , IVectorBase(style)
   {
     mIgnoreMouse = true;
@@ -448,10 +448,19 @@ public:
   {
     DrawPressableRectangle(g, mWidgetBounds, false, false, false);
   }
+
+  void OnAttached() override
+  {
+    if (mAttachFunc)
+      mAttachFunc(this, mWidgetBounds);
+  }
   
   void OnResize() override
   {
     SetTargetRECT(MakeRects(mRECT));
+
+    if (mResizeFunc && mChildren.GetSize())
+      mResizeFunc(this, mWidgetBounds);
   }
 };
 

--- a/IGraphics/Controls/IVNumberBoxControl.h
+++ b/IGraphics/Controls/IVNumberBoxControl.h
@@ -21,20 +21,24 @@ BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 
 /** A "meta control" for a number box with an Inc/Dec button
- * It adds several child buttons 
+ * It adds several child buttons if buttons = true
  * @ingroup IControls */
-class IVNumberBoxControl : public IControl
+class IVNumberBoxControl : public IContainerBase
                          , public IVectorBase
 {
 public:
-  IVNumberBoxControl(const IRECT& bounds, int paramIdx = kNoParameter, IActionFunction actionFunc = nullptr, const char* label = "", const IVStyle& style = DEFAULT_STYLE, double defaultValue = 50.f, double minValue = 1.f, double maxValue = 100.f, const char* fmtStr = "%0.0f")
-  : IControl(bounds, paramIdx, actionFunc)
+  IVNumberBoxControl(const IRECT& bounds, int paramIdx = kNoParameter, IActionFunction actionFunc = nullptr, const char* label = "", const IVStyle& style = DEFAULT_STYLE, bool buttons = false, double defaultValue = 50.f, double minValue = 1.f, double maxValue = 100.f, const char* fmtStr = "%0.0f", bool drawTriangle = true)
+  : IContainerBase(bounds, paramIdx, actionFunc)
   , IVectorBase(style.WithDrawShadows(false)
-                .WithValueText(style.valueText.WithVAlign(EVAlign::Middle)))
+                .WithDrawFrame(true)
+                .WithValueText(style.valueText.WithVAlign(EVAlign::Middle))
+                .WithLabelText(style.labelText.WithVAlign(EVAlign::Middle)))
   , mFmtStr(fmtStr)
+  , mButtons(buttons)
   , mMinValue(minValue)
   , mMaxValue(maxValue)
   , mRealValue(defaultValue)
+  , mDrawTriangle(drawTriangle)
   {
     assert(defaultValue >= minValue && defaultValue <= maxValue);
     
@@ -43,7 +47,7 @@ public:
    
   void OnInit() override
   {
-    if(GetParam())
+    if (GetParam())
     {
       mMinValue = GetParam()->GetMin();
       mMaxValue = GetParam()->GetMax();
@@ -55,21 +59,37 @@ public:
   {
     DrawLabel(g);
     
-    if(mMouseIsOver)
+    if (mMouseIsOver)
       g.FillRect(GetColor(kHL), mTextReadout->GetRECT());
+    
+    if (mMouseIsDown)
+      g.FillRect(GetColor(kFG), mTextReadout->GetRECT());
+    
+    if (mDrawTriangle)
+    {
+      auto triangleRect = mTextReadout->GetRECT().GetPadded(-2.0f);
+      
+      g.FillTriangle(GetColor(mMouseIsOver ? kX1 : kSH), triangleRect.L, triangleRect.T, triangleRect.L + triangleRect.H(), triangleRect.MH(), triangleRect.L, triangleRect.B);
+    }
   }
   
   void OnResize() override
   {
     MakeRects(mRECT, false);
     
-    if(mIncButton && mDecButton)
+    IRECT sections = mWidgetBounds;
+    sections.Pad(-1.f);
+  
+    if (mTextReadout)
     {
-      IRECT sections = mWidgetBounds;
-      mTextReadout->SetTargetAndDrawRECTs(sections.ReduceFromLeft(sections.W() * 0.75f));
-      sections.Pad(-1.f, 1.f, 0.f, 1.f);
-      mIncButton->SetTargetAndDrawRECTs(sections.FracRectVertical(0.5f, true));
-      mDecButton->SetTargetAndDrawRECTs(sections.FracRectVertical(0.5f, false));
+      mTextReadout->SetTargetAndDrawRECTs(sections.ReduceFromLeft(sections.W() * (mButtons ? 0.75f : 1.f)));
+      
+      if (mButtons)
+      {
+        mIncButton->SetTargetAndDrawRECTs(sections.FracRectVertical(0.5f, true).GetPadded(-2.f, 0.f, 0.f, -1.f));
+        mDecButton->SetTargetAndDrawRECTs(sections.FracRectVertical(0.5f, false).GetPadded(-2.f, -1.f, 0.f, 0.f));
+      }
+      
       SetTargetRECT(mTextReadout->GetRECT());
     }
   }
@@ -77,13 +97,17 @@ public:
   void OnAttached() override
   {
     IRECT sections = mWidgetBounds;
-    GetUI()->AttachControl(mTextReadout = new IVLabelControl(sections.ReduceFromLeft(sections.W() * 0.75f), "0", mStyle.WithDrawFrame(true)));
+    sections.Pad(-1.f);
+
+    AddChildControl(mTextReadout = new IVLabelControl(sections.ReduceFromLeft(sections.W() * (mButtons ? 0.75f : 1.f)), "0", mStyle.WithDrawFrame(true)));
     
     mTextReadout->SetStrFmt(32, mFmtStr.Get(), mRealValue);
-    
-    sections.Pad(-1.f, 1.f, 0.f, 1.f);
-    GetUI()->AttachControl(mIncButton = new IVButtonControl(sections.FracRectVertical(0.5f, true), SplashClickActionFunc, "+", mStyle))->SetAnimationEndActionFunction(mIncrementFunc);
-    GetUI()->AttachControl(mDecButton = new IVButtonControl(sections.FracRectVertical(0.5f, false), SplashClickActionFunc, "-", mStyle))->SetAnimationEndActionFunction(mDecrementFunc);
+
+    if (mButtons)
+    {
+      AddChildControl(mIncButton = new IVButtonControl(sections.FracRectVertical(0.5f, true).GetPadded(-2.f, 0.f, 0.f, -1.f), SplashClickActionFunc, "+", mStyle))->SetAnimationEndActionFunction(mIncrementFunc);
+      AddChildControl(mDecButton = new IVButtonControl(sections.FracRectVertical(0.5f, false).GetPadded(-2.f, -1.f, 0.f, 0.f), SplashClickActionFunc, "-", mStyle))->SetAnimationEndActionFunction(mDecrementFunc);
+    }
   }
   
   void OnMouseDown(float x, float y, const IMouseMod &mod) override
@@ -91,8 +115,10 @@ public:
     if (mHideCursorOnDrag)
       GetUI()->HideMouseCursor(true, true);
 
-    if(GetParam())
+    if (GetParam())
       GetDelegate()->BeginInformHostOfParamChangeFromUI(GetParamIdx());
+    
+    mMouseIsDown = true;
   }
   
   void OnMouseUp(float x, float y, const IMouseMod &mod) override
@@ -100,8 +126,12 @@ public:
     if (mHideCursorOnDrag)
       GetUI()->HideMouseCursor(false);
     
-    if(GetParam())
+    if (GetParam())
       GetDelegate()->EndInformHostOfParamChangeFromUI(GetParamIdx());
+    
+    mMouseIsDown = false;
+    
+    SetDirty(true);
   }
   
   void OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod &mod) override
@@ -113,7 +143,7 @@ public:
   
   void OnMouseDblClick(float x, float y, const IMouseMod &mod) override
   {
-    if(mTextReadout->GetRECT().Contains(x, y))
+    if (!IsDisabled() && mTextReadout->GetRECT().Contains(x, y))
       GetUI()->CreateTextEntry(*this, mText, mTextReadout->GetRECT(), mTextReadout->GetStr());
   }
   
@@ -133,7 +163,7 @@ public:
   
   void SetValueFromDelegate(double value, int valIdx = 0) override
   {
-    if(GetParam())
+    if (GetParam())
     {
       mRealValue = GetParam()->FromNormalized(value);
       OnValueChanged(true);
@@ -144,7 +174,7 @@ public:
   
   void SetValueFromUserInput(double value, int valIdx = 0) override
   {
-    if(GetParam())
+    if (GetParam())
     {
       mRealValue = GetParam()->FromNormalized(value);
       OnValueChanged(true);
@@ -157,8 +187,12 @@ public:
   {
     IVectorBase::SetStyle(style);
     mTextReadout->SetStyle(style);
-    mIncButton->SetStyle(style);
-    mDecButton->SetStyle(style);
+    
+    if (mButtons)
+    {
+      mIncButton->SetStyle(style);
+      mDecButton->SetStyle(style);
+    }
   }
   
   bool IsFineControl(const IMouseMod& mod, bool wheel) const
@@ -180,13 +214,15 @@ public:
     
     mTextReadout->SetStrFmt(32, mFmtStr.Get(), mRealValue);
     
-    if(!preventAction && GetParam())
+    if (!preventAction && GetParam())
       SetValue(GetParam()->ToNormalized(mRealValue));
     
     SetDirty(!preventAction);
   }
   
   double GetRealValue() const { return mRealValue; }
+  
+  void SetDrawTriangle(bool draw) { mDrawTriangle = draw; SetDirty(false); }
   
 protected:
   
@@ -202,6 +238,9 @@ protected:
   double mMaxValue;
   double mRealValue = 0.f;
   bool mHideCursorOnDrag = true;
+  bool mButtons = false;
+  bool mDrawTriangle = true;
+  bool mMouseIsDown = false;
 };
 
 END_IGRAPHICS_NAMESPACE

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -37,6 +37,8 @@
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 
+class IContainerBase;
+
 /** The lowest level base class of an IGraphics control. A control is anything on the GUI 
 *  @ingroup BaseControls */
 class IControl
@@ -452,6 +454,11 @@ public:
     OnRescale();
   }
   
+  /** @return A pointer to the parent container, if the control is a sub control */
+  IContainerBase* GetParent() const { return mParent; }
+  
+  void SetParent(IContainerBase* pParent) { mParent = pParent; }
+  
   /** @return A pointer to the IGraphics context that owns this control */ 
   IGraphics* GetUI() { return mGraphics; }
     
@@ -524,7 +531,7 @@ protected:
         func(v, args...);
     }
   }
-    
+  
   IRECT mRECT;
   IRECT mTargetRECT;
   
@@ -567,6 +574,7 @@ protected:
 #endif
   
 private:
+  IContainerBase* mParent = nullptr;
   IGEditorDelegate* mDelegate = nullptr;
   IGraphics* mGraphics = nullptr;
   IActionFunction mActionFunc = nullptr;
@@ -585,6 +593,122 @@ private:
  * \addtogroup BaseControls
  * @{
  */
+
+/** IContainerBase allows a control to nest sub controls and it clips the drawing of those subcontrols
+ * Inheritors can add child controls by overriding OnAttached() and calling AddChildControl(), or passing in an AttachFunc lambda to the construtor.
+ * Child controls should not have been added elsewhere
+ * OnResized() should also be overriden if the control bounds will change (can also be specified in a ResizeFunc lambda) */
+class IContainerBase : public IControl
+{
+public:
+  using AttachFunc = std::function<void(IContainerBase* pContainer, const IRECT& bounds)>;
+  using ResizeFunc = std::function<void(IContainerBase* pContainer, const IRECT& bounds)>;
+  
+  IContainerBase(const IRECT& bounds, int paramIdx = kNoParameter, IActionFunction actionFunc = nullptr)
+  : IControl(bounds, paramIdx, actionFunc)
+  {}
+  
+  IContainerBase(const IRECT& bounds, const std::initializer_list<int>& params, IActionFunction actionFunc = nullptr)
+  : IControl(bounds, params, actionFunc)
+  {}
+  
+  IContainerBase(const IRECT& bounds, IActionFunction actionFunc)
+  : IControl(bounds, actionFunc)
+  {}
+  
+  IContainerBase(const IRECT& bounds, AttachFunc attachFunc, ResizeFunc resizeFunc)
+  : IControl(bounds)
+  , mAttachFunc(attachFunc)
+  , mResizeFunc(resizeFunc)
+  {
+    mIgnoreMouse = true;
+  }
+  
+  void SetAttachFunc(AttachFunc attachFunc)
+  {
+    mAttachFunc = attachFunc;
+  }
+  
+  void SetResizeFunc(ResizeFunc resizeFunc)
+  {
+    mResizeFunc = resizeFunc;
+  }
+  
+  virtual void Draw(IGraphics& g) override
+  {
+    /* NO-OP */
+  }
+  
+  virtual ~IContainerBase()
+  {
+    mChildren.Empty(false);
+  }
+  
+  virtual void OnAttached() override
+  {
+    if (mAttachFunc)
+      mAttachFunc(this, mRECT);
+    
+    OnResize();
+  }
+  
+  virtual void OnResize() override
+  {
+    if (mResizeFunc && mChildren.GetSize())
+      mResizeFunc(this, mRECT);
+  }
+  
+  void SetDisabled(bool disable) override
+  {
+    ForAllChildrenFunc([disable](int childIdx, IControl* pChild) {
+      pChild->SetDisabled(disable);
+    });
+
+    IControl::SetDisabled(disable);
+  }
+
+  void Hide(bool hide) override
+  {
+    ForAllChildrenFunc([hide](int childIdx, IControl* pChild) {
+      pChild->Hide(hide);
+    });
+    
+    IControl::Hide(hide);
+  }
+  
+  IControl* AddChildControl(IControl* pControl, int ctrlTag = kNoTag, const char* group = "")
+  {
+    pControl->SetParent(this);
+    return mChildren.Add(GetUI()->AttachControl(pControl, ctrlTag, group));
+  }
+  
+  void RemoveChildControl(IControl* pControl)
+  {
+    pControl->SetParent(nullptr);
+    mChildren.DeletePtr(pControl, false);
+    GetUI()->RemoveControl(pControl);
+  }
+  
+  IControl* GetChild(int idx)
+  {
+    return mChildren.Get(idx);
+  }
+  
+  int NChildren() const { return mChildren.GetSize(); }
+  
+  void ForAllChildrenFunc(std::function<void(int childIdx, IControl* pControl)> func)
+  {
+    for (int i=0; i<mChildren.GetSize(); i++)
+    {
+      func(i, mChildren.Get(i));
+    }
+  }
+  
+protected:
+  AttachFunc mAttachFunc = nullptr;
+  ResizeFunc mResizeFunc = nullptr;
+  WDL_PtrList<IControl> mChildren;
+};
 
 /** A base interface to be combined with IControl for bitmap-based controls "IBControls", managing an IBitmap */
 class IBitmapBase
@@ -1733,7 +1857,7 @@ protected:
  * If only one path is added there will be no submenu. When you call SetupMenu() the added paths are scanned and any
  * matching files in those paths are added to the menu.
  */
-class IDirBrowseControlBase : public IControl
+class IDirBrowseControlBase : public IContainerBase
 {
 public:
   /** Creates an IDirBrowseControlBase
@@ -1741,7 +1865,7 @@ public:
    * @param extension The file extenstion to browse for, e.g excluding the dot e.g. "txt"
    * @param showFileExtension Should the menu show the file extension */
   IDirBrowseControlBase(const IRECT& bounds, const char* extension, bool showFileExtensions = true)
-  : IControl(bounds)
+  : IContainerBase(bounds)
   , mShowFileExtensions(showFileExtensions)
   {
     mExtension.Set(extension);

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -1921,19 +1921,21 @@ protected:
  */
 
 /** A basic control to fill a rectangle with a color or gradient */
-class IPanelControl : public IControl
+class IPanelControl : public IContainerBase
 {
 public:
-  IPanelControl(const IRECT& bounds, const IColor& color, bool drawFrame = false)
-  : IControl(bounds, kNoParameter)
+  IPanelControl(const IRECT& bounds, const IColor& color, bool drawFrame = false,
+                AttachFunc attachFunc = nullptr, ResizeFunc resizeFunc = nullptr)
+  : IContainerBase(bounds, attachFunc, resizeFunc)
   , mPattern(color)
   , mDrawFrame(drawFrame)
   {
     mIgnoreMouse = true;
   }
   
-  IPanelControl(const IRECT& bounds, const IPattern& pattern, bool drawFrame = false)
-  : IControl(bounds, kNoParameter)
+  IPanelControl(const IRECT& bounds, const IPattern& pattern, bool drawFrame = false,
+                AttachFunc attachFunc = nullptr, ResizeFunc resizeFunc = nullptr)
+  : IContainerBase(bounds, attachFunc, resizeFunc)
   , mPattern(pattern)
   , mDrawFrame(drawFrame)
   {

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -203,25 +203,22 @@ void IGraphics::RemoveAllControls()
   mControls.Empty(true);
 }
 
-void IGraphics::SetControlPosition(int idx, float x, float y)
+void IGraphics::SetControlPosition(IControl* pControl, float x, float y)
 {
-  IControl* pControl = GetControl(idx);
   pControl->SetPosition(x, y);
   if (!pControl->IsHidden())
     SetAllControlsDirty();
 }
 
-void IGraphics::SetControlSize(int idx, float w, float h)
+void IGraphics::SetControlSize(IControl* pControl, float w, float h)
 {
-  IControl* pControl = GetControl(idx);
   pControl->SetSize(w, h);
   if (!pControl->IsHidden())
     SetAllControlsDirty();
 }
 
-void IGraphics::SetControlBounds(int idx, const IRECT& r)
+void IGraphics::SetControlBounds(IControl* pControl, const IRECT& r)
 {
-  IControl* pControl = GetControl(idx);
   pControl->SetTargetAndDrawRECTs(r);
   if (!pControl->IsHidden())
     SetAllControlsDirty();
@@ -813,7 +810,14 @@ bool IGraphics::IsDirty(IRECTList& rects)
     if (pControl->IsDirty())
     {
       // N.B padding outlines for single line outlines
-      rects.Add(pControl->GetRECT().GetPadded(0.75));
+      auto rectToAdd = pControl->GetRECT().GetPadded(0.75);
+      
+      if (pControl->GetParent())
+      {
+        rectToAdd.Clank(pControl->GetParent()->GetRECT().GetPadded(0.75));
+      }
+      
+      rects.Add(rectToAdd);
       dirty = true;
     }
   };
@@ -857,6 +861,20 @@ void IGraphics::DrawControl(IControl* pControl, const IRECT& bounds, float scale
 
     if (clipBounds.W() <= 0.0 || clipBounds.H() <= 0)
       return;
+    
+    IControl* pParent = pControl->GetParent();
+    
+    while (pParent)
+    {
+      IRECT parentBounds = pParent->GetRECT().GetPadded(0.75).GetPixelAligned(scale);
+
+      if(!clipBounds.Intersects(parentBounds))
+        return;
+
+      clipBounds.Clank(parentBounds);
+      
+      pParent = pParent->GetParent();
+    }
     
     PrepareRegion(clipBounds);
     pControl->Draw(*this);
@@ -1258,7 +1276,7 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
         }
 #ifndef NDEBUG
       }
-      else if (pControl->GetRECT().Contains(x, y))
+      else if (pControl->GetRECT().Contains(x, y) && pControl->GetParent() == nullptr)
       {
         return c;
       }
@@ -1290,6 +1308,7 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
   
   if (!pControl && mTextEntryControl && mTextEntryControl->EditInProgress())
     pControl = mTextEntryControl.get();
+  
   
 #if !defined(NDEBUG)
   if (!pControl && mLiveEdit)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1437,21 +1437,21 @@ public:
   void SetAllControlsClean();
     
   /** Reposition a control, redrawing the interface correctly
-   @param idx The index of the control
-   @param x The new x position
-   @param y The new y position */
-  void SetControlPosition(int idx, float x, float y);
+   * @param pControl The control
+   * @param x The new x position
+   * @param y The new y position */
+  void SetControlPosition(IControl* pControl, float x, float y);
   
   /** Resize a control, redrawing the interface correctly
-   @param idx The index of the control
-   @param w The new width
-   @param h The new height */
-  void SetControlSize(int idx, float w, float h);
+   * @param pControl The control
+   * @param w The new width
+   * @param h The new height */
+  void SetControlSize(IControl* pControl, float w, float h);
   
   /** Set a controls target and draw rect to r, redrawing the interface correctly
-   @param idx The index of the control 
-   @param r The new bounds for the control's target and draw rect */
-  void SetControlBounds(int idx, const IRECT& r);
+   * @param idx The index of the control
+   * @param r The new bounds for the control's target and draw rect */
+  void SetControlBounds(IControl* pControl, const IRECT& r);
   
 private:
   /** Get the index of the control at x and y coordinates on mouse event

--- a/IGraphics/IGraphicsLiveEdit.h
+++ b/IGraphics/IGraphicsLiveEdit.h
@@ -59,12 +59,12 @@ public:
       mMouseDownRECT = pControl->GetRECT();
       mMouseDownTargetRECT = pControl->GetTargetRECT();
 
-      if(!mod.S)
+      if (!mod.S)
         mSelectedControls.Empty();
       
       mSelectedControls.Add(pControl);
 
-      if(mod.A)
+      if (mod.A)
       {
         GetUI()->AttachControl(new PlaceHolder(mMouseDownRECT));
         mClickedOnControl = GetUI()->NControls() - 1;
@@ -79,13 +79,13 @@ public:
       {
         mClickedOnControl = c;
         
-        if(GetHandleRect(mMouseDownRECT).Contains(x, y))
+        if (GetHandleRect(mMouseDownRECT).Contains(x, y))
         {
           mMouseClickedOnResizeHandle = true;
         }
       }
     }
-    else if(mod.R)
+    else if (mod.R)
     {
       GetUI()->CreatePopupMenu(*this, mRightClickOutsideControlMenu, x, y);
     }
@@ -99,14 +99,14 @@ public:
   
   void OnMouseUp(float x, float y, const IMouseMod& mod) override
   {
-    if(mMouseClickedOnResizeHandle)
+    if (mMouseClickedOnResizeHandle)
     {
       IControl* pControl = GetUI()->GetControl(mClickedOnControl);
       IRECT r = pControl->GetRECT();
       float w = r.R - r.L;
       float h = r.B - r.T;
       
-      if(w < 0.f || h < 0.f)
+      if (w < 0.f || h < 0.f)
       {
         pControl->SetRECT(mMouseDownRECT);
         pControl->SetTargetRECT(mMouseDownTargetRECT);
@@ -131,7 +131,7 @@ public:
       IRECT cr = GetUI()->GetControl(c)->GetRECT();
       IRECT h = GetHandleRect(cr);
       
-      if(h.Contains(x, y))
+      if (h.Contains(x, y))
       {
         GetUI()->SetMouseCursor(ECursor::SIZENWSE);
         return;
@@ -148,27 +148,27 @@ public:
     float mouseDownX, mouseDownY;
     GetUI()->GetMouseDownPoint(mouseDownX, mouseDownY);
     
-    if(mClickedOnControl > 0)
+    if (mClickedOnControl > 0)
     {
       IControl* pControl = GetUI()->GetControl(mClickedOnControl);
       
-      if(mMouseClickedOnResizeHandle)
+      if (mMouseClickedOnResizeHandle)
       {
         IRECT r = pControl->GetRECT();
         r.R = SnapToGrid(mMouseDownRECT.R + (x - mouseDownX));
         r.B = SnapToGrid(mMouseDownRECT.B + (y - mouseDownY));
         
-        if(r.R < mMouseDownRECT.L +mGridSize) r.R = mMouseDownRECT.L+mGridSize;
-        if(r.B < mMouseDownRECT.T +mGridSize) r.B = mMouseDownRECT.T+mGridSize;
+        if (r.R < mMouseDownRECT.L +mGridSize) r.R = mMouseDownRECT.L+mGridSize;
+        if (r.B < mMouseDownRECT.T +mGridSize) r.B = mMouseDownRECT.T+mGridSize;
           
-        GetUI()->SetControlSize(mClickedOnControl, r.W(), r.H());
+        GetUI()->SetControlSize(pControl, r.W(), r.H());
       }
       else
       {
         const float x1 = SnapToGrid(mMouseDownRECT.L + (x - mouseDownX));
         const float y1 = SnapToGrid(mMouseDownRECT.T + (y - mouseDownY));
           
-        GetUI()->SetControlPosition(mClickedOnControl, x1, y1);
+        GetUI()->SetControlPosition(pControl, x1, y1);
       }
     }
     else
@@ -181,13 +181,13 @@ public:
       mDragRegion.B = y < mouseDownY ? mouseDownY : y;
       
       GetUI()->ForStandardControlsFunc([&](IControl* pControl) {
-                                         if(mDragRegion.Contains(pControl->GetRECT())) {
-                                           if(mSelectedControls.FindR(pControl) == -1)
+                                         if (mDragRegion.Contains(pControl->GetRECT())) {
+                                           if (mSelectedControls.FindR(pControl) == -1)
                                              mSelectedControls.Add(pControl);
                                          }
                                          else {
                                            int idx = mSelectedControls.FindR(pControl);
-                                           if(idx > -1)
+                                           if (idx > -1)
                                              mSelectedControls.Delete(idx);
                                          }
                                        });
@@ -198,11 +198,11 @@ public:
   {
     GetUI()->ReleaseMouseCapture();
     
-    if(key.VK == kVK_BACK || key.VK == kVK_DELETE)
+    if (key.VK == kVK_BACK || key.VK == kVK_DELETE)
     {
-      if(mSelectedControls.GetSize())
+      if (mSelectedControls.GetSize())
       {
-        for(int i = 0; i < mSelectedControls.GetSize(); i++)
+        for (int i = 0; i < mSelectedControls.GetSize(); i++)
         {
           IControl* pControl = mSelectedControls.Get(i);
           GetUI()->RemoveControl(pControl);
@@ -220,7 +220,7 @@ public:
   
   void OnPopupMenuSelection(IPopupMenu* pSelectedMenu, int valIdx) override
   {
-    if(pSelectedMenu && pSelectedMenu == &mRightClickOutsideControlMenu)
+    if (pSelectedMenu && pSelectedMenu == &mRightClickOutsideControlMenu)
     {
       auto idx = pSelectedMenu->GetChosenItemIdx();
       float x, y;
@@ -260,29 +260,32 @@ public:
     IBlend b {EBlend::Add, 0.25f};
     g.DrawGrid(mGridColor, g.GetBounds(), mGridSize, mGridSize, &b);
     
-    for(int i = 1; i < g.NControls(); i++)
+    for (int i = 1; i < g.NControls(); i++)
     {
       IControl* pControl = g.GetControl(i);
       IRECT cr = pControl->GetRECT();
-
-      if(pControl->IsHidden())
-        g.DrawDottedRect(COLOR_RED, cr);
-      else if(pControl->IsDisabled())
-        g.DrawDottedRect(COLOR_GREEN, cr);
-      else
-        g.DrawDottedRect(COLOR_BLUE, cr);
       
-      IRECT h = GetHandleRect(cr);
-      g.FillTriangle(mRectColor, h.L, h.B, h.R, h.B, h.R, h.T);
-      g.DrawTriangle(COLOR_BLACK, h.L, h.B, h.R, h.B, h.R, h.T);
+      if (!pControl->GetParent()) // don't allow reszing sub controls
+      {
+        if (pControl->IsHidden())
+          g.DrawDottedRect(COLOR_RED, cr);
+        else if (pControl->IsDisabled())
+          g.DrawDottedRect(COLOR_GREEN, cr);
+        else
+          g.DrawDottedRect(COLOR_BLUE, cr);
+        
+        IRECT h = GetHandleRect(cr);
+        g.FillTriangle(mRectColor, h.L, h.B, h.R, h.B, h.R, h.T);
+        g.DrawTriangle(COLOR_BLACK, h.L, h.B, h.R, h.B, h.R, h.T);
+      }
     }
     
-    for(int i = 0; i< mSelectedControls.GetSize(); i++)
+    for (int i = 0; i< mSelectedControls.GetSize(); i++)
     {
       g.DrawDottedRect(COLOR_WHITE, mSelectedControls.Get(i)->GetRECT());
     }
     
-    if(!mDragRegion.Empty())
+    if (!mDragRegion.Empty())
     {
       g.DrawDottedRect(COLOR_RED, mDragRegion);
     }

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -1412,8 +1412,8 @@ struct IRECT
       return IRECT(L, T, R, T + h);
   }
   
-  /** \todo 
-   * @param rhs \todo */
+  /** Clank will limit this IRECT's bounds based on the boundaries of the IRECT passed in as an argument
+   * @param rhs The rectangle to limit with  */
   void Clank(const IRECT& rhs)
   {
     if (L < rhs.L)


### PR DESCRIPTION
This PR Adds IContainerBase - an IControl base class that can have child controls. It adapts the IGraphics drawing code accordingly to handle clipping and adapts existing IControls that are better done with child controls