### PR TITLE
Rework IOS text entry to allow cancelling (and with OK as default)

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -392,17 +392,6 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   mMTLLayer = nil;
 }
 
-- (void) textFieldDidEndEditing:(UITextField*) textField reason:(UITextFieldDidEndEditingReason) reason
-{
-  if(textField == mTextField)
-  {
-    mGraphics->SetControlValueAfterTextEdit([[mTextField text] UTF8String]);
-    mGraphics->SetAllControlsDirty();
-    
-    [self endUserInput];
-  }
-}
-
 - (BOOL) textFieldShouldReturn:(UITextField*) textField
 {
   if (textField == mTextField)
@@ -413,11 +402,6 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
     [self endUserInput];
   }
   return YES;
-}
-
-- (void) textFieldDidEndEditing:(UITextField*) textField
-{
-  [self endUserInput];
 }
 
 - (BOOL) textField:(UITextField*) textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString*) string
@@ -498,12 +482,26 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   
   mAlertController = [UIAlertController alertControllerWithTitle:@"Input a value:" message:@"" preferredStyle:UIAlertControllerStyleAlert];
 
-  UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-  [mAlertController addAction:okAction];
-  
-  UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:nil];
+  void (^cancelHandler)(UIAlertAction*) = ^(UIAlertAction *action)
+  {
+    self->mGraphics->SetAllControlsDirty();
+    [self endUserInput];
+  };
+    
+  UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:cancelHandler];
   [mAlertController addAction:cancelAction];
-  
+
+  void (^okHandler)(UIAlertAction*) = ^(UIAlertAction *action)
+  {
+    self->mGraphics->SetControlValueAfterTextEdit([[self->mTextField text] UTF8String]);
+    self->mGraphics->SetAllControlsDirty();
+    [self endUserInput];
+  };
+    
+  UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:okHandler];
+  [mAlertController addAction:okAction];
+  [mAlertController setPreferredAction:okAction];
+    
   __weak IGRAPHICS_VIEW* weakSelf = self;
   [mAlertController addTextFieldWithConfigurationHandler:^(UITextField* aTextField) {
     IGRAPHICS_VIEW* strongSelf = weakSelf;

--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -482,10 +482,13 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   
   mAlertController = [UIAlertController alertControllerWithTitle:@"Input a value:" message:@"" preferredStyle:UIAlertControllerStyleAlert];
 
+  __weak IGRAPHICS_VIEW* weakSelf = self;
+
   void (^cancelHandler)(UIAlertAction*) = ^(UIAlertAction *action)
   {
-    self->mGraphics->SetAllControlsDirty();
-    [self endUserInput];
+    __strong IGRAPHICS_VIEW* strongSelf = weakSelf;
+    strongSelf->mGraphics->SetAllControlsDirty();
+    [strongSelf endUserInput];
   };
     
   UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:cancelHandler];
@@ -493,18 +496,18 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
 
   void (^okHandler)(UIAlertAction*) = ^(UIAlertAction *action)
   {
-    self->mGraphics->SetControlValueAfterTextEdit([[self->mTextField text] UTF8String]);
-    self->mGraphics->SetAllControlsDirty();
-    [self endUserInput];
+    __strong IGRAPHICS_VIEW* strongSelf = weakSelf;
+    strongSelf->mGraphics->SetControlValueAfterTextEdit([[strongSelf->mTextField text] UTF8String]);
+    strongSelf->mGraphics->SetAllControlsDirty();
+    [strongSelf endUserInput];
   };
     
   UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:okHandler];
   [mAlertController addAction:okAction];
   [mAlertController setPreferredAction:okAction];
     
-  __weak IGRAPHICS_VIEW* weakSelf = self;
   [mAlertController addTextFieldWithConfigurationHandler:^(UITextField* aTextField) {
-    IGRAPHICS_VIEW* strongSelf = weakSelf;
+    __strong IGRAPHICS_VIEW* strongSelf = weakSelf;
     strongSelf->mTextField = aTextField;
     strongSelf->mTextFieldLength = length;
     aTextField.delegate = strongSelf;


### PR DESCRIPTION
This PR does three things:

1 - fixes #968 (so that cancel works) 
2 - puts the OK button on the right (and cancel on the left)
3 - sets OK as default (highlighted)x