### PR TITLE
IGraphics: Add default draw scale constants

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -48,8 +48,8 @@ IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 , mHeight(h)
 , mFPS(fps)
 , mDrawScale(scale)
-, mMinScale(scale / 2)
-, mMaxScale(scale * 2)
+, mMinScale(DEFAULT_MIN_DRAW_SCALE)
+, mMaxScale(DEFAULT_MAX_DRAW_SCALE)
 , mDelegate(&dlg)
 {
   StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
@@ -119,6 +119,12 @@ void IGraphics::Resize(int w, int h, float scale, bool needsPlatformResize)
 void IGraphics::SetLayoutOnResize(bool layoutOnResize)
 {
   mLayoutOnResize = layoutOnResize;
+}
+
+void IGraphics::SetScaleConstraints(float lo, float hi)
+{
+  mMinScale = std::min(lo, hi);
+  mMaxScale = std::max(lo, hi);
 }
 
 void IGraphics::RemoveControlWithTag(int ctrlTag)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1026,14 +1026,10 @@ public:
    * @param pMenu The menu that was clicked */
   void SetControlValueAfterPopupMenu(IPopupMenu* pMenu);
     
-  /** \todo 
-   * @param lo \todo
-   * @param hi \todo */
-  void SetScaleConstraints(float lo, float hi)
-  {
-    mMinScale = std::min(lo, hi);
-    mMaxScale = std::max(lo, hi);
-  }
+  /** Sets the minimum and maximum (draw) scaling values
+   * @param lo The minimum scalar that the IGraphics context can be scaled down to
+   * @param hi The maxiumum scalar that the IGraphics context can be scaled up to */
+  void SetScaleConstraints(float lo, float hi);
   
   /** \todo detailed description of how this works
    * @param w New width in pixels

--- a/IGraphics/IGraphicsConstants.h
+++ b/IGraphics/IGraphicsConstants.h
@@ -37,6 +37,9 @@ static constexpr int MAX_IMG_SCALE = 3;
 static constexpr int DEFAULT_TEXT_ENTRY_LEN = 7;
 static constexpr double DEFAULT_GEARING = 4.0;
 
+static constexpr double DEFAULT_MIN_DRAW_SCALE = 0.5;
+static constexpr double DEFAULT_MAX_DRAW_SCALE = 4.0;
+
 //what is this stuff
 #define TOOLWIN_BORDER_W 6
 #define TOOLWIN_BORDER_H 23


### PR DESCRIPTION
Previously, if the IGraphics was created with a scale factor of 0.5, the minimum would be a predefined fraction of that This change makes it easier to reason about the minimum and maximum scale factor. It also increases the default maximum scale factor to 4, rather than 2x