### PR TITLE
Add SVG stroke/fill color overrides (NanoSVG only)

### DIFF
--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -1343,12 +1343,43 @@ ISVGButtonControl::ISVGButtonControl(const IRECT& bounds, IActionFunction aF, co
 {
 }
 
+
+ISVGButtonControl::ISVGButtonControl(const IRECT& bounds, IActionFunction aF, const ISVG& image, const std::array<IColor, 4> colors, EColorReplacement colorReplacement)
+: IButtonControlBase(bounds, aF)
+, mOffSVG(image)
+, mOnSVG(image)
+, mColors(colors)
+, mColorReplacement(colorReplacement)
+{
+}
+
 void ISVGButtonControl::Draw(IGraphics& g)
 {
+  IColor* pOnColorFill = nullptr;
+  IColor* pOffColorFill = nullptr;
+  IColor* pOnColorStroke = nullptr;
+  IColor* pOffColorStroke = nullptr;
+  
+  switch (mColorReplacement) {
+    
+    case EColorReplacement::None:
+      break;
+    case EColorReplacement::Fill:
+      pOnColorFill = mMouseIsOver ? &mColors[3] : &mColors[1];
+      pOffColorFill = mMouseIsOver ? &mColors[2] : &mColors[0];
+      break;
+    case EColorReplacement::Stroke:
+      pOnColorStroke = mMouseIsOver ? &mColors[3] : &mColors[1];
+      pOffColorStroke = mMouseIsOver ? &mColors[2] : &mColors[0];
+      break;
+  }
+  
   if (GetValue() > 0.5)
-    g.DrawSVG(mOnSVG, mRECT, &mBlend);
+    g.DrawSVG(mOnSVG, mRECT, &mBlend, pOnColorStroke, pOnColorFill);
   else
-    g.DrawSVG(mOffSVG, mRECT, &mBlend);
+    g.DrawSVG(mOffSVG, mRECT, &mBlend, pOffColorStroke, pOffColorFill);
+}
+  }
 }
 
 ISVGKnobControl::ISVGKnobControl(const IRECT& bounds, const ISVG& svg, int paramIdx)

--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -1379,7 +1379,63 @@ void ISVGButtonControl::Draw(IGraphics& g)
   else
     g.DrawSVG(mOffSVG, mRECT, &mBlend, pOffColorStroke, pOffColorFill);
 }
+
+ISVGToggleControl::ISVGToggleControl(const IRECT& bounds, IActionFunction aF, const ISVG& offImage, const ISVG& onImage)
+: ISwitchControlBase(bounds, kNoParameter, aF)
+, mOffSVG(offImage)
+, mOnSVG(onImage)
+{
+}
+
+ISVGToggleControl::ISVGToggleControl(const IRECT& bounds, int paramIdx, const ISVG& offImage, const ISVG& onImage)
+: ISwitchControlBase(bounds, paramIdx)
+, mOffSVG(offImage)
+, mOnSVG(onImage)
+{
+}
+
+ISVGToggleControl::ISVGToggleControl(const IRECT& bounds, IActionFunction aF, const ISVG& image, const std::array<IColor, 4> colors, EColorReplacement colorReplacement)
+: ISwitchControlBase(bounds, kNoParameter, aF)
+, mOffSVG(image)
+, mOnSVG(image)
+, mColors(colors)
+, mColorReplacement(colorReplacement)
+{
+}
+
+ISVGToggleControl::ISVGToggleControl(const IRECT& bounds, int paramIdx, const ISVG& image, const std::array<IColor, 4> colors, EColorReplacement colorReplacement)
+: ISwitchControlBase(bounds, paramIdx)
+, mOffSVG(image)
+, mOnSVG(image)
+, mColors(colors)
+, mColorReplacement(colorReplacement)
+{
+}
+
+void ISVGToggleControl::Draw(IGraphics& g)
+{
+  IColor* pOnColorFill = nullptr;
+  IColor* pOffColorFill = nullptr;
+  IColor* pOnColorStroke = nullptr;
+  IColor* pOffColorStroke = nullptr;
+  
+  switch (mColorReplacement) {
+    case EColorReplacement::None:
+      break;
+    case EColorReplacement::Fill:
+      pOnColorFill = mMouseIsOver ? &mColors[3] : &mColors[1];
+      pOffColorFill = mMouseIsOver ? &mColors[2] : &mColors[0];
+      break;
+    case EColorReplacement::Stroke:
+      pOnColorStroke = mMouseIsOver ? &mColors[3] : &mColors[1];
+      pOffColorStroke = mMouseIsOver ? &mColors[2] : &mColors[0];
+      break;
   }
+  
+  if (GetValue() > 0.5)
+    g.DrawSVG(mOnSVG, mRECT, &mBlend, pOnColorStroke, pOnColorFill);
+  else
+    g.DrawSVG(mOffSVG, mRECT, &mBlend, pOffColorStroke, pOffColorFill);
 }
 
 ISVGKnobControl::ISVGKnobControl(const IRECT& bounds, const ISVG& svg, int paramIdx)

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -537,9 +537,51 @@ public:
 protected:
   ISVG mOffSVG;
   ISVG mOnSVG;
-  IColor mOffColor {0,0,0,0};
-  IColor mOnColor {0,0,0,0};
-  bool mReplaceFill = true;
+  std::array<IColor, 4> mColors;
+  EColorReplacement mColorReplacement = EColorReplacement::None;
+};
+
+/** A vector toggle switch control which shows an SVG image */
+class ISVGToggleControl : public ISwitchControlBase
+{
+public:
+  /** Constructs an SVG button control, with an action function
+   * @param bounds The control's bounds
+   * @param aF An action function to execute when a button is clicked \see IActionFunction
+   * @param offImage An SVG for the off state of the button
+   * @param onImage An SVG for the on state of the button */
+  ISVGToggleControl(const IRECT& bounds, IActionFunction aF, const ISVG& offImage, const ISVG& onImage);
+
+  /** Constructs an SVG button control, with an action function
+   * @param bounds The control's bounds
+   * @param paramIdx The parameter index to link this control to
+   * @param offImage An SVG for the off state of the button
+   * @param onImage An SVG for the on state of the button */
+  ISVGToggleControl(const IRECT& bounds, int paramIdx, const ISVG& offImage, const ISVG& onImage);
+  
+  /** Constructs an SVG button control, with an action function and a single image, with color overrides
+   * @param bounds The control's bounds
+   * @param aF An action function to execute when a button is clicked \see IActionFunction
+   * @param image An SVG for the on/off state of the button
+   * @param colors Colors to replace the SVG's fill/stroke in the off/on/mouse-over-off/mouse-over-on states
+   * @param colorReplacement Should the fill or stroke in the SVG be colored */
+  ISVGToggleControl(const IRECT& bounds, IActionFunction aF, const ISVG& image, const std::array<IColor, 4> colors = {COLOR_BLACK, COLOR_WHITE, COLOR_DARK_GRAY, COLOR_LIGHT_GRAY}, EColorReplacement colorReplacement = EColorReplacement::Fill);
+
+  /** Constructs an SVG button control, with an action function and a single image, with color overrides
+   * @param bounds The control's bounds
+   * @param paramIdx The parameter index to link this control to
+   * @param image An SVG for the on/off state of the button
+   * @param colors Colors to replace the SVG's fill/stroke in the off/on/mouse-over-off/mouse-over-on states
+   * @param colorReplacement Should the fill or stroke in the SVG be colored */
+  ISVGToggleControl(const IRECT& bounds, int paramIdx, const ISVG& image, const std::array<IColor, 4> colors = {COLOR_BLACK, COLOR_WHITE, COLOR_DARK_GRAY, COLOR_LIGHT_GRAY}, EColorReplacement colorReplacement = EColorReplacement::Fill);
+
+  void Draw(IGraphics& g) override;
+
+protected:
+  ISVG mOffSVG;
+  ISVG mOnSVG;
+  std::array<IColor, 4> mColors;
+  EColorReplacement mColorReplacement = EColorReplacement::None;
 };
 
 /** A vector switch control which shows one of multiple SVG states. Click to cycle through states. */

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -513,21 +513,33 @@ private:
   float mEndAngle = 135.f;
 };
 
-/** A vector button/momentary switch control which shows two SVG states */
+/** A vector button/momentary switch control which shows an SVG image */
 class ISVGButtonControl : public IButtonControlBase
 {
 public:
-  /** Constructs a vector button control, with an action function
+  /** Constructs an SVG button control, with an action function
    * @param bounds The control's bounds
-   * @param aF An action function to execute when a button is clicked \see IActionFunction */
+   * @param aF An action function to execute when a button is clicked \see IActionFunction 
+   * @param offImage An SVG for the off state of the button
+   * @param onImage An SVG for the on state of the button */
   ISVGButtonControl(const IRECT& bounds, IActionFunction aF, const ISVG& offImage, const ISVG& onImage);
+  
+  /** Constructs an SVG button control, with an action function and a single image, with color overrides
+   * @param bounds The control's bounds
+   * @param aF An action function to execute when a button is clicked \see IActionFunction
+   * @param image An SVG for the on/off state of the button  
+   * @param colors Colors to replace the SVG's fill/stroke in the off/on/mouse-over-off/mouse-over-on states
+   * @param colorReplacement Should the fill or stroke in the SVG be colored */
+  ISVGButtonControl(const IRECT& bounds, IActionFunction aF, const ISVG& image, const std::array<IColor, 4> colors = {COLOR_BLACK, COLOR_WHITE, COLOR_DARK_GRAY, COLOR_LIGHT_GRAY}, EColorReplacement colorReplacement = EColorReplacement::Fill);
 
   void Draw(IGraphics& g) override;
-  //void OnResize() override;
 
 protected:
   ISVG mOffSVG;
   ISVG mOnSVG;
+  IColor mOffColor {0,0,0,0};
+  IColor mOnColor {0,0,0,0};
+  bool mReplaceFill = true;
 };
 
 /** A vector switch control which shows one of multiple SVG states. Click to cycle through states. */

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -2729,7 +2729,7 @@ void IGraphics::DrawFittedBitmap(const IBitmap& bitmap, const IRECT& bounds, con
   PathTransformRestore();
 }
 
-void IGraphics::DrawSVG(const ISVG& svg, const IRECT& dest, const IBlend* pBlend)
+void IGraphics::DrawSVG(const ISVG& svg, const IRECT& dest, const IBlend* pBlend, const IColor* pStrokeColor, const IColor* pFillColor)
 {
   float xScale = dest.W() / svg.W();
   float yScale = dest.H() / svg.H();
@@ -2738,7 +2738,7 @@ void IGraphics::DrawSVG(const ISVG& svg, const IRECT& dest, const IBlend* pBlend
   PathTransformSave();
   PathTransformTranslate(dest.L, dest.T);
   PathTransformScale(scale);
-  DoDrawSVG(svg, pBlend);
+  DoDrawSVG(svg, pBlend, pStrokeColor, pFillColor);
   PathTransformRestore();
 }
 
@@ -2792,7 +2792,7 @@ IPattern IGraphics::GetSVGPattern(const NSVGpaint& paint, float opacity)
   }
 }
 
-void IGraphics::DoDrawSVG(const ISVG& svg, const IBlend* pBlend)
+void IGraphics::DoDrawSVG(const ISVG& svg, const IBlend* pBlend, const IColor* pStrokeColor, const IColor* pFillColor)
 {
 #ifdef SVG_USE_SKIA
   SkCanvas* canvas = static_cast<SkCanvas*>(GetDrawContext());
@@ -2861,7 +2861,7 @@ void IGraphics::DoDrawSVG(const ISVG& svg, const IBlend* pBlend)
       options.mFillRule = EFillRule::Preserve;
       
       options.mPreserve = pShape->stroke.type != NSVG_PAINT_NONE;
-      PathFill(GetSVGPattern(pShape->fill, pShape->opacity), options, pBlend);
+      PathFill(pFillColor ? IPattern(*pFillColor) : GetSVGPattern(pShape->fill, pShape->opacity), options, pBlend);
     }
     
     // Stroke
@@ -2887,7 +2887,7 @@ void IGraphics::DoDrawSVG(const ISVG& svg, const IBlend* pBlend)
       
       options.mDash.SetDash(pShape->strokeDashArray, pShape->strokeDashOffset, pShape->strokeDashCount);
       
-      PathStroke(GetSVGPattern(pShape->stroke, pShape->opacity), pShape->strokeWidth, options, pBlend);
+      PathStroke(pStrokeColor ? IPattern(*pStrokeColor) : GetSVGPattern(pShape->stroke, pShape->opacity), pShape->strokeWidth, options, pBlend);
     }
   }
 #endif

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -102,8 +102,10 @@ public:
   /** Draw an SVG image to the graphics context
    * @param svg The SVG image to the graphics context
    * @param bounds The rectangular region to draw the image in
-   * @param pBlend Optional blend method */
-  virtual void DrawSVG(const ISVG& svg, const IRECT& bounds, const IBlend* pBlend = 0);
+   * @param pBlend Optional blend method
+   * @param pStrokeColor Optional color to override all SVG stroke commands
+   * @param pFillColor Optional color to override all SVG fill commands */
+  virtual void DrawSVG(const ISVG& svg, const IRECT& bounds, const IBlend* pBlend = 0, const IColor* pStrokeColor = nullptr, const IColor* pFillColor = nullptr);
 
   /** Draw an SVG image to the graphics context with rotation
    * @param svg The SVG image to draw to the graphics context
@@ -761,7 +763,7 @@ public:
 private:
   IPattern GetSVGPattern(const NSVGpaint& paint, float opacity);
 
-  void DoDrawSVG(const ISVG& svg, const IBlend* pBlend = nullptr);
+  void DoDrawSVG(const ISVG& svg, const IBlend* pBlend = nullptr, const IColor* pStrokeColor = nullptr, const IColor* pFillColor = nullptr);
   
   /** Prepare a particular area of the display for drawing, normally resulting in clipping of the region.
    * @param bounds The rectangular region to prepare  */

--- a/IGraphics/IGraphicsConstants.h
+++ b/IGraphics/IGraphicsConstants.h
@@ -161,6 +161,9 @@ enum class EPatternType { Solid, Linear, Radial, Sweep };
 enum class EPatternExtend { None, Pad, Reflect, Repeat };
 
 /** \todo */
+enum class EColorReplacement { None, Fill, Stroke };
+
+/** \todo */
 enum class EUIResizerMode { Scale, Size };
 
 /** \todo */


### PR DESCRIPTION
It's really common to use SVGs for icons, where you want to override the stroke or fill color on mouse events. This PR adds a "brute force" way to do that, replacing all stroke and/or all fill commands. It only works when using NanoSVG (skia's superior svg rendering wont work with this, but if you want to use NanoSVG with skia, you can define IGRAPHICS_NO_SKIA_SVG)