### PR TITLE
`IDirBrowseControlBase::ScanDirectory` finds files whose names include the extension elsewhere in their path.

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -1117,6 +1117,27 @@ void IDirBrowseControlBase::CheckSelectedItem()
   }
 }
 
+// Find the last occurrence of str2 in str1.
+// Return a pointer to the first character of the match.
+// Return a pointer to the start of str1 if str2 is empty.
+// Return a nullptr if str2 isn't found in str1.
+const char* strrstr(const char* str1, const char* str2) {
+  if (*str2 == '\0')
+    return str1;
+  
+  const char* result = nullptr;
+  
+  while (*str1 != '\0')
+  {
+    if (std::strncmp(str1, str2, std::strlen(str2)) == 0)
+      result = str1;
+    
+    str1++;
+  }
+  
+  return result;
+}
+
 void IDirBrowseControlBase::ScanDirectory(const char* path, IPopupMenu& menuToAddTo)
 {
   WDL_DirScan d;
@@ -1138,7 +1159,7 @@ void IDirBrowseControlBase::ScanDirectory(const char* path, IPopupMenu& menuToAd
         }
         else
         {
-          const char* a = strstr(f, mExtension.Get());
+          const char* a = strrstr(f, mExtension.Get());
           if (a && a > f && strlen(a) == strlen(mExtension.Get()))
           {
             WDL_String menuEntry {f};


### PR DESCRIPTION
Define `strrstr`, which behaves like `strstr` but finds the _last_ instance instead of the first.
Use it in ScanDirectory()

Resolves #989.

PR Checklist:
* ✅ [create an issue](https://github.com/iPlug2/iPlug2/issues/new/choose) first to outline the problem, to reference in this PR
* ✅ clearly describe the problem that the PR fixes
* ✅ each PR should address one thing. It can include multiple commits, but you should try and tidy up work done into logical units if possible.
* ✅ pay attention to [iplug2 coding style](https://github.com/iPlug2/iPlug2/blob/master/Documentation/codingstyle.md)
  * _Mimic style of `strstr` for new function `strrstr`_
* ✅ If it applies to an option e.g. IGRAPHICS_NANOVG or VST3 plug-ins, try to provide fixes for all options (e.g. all graphics backends or all plug-in formats)
  * _N/A_