### PR TITLE
Move AAX automation indicator to target RECT

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -390,7 +390,7 @@ void IControl::DrawPTHighlight(IGraphics& g)
 {
   if (mPTisHighlighted)
   {
-    g.FillCircle(mPTHighlightColor, mRECT.R-5, mRECT.T+5, 2);
+    g.FillCircle(mPTHighlightColor, mTargetRECT.R-5, mTargetRECT.T+5, 2);
   }
 }
 


### PR DESCRIPTION
Bitmap controls may have larger bounds to accommodate shadows, reflections, etc. and placing the automation indicator at the bounds of the control can be confusing.

Here are some instructions for a good PR

* [create an issue](https://github.com/iPlug2/iPlug2/issues/new/choose) first to outline the problem, to reference in this PR
  See issue:#962
* clearly describe the problem that the PR fixes
  Allows developer to move AAX automation indicator closer to the actual control when the bounds of the control are larger to accommodate shadows, etc. in bitmaps.
* each PR should address one thing. It can include multiple commits, but you should try and tidy up work done into logical units if possible.
* pay attention to [iplug2 coding style](https://github.com/iPlug2/iPlug2/blob/master/Documentation/codingstyle.md)
* If it applies to an option e.g. IGRAPHICS_NANOVG or VST3 plug-ins, try to provide fixes for all options (e.g. all graphics backends or all plug-in formats)
  This change is graphics back-end agnostic.

If you follow these rules, it is more likely we will consider your PR, but please don't be upset if we decide we don't want to merge your work.

thanks, we like PRs!

oli & alex