### PR TITLE
macOS/iOS popup menus are centred on the selected item 

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -68,6 +68,19 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   [self.view addSubview:self.tableView];
 }
 
+- (void) viewDidAppear:(BOOL)animated
+{
+  auto selectedItemIdx = mMenu->GetChosenItemIdx();
+
+  if (selectedItemIdx > -1)
+  {
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:selectedItemIdx inSection:0];
+    [self.tableView scrollToRowAtIndexPath:indexPath
+                           atScrollPosition:UITableViewScrollPositionMiddle
+                             animated:NO];
+  }
+}
+
 - (id) initWithIPopupMenuAndIGraphics:(IPopupMenu*) pMenu :(IGraphicsIOS*) pGraphics
 {
   self = [super init];

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -1079,7 +1079,21 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
   NSMenu* pNSMenu = [[[IGRAPHICS_MENU alloc] initWithIPopupMenuAndReceiver:&menu : pDummyView] autorelease];
   NSPoint wp = {bounds.origin.x, bounds.origin.y + bounds.size.height + 4};
 
-  [pNSMenu popUpMenuPositioningItem:nil atLocation:wp inView:self];
+  NSMenuItem* pSelectedItem = nil;
+  
+  auto selectedItemIdx = menu.GetChosenItemIdx();
+
+  if (selectedItemIdx > -1)
+  {
+    pSelectedItem = [pNSMenu itemAtIndex:selectedItemIdx];
+  }
+  
+  if (pSelectedItem != nil)
+  {
+    wp = {bounds.origin.x, bounds.origin.y};
+  }
+  
+  [pNSMenu popUpMenuPositioningItem:pSelectedItem atLocation:wp inView:self];
   
   NSMenuItem* pChosenItem = [pDummyView menuItem];
   NSMenu* pChosenMenu = [pChosenItem menu];


### PR DESCRIPTION
This PR makes it so that on macOS and iOS when a platform popup menu is created, the selected item will be centred on the selection, which is much better when the list is long/goes offscreen. Unfortunately it seems windows doesn't have such functionality.

![image](https://github.com/iPlug2/iPlug2/assets/655662/1d13384c-3b3c-45ea-a813-90c3511b998a)
