### PR TITLE
AAX: Check that the parameter id is not kNoParameter before highlighting

### DIFF
--- a/IPlug/AAX/IPlugAAX.cpp
+++ b/IPlug/AAX/IPlugAAX.cpp
@@ -84,7 +84,11 @@ AAX_Result AAX_CEffectGUI_IPLUG::SetControlHighlightInfo(AAX_CParamID paramID, A
   {
     int paramIdx = atoi(paramID) - kAAXParamIdxOffset;
 
-    pViewInterface->SetPTParameterHighlight(paramIdx, (bool) iIsHighlighted, (int) iColor);
+    if (paramIdx != kNoParameter)
+    {
+      pViewInterface->SetPTParameterHighlight(paramIdx, (bool) iIsHighlighted, (int) iColor);
+    }
+    
     return AAX_SUCCESS;
   }
   


### PR DESCRIPTION
Fixes #961 as discussed in that issue.