### PR TITLE
Dismiss the view controller before handling the selection (see #965)

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -160,14 +160,14 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
 
   if (pItem->GetIsChoosable())
   {
+    [self dismissViewControllerAnimated:YES completion:nil];
+
     mMenu->SetChosenItemIdx(cellIndex);
     
     if (mMenu->GetFunction())
       mMenu->ExecFunction();
     
     mGraphics->SetControlValueAfterPopupMenu(mMenu);
-    
-    [self dismissViewControllerAnimated:YES completion:nil];
   }
 }
 


### PR DESCRIPTION
This PR fixes #965 by dismissing the menu before calling the handler - it is simply a code reordering and should not have any negative side-effects