### PR TITLE
Add multi-channel NonIntegerResampler class

### DIFF
--- a/IPlug/Extras/LanczosResampler.h
+++ b/IPlug/Extras/LanczosResampler.h
@@ -1,0 +1,271 @@
+
+/*
+ LanczosResampler derived from
+ https://github.com/surge-synthesizer/sst-basic-blocks/blob/main/include/sst/basic-blocks/dsp/LanczosResampler.h
+ 
+ * sst-basic-blocks - an open source library of core audio utilities
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful on the audio thread for blocks,
+ * modulation, etc... or useful for adapting code to multiple environments.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log. Parts of this code are derived from similar
+ * functions original in Surge or ShortCircuit.
+ *
+ * sst-basic-blocks is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * All source in sst-basic-blocks available at
+ * https://github.com/surge-synthesizer/sst-basic-blocks
+ */
+
+/*
+ * A special note on licensing: This file (and only this file)
+ * has Paul Walker (baconpaul) as the sole author to date.
+ *
+ * In order to make this handy small function based on public
+ * information available to a set of open source projects
+ * adapting hardware to software, but which are licensed under
+ * MIT or BSD or similar licenses, this file and only this file
+ * can be used in an MIT/BSD context as well as a GPL3 context, by
+ * copying it and modifying it as you see fit.
+ *
+ * If you do that, you will need to replace the `sum_ps_to_float`
+ * call below with either an hadd if you are SSE3 or higher or
+ * an appropriate reduction operator from your toolkit.
+ *
+ * But basically: Need to resample 48k to variable rate with
+ * a small window and want to use this? Go for it!
+ *
+ * For avoidance of doubt, this license exception only
+ * applies to this file.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <utility>
+#include <cmath>
+#include <cstring>
+
+#if defined IPLUG_SIMDE
+  #if defined(__arm64__)
+    #define SIMDE_ENABLE_NATIVE_ALIASES
+    #include "simde/x86/sse2.h"
+  #else
+    #include <emmintrin.h>
+  #endif
+#endif
+
+namespace iplug
+{
+/*
+ * See https://en.wikipedia.org/wiki/Lanczos_resampling
+ */
+
+template<typename T = double, int NCHANS=2>
+class LanczosResampler
+{
+private:
+  static constexpr size_t A = 4;
+  static constexpr size_t kBufferSize = 4096;
+  static constexpr size_t kFilterWidth = A * 2;
+  static constexpr size_t kTableObs = 8192;
+  static constexpr double kDeltaX = 1.0 / (kTableObs);
+
+public:
+  LanczosResampler(float inputRate, float outputRate)
+  : mInputSampleRate(inputRate)
+  , mOutputSamplerate(outputRate)
+  , mPhaseOutIncr(mInputSampleRate / mOutputSamplerate)
+  {
+    memset(mInputBuffer, 0, NCHANS * kBufferSize * sizeof(T));
+
+    auto kernel = [](double x) {
+      if (std::fabs(x) < 1e-7)
+        return T(1.0);
+      return T(A * std::sin(M_PI * x) * std::sin(M_PI * x / A) / (M_PI * M_PI * x * x));
+    };
+  
+    if (!sTablesInitialized)
+    {
+      for (auto t = 0; t < kTableObs + 1; ++t)
+      {
+        const double x0 = kDeltaX * t;
+        
+        for (auto i=0; i<kFilterWidth; ++i)
+        {
+          const double x = x0 + i - A;
+          sTable[t][i] = kernel(x);
+        }
+      }
+      
+      for (auto t=0; t<kTableObs; ++t)
+      {
+        for (auto i=0; i<kFilterWidth; ++i)
+        {
+          sDeltaTable[t][i] = sTable[t + 1][i] - sTable[t][i];
+        }
+      }
+      
+      for (auto i=0; i<kFilterWidth; ++i)
+      {
+        // Wrap at the end - deriv is the same
+        sDeltaTable[kTableObs][i] = sDeltaTable[0][i];
+      }
+      sTablesInitialized = true;
+    }
+  }
+
+  inline size_t inputsRequiredToGenerateOutputs(size_t desiredOutputs) const
+  {
+    /*
+     * So (mPhaseIn + mPhaseInIncr * res - mPhaseOut - mPhaseOutIncr * desiredOutputs) * sri > A + 1
+     *
+     * Use the fact that mPhaseInIncr = mInputSampleRate and find
+     * res > (A+1) - (mPhaseIn - mPhaseOut + mPhaseOutIncr * desiredOutputs) * sri
+     */
+    auto res = A + 1.0 - (mPhaseIn - mPhaseOut - mPhaseOutIncr * desiredOutputs);
+
+    return static_cast<size_t>(std::max(res + 1.0, 0.0)); // Check this calculation
+  }
+
+  inline void pushBlock(T** inputs, size_t nFrames)
+  {
+    for (auto s=0; s<nFrames; s++)
+    {
+      for (auto c=0; c<NCHANS; c++)
+      {
+        mInputBuffer[c][mWritePos] = inputs[c][s];
+        mInputBuffer[c][mWritePos + kBufferSize] = inputs[c][s]; // this way we can always wrap
+      }
+      
+      mWritePos = (mWritePos + 1) & (kBufferSize - 1);
+      mPhaseIn += mPhaseInIncr;
+    }
+  }
+
+  size_t popBlock(T** outputs, size_t max)
+  {
+    int populated = 0;
+    while (populated < max && (mPhaseIn - mPhaseOut) > A + 1)
+    {
+      read((mPhaseIn - mPhaseOut), outputs, populated);
+      mPhaseOut += mPhaseOutIncr;
+      populated++;
+    }
+    return populated;
+  }
+
+  inline void renormalizePhases()
+  {
+    mPhaseIn -= mPhaseOut;
+    mPhaseOut = 0;
+  }
+
+private:
+  inline void read(double xBack, T** outputs, int s) const
+  {
+    double p0 = mWritePos - xBack;
+    int idx0 = std::floor(p0);
+    double off0 = 1.0 - (p0 - idx0);
+
+    idx0 = (idx0 + kBufferSize) & (kBufferSize - 1);
+    idx0 += (idx0 <= (int)A) * kBufferSize;
+
+    double off0byto = off0 * kTableObs;
+    int tidx = (int)(off0byto);
+    double fidx = (off0byto - tidx);
+    
+    T temp[NCHANS] = {0.0};
+
+#if defined IPLUG_SIMDE && SAMPLE_TYPE_FLOAT
+    auto sum_ps_to_float = [](__m128 x) {
+
+      auto sum_ps_to_ss = [](__m128 x) {
+        // FIXME: With SSE 3 this can be a dual hadd
+        __m128 a = _mm_add_ps(x, _mm_movehl_ps(x, x));
+        return _mm_add_ss(a, _mm_shuffle_ps(a, a, _MM_SHUFFLE(0, 0, 0, 1)));
+      };
+      
+      __m128 r = sum_ps_to_ss(x);
+      float f;
+      _mm_store_ss(&f, r);
+      return f;
+    };
+    
+    auto fl = _mm_set1_ps((float)fidx);
+    auto f0 = _mm_load_ps(&sTable[tidx][0]);
+    auto df0 = _mm_load_ps(&sDeltaTable[tidx][0]);
+
+    f0 = _mm_add_ps(f0, _mm_mul_ps(df0, fl));
+
+    auto f1 = _mm_load_ps(&sTable[tidx][4]);
+    auto df1 = _mm_load_ps(&sDeltaTable[tidx][4]);
+    f1 = _mm_add_ps(f1, _mm_mul_ps(df1, fl));
+
+    for (auto c=0; c<NCHANS;c++)
+    {
+      auto d0 = _mm_loadu_ps(&mInputBuffer[c][idx0 - A]);
+      auto d1 = _mm_loadu_ps(&mInputBuffer[c][idx0]);
+      auto rv = _mm_add_ps(_mm_mul_ps(f0, d0), _mm_mul_ps(f1, d1));
+      temp[c] = sum_ps_to_float(rv);
+    }
+#else
+    
+    for (auto i=0; i<4; i++)
+    {
+      const auto fl = fidx;
+      auto f0 = sTable[tidx][i];
+      const auto df0 = sDeltaTable[tidx][i];
+      f0 += df0 * fl;
+      
+      auto f1 = sTable[tidx][4+i];
+      const auto df1 = sDeltaTable[tidx][4+i];
+      f1 += df1 * fl;
+      
+      for (auto c=0; c<NCHANS;c++)
+      {
+        const auto d0 = mInputBuffer[c][idx0 - A + i];
+        const auto d1 = mInputBuffer[c][idx0 + i];
+        const auto rv = (f0 * d0) + (f1 * d1);
+        temp[c] += rv;
+      }
+    }
+#endif
+    
+    for (auto c=0; c<NCHANS;c++)
+    {
+      outputs[c][s] = temp[c];
+    }
+  }
+
+  
+  static T sTable alignas(16)[kTableObs + 1][kFilterWidth];
+  static T sDeltaTable alignas(16)[kTableObs + 1][kFilterWidth];
+  static bool sTablesInitialized;
+
+  T mInputBuffer[NCHANS][kBufferSize * 2];
+  int mWritePos = 0;
+  const float mInputSampleRate;
+  const float mOutputSamplerate;
+  double mPhaseIn = 0.0;
+  double mPhaseOut = 0.0;
+  double mPhaseInIncr = 1.0;
+  double mPhaseOutIncr = 0.0;
+};
+
+template<typename T, int NCHANS>
+T LanczosResampler<T, NCHANS>::sTable alignas(16) [LanczosResampler<T, NCHANS>::kTableObs + 1][LanczosResampler::kFilterWidth];
+
+template<typename T, int NCHANS>
+T LanczosResampler<T, NCHANS>::sDeltaTable alignas(16) [LanczosResampler<T, NCHANS>::kTableObs + 1][LanczosResampler::kFilterWidth];
+
+template<typename T, int NCHANS>
+bool LanczosResampler<T, NCHANS>::sTablesInitialized{false};
+
+} // namespace iplug
+

--- a/IPlug/Extras/NonIntegerResampler.h
+++ b/IPlug/Extras/NonIntegerResampler.h
@@ -1,0 +1,204 @@
+/*
+ ==============================================================================
+ 
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+ 
+ See LICENSE.txt for  more info.
+ 
+ ==============================================================================
+*/
+
+#pragma once
+
+#include <functional>
+#include <cmath>
+
+#include "IPlugPlatform.h"
+
+#include "heapbuf.h"
+#include "ptrlist.h"
+
+#include "LanczosResampler.h"
+
+BEGIN_IPLUG_NAMESPACE
+
+enum ESRCMode
+{
+  kLinearInterpolation = 0,
+  kCubicInterpolation,
+  kLancsoz,
+  kNumResamplingModes
+};
+
+template<typename T = double, int NCHANS=2>
+class NonIntegerResampler
+{
+public:
+  using BlockProcessFunc = std::function<void(T**, T**, int)>;
+  
+  NonIntegerResampler(double renderingSampleRate, ESRCMode mode = ESRCMode::kLinearInterpolation)
+  : mResamplingMode(mode)
+  , mRenderingSampleRate(renderingSampleRate)
+  {
+  }
+  
+  ~NonIntegerResampler()
+  {
+  }
+
+  NonIntegerResampler(const NonIntegerResampler&) = delete;
+  NonIntegerResampler& operator=(const NonIntegerResampler&) = delete;
+
+  void SetResamplingMode(ESRCMode mode)
+  {
+    mResamplingMode = mode;
+    Reset(mInputSampleRate);
+  }
+  
+  void Reset(double inputSampleRate, int blockSize = DEFAULT_BLOCK_SIZE)
+  {
+    mInputSampleRate = inputSampleRate;
+    mUpRatio = mInputSampleRate / mRenderingSampleRate;
+    mDownRatio = mRenderingSampleRate / mInputSampleRate;
+    mResampledData.Resize(DEFAULT_BLOCK_SIZE * NCHANS);
+    memset(mResampledData.Get(), 0.0f, DEFAULT_BLOCK_SIZE * NCHANS * sizeof(T));
+    mScratchPtrs.Empty();
+    
+    for (auto chan=0; chan<NCHANS; chan++)
+    {
+      mScratchPtrs.Add(mResampledData.Get() + (chan * DEFAULT_BLOCK_SIZE));
+    }
+
+    if (mResamplingMode == ESRCMode::kLancsoz)
+    {
+      mResamplerUp = std::make_unique<LanczosResampler<T, NCHANS>>(mInputSampleRate, mRenderingSampleRate);
+      mResamplerDown = std::make_unique<LanczosResampler<T, NCHANS>>(mRenderingSampleRate, mInputSampleRate);
+        
+      /* Prepopulate the upsampler with silence so it can run ahead */
+      auto numSamplesToAdvance = mResamplerUp->inputsRequiredToGenerateOutputs(1) * 2;
+      mResamplerUp->pushBlock(mScratchPtrs.GetList(), numSamplesToAdvance);
+    }
+  }
+
+  /** Resample an input block with a per-block function (up sample input -> process with function -> down sample)
+   * @param inputs Two-dimensional array containing the non-interleaved input buffers of audio samples for all channels
+   * @param outputs Two-dimensional array for audio output (non-interleaved).
+   * @param nFrames The block size for this block: number of samples per channel.
+   * @param func The function that processes the audio sample at the higher sampling rate. NOTE: std::function can call malloc if you pass in captures */
+  void ProcessBlock(T** inputs, T** outputs, int nFrames, BlockProcessFunc func)
+  {
+    switch (mResamplingMode) 
+    {
+      case ESRCMode::kLinearInterpolation:
+      {
+        const auto nNewFrames = LinearInterpolate(inputs, mScratchPtrs.GetList(), nFrames, mUpRatio, DEFAULT_BLOCK_SIZE);
+        func(mScratchPtrs.GetList(), mScratchPtrs.GetList(), nNewFrames);
+        LinearInterpolate(mScratchPtrs.GetList(), outputs, nNewFrames, mDownRatio, nFrames);
+        break;
+      }
+      case ESRCMode::kCubicInterpolation:
+      {
+        const auto nNewFrames = CubicInterpolate(inputs, mScratchPtrs.GetList(), nFrames, mUpRatio, DEFAULT_BLOCK_SIZE);
+        func(mScratchPtrs.GetList(), mScratchPtrs.GetList(), nNewFrames);
+        CubicInterpolate(mScratchPtrs.GetList(), outputs, nNewFrames, mDownRatio, nFrames);
+        break;
+      }
+      case ESRCMode::kLancsoz:
+      {
+        mResamplerUp->pushBlock(inputs, nFrames);
+        
+        const auto outputLen = static_cast<int>(std::ceil(static_cast<double>(nFrames) / mUpRatio));
+
+        while (mResamplerUp->inputsRequiredToGenerateOutputs(outputLen) == 0)
+        {
+          mResamplerUp->popBlock(mScratchPtrs.GetList(), outputLen);
+          func(mScratchPtrs.GetList(), mScratchPtrs.GetList(), outputLen);
+          
+          mResamplerDown->pushBlock(mScratchPtrs.GetList(), outputLen);
+        }
+        
+        mResamplerDown->popBlock(outputs, nFrames);
+        mResamplerUp->renormalizePhases();
+        mResamplerDown->renormalizePhases();
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+private:
+  static inline int LinearInterpolate(T** inputs, T** outputs, int inputLen, double ratio, int maxOutputLen)
+  {
+    const auto outputLen =
+      std::min(static_cast<int>(std::ceil(static_cast<double>(inputLen) / ratio)), maxOutputLen);
+
+    for (auto writePos = 0; writePos < outputLen; writePos++)
+    {
+      const auto readPos = ratio * static_cast<double>(writePos);
+      const auto readPostionTrunc = std::floor(readPos);
+      const auto readPosInt = static_cast<int>(readPostionTrunc);
+
+      if (readPosInt < inputLen)
+      {
+        const auto y = readPos - readPostionTrunc;
+
+        for (auto chan=0; chan<NCHANS; chan++)
+        {
+          const auto x0 = inputs[chan][readPosInt];
+          const auto x1 = ((readPosInt + 1) < inputLen) ? inputs[chan][readPosInt + 1] : inputs[chan][readPosInt-1];
+          outputs[chan][writePos] = (1.0 - y) * x0 + y * x1;
+        }
+      }
+    }
+
+    return outputLen;
+  }
+  
+  static inline int CubicInterpolate(T** inputs, T** outputs, int inputLen, double ratio, int maxOutputLen)
+  {
+    const auto outputLen =
+      std::min(static_cast<int>(std::ceil(static_cast<double>(inputLen) / ratio)), maxOutputLen);
+
+    for (auto writePos = 0; writePos < outputLen; writePos++)
+    {
+      const auto readPos = ratio * static_cast<double>(writePos);
+      const auto readPostionTrunc = std::floor(readPos);
+      const auto readPosInt = static_cast<int>(readPostionTrunc);
+
+      if (readPosInt < inputLen)
+      {
+        const auto y = readPos - readPostionTrunc;
+        
+        for (auto chan=0; chan<NCHANS; chan++)
+        {
+          const auto xm1 = ((readPosInt - 1) > 0) ? inputs[chan][readPosInt - 1] : 0.0f;
+          const auto x0 = ((readPosInt) < inputLen) ? inputs[chan][readPosInt] : inputs[chan][readPosInt-1];
+          const auto x1 = ((readPosInt + 1) < inputLen) ? inputs[chan][readPosInt + 1] : inputs[chan][readPosInt-1];
+          const auto x2 = ((readPosInt + 2) < inputLen) ? inputs[chan][readPosInt + 2] : inputs[chan][readPosInt-1];
+          
+          const auto  c = (x1 - xm1) * 0.5;
+          const auto  v = x0 - x1;
+          const auto  w = c + v;
+          const auto  a = w + v + (x2 - x0) * 0.5;
+          const auto  b = w + a;
+          
+          outputs[chan][writePos] = ((((a * y) -b) * y + c) * y + x0);
+        }
+      }
+    }
+    
+    return outputLen;
+  }
+  
+  WDL_TypedBuf<T> mResampledData;
+  WDL_PtrList<T> mScratchPtrs;
+  double mUpRatio = 0.0, mDownRatio = 0.0;
+  double mInputSampleRate = 0.0;
+  const double mRenderingSampleRate;
+  ESRCMode mResamplingMode;
+  
+  std::unique_ptr<LanczosResampler<T, NCHANS>> mResamplerUp, mResamplerDown;
+};
+
+END_IPLUG_NAMESPACE

--- a/IPlug/Extras/Oversampler.h
+++ b/IPlug/Extras/Oversampler.h
@@ -110,7 +110,7 @@ public:
   {
     int numBufSamples = 1;
     
-    if(mBlockProcessing)
+    if (mBlockProcessing)
       numBufSamples = blockSize;
     else
     {
@@ -179,7 +179,7 @@ public:
     assert(nInChans <= mNInChannels);
     assert(nOutChans <= mNOutChannels);
     
-    if(mRate != mPrevRate)
+    if (mRate != mPrevRate)
     {
       switch (mRate) {
         case 2:
@@ -205,7 +205,7 @@ public:
       mPrevRate = mRate;
     }
 
-    for(auto c = 0; c < nInChans; c++) {
+    for (auto c = 0; c < nInChans; c++) {
       if (mRate >= 2) {
         mUpsampler2x.Get(c)->process_block(mUp2BufferPtrs.Get(c), inputs[c], nFrames);
       }
@@ -224,7 +224,7 @@ public:
       func(inputs, outputs, nFrames);
     } else {
       for (auto i = 0; i < mRate; i++) {
-        for(auto c = 0; c < nInChans; c++) {
+        for (auto c = 0; c < nInChans; c++) {
           mNextInputPtrs.Set(c, mInPtrLoopSrc->Get(c) + (i * nFrames));
           mNextOutputPtrs.Set(c, mOutPtrLoopSrc->Get(c) + (i * nFrames));
         }
@@ -232,7 +232,7 @@ public:
       }
     }
     
-    for(auto c = 0; c < nOutChans; c++) {
+    for (auto c = 0; c < nOutChans; c++) {
       if (mRate == 16) {
         mDownsampler16x.Get(c)->process_block(mDown8BufferPtrs.Get(c), mDown16BufferPtrs.Get(c), nFrames * 8);
       }
@@ -256,7 +256,7 @@ public:
   {
     T output;
 
-    if(mRate == 16)
+    if (mRate == 16)
     {
       mUpsampler2x.Get(0)->process_sample(mUp2x.Get()[0], mUp2x.Get()[1], input);
       mUpsampler4x.Get(0)->process_block(mUp4x.Get(), mUp2x.Get(), 2);
@@ -329,7 +329,7 @@ public:
       mWritePos++;
       mWritePos &= 15;
 
-      if(mWritePos == 0)
+      if (mWritePos == 0)
       {
         mDownsampler16x.Get(0)->process_block(mDown8x.Get(), mDown16x.Get(), 8);
         mDownsampler8x.Get(0)->process_block(mDown4x.Get(), mDown8x.Get(), 4);
@@ -345,7 +345,7 @@ public:
       mWritePos++;
       mWritePos &= 7;
 
-      if(mWritePos == 0)
+      if (mWritePos == 0)
       {
         mDownsampler8x.Get(0)->process_block(mDown4x.Get(), mDown8x.Get(), 4);
         mDownsampler4x.Get(0)->process_block(mDown2x.Get(), mDown4x.Get(), 2);
@@ -360,7 +360,7 @@ public:
       mWritePos++;
       mWritePos &= 3;
 
-      if(mWritePos == 0)
+      if (mWritePos == 0)
       {
         mDownsampler4x.Get(0)->process_block(mDown2x.Get(), mDown4x.Get(), 2);
         mDownSamplerOutput = mDownsampler2x.Get(0)->process_sample(mDown2x.Get());
@@ -373,7 +373,7 @@ public:
 
       mWritePos = !mWritePos;
 
-      if(mWritePos == 0)
+      if (mWritePos == 0)
       {
         mDownSamplerOutput = mDownsampler2x.Get(0)->process_sample(mDown2x.Get());
       }
@@ -395,7 +395,7 @@ public:
       }
     }
 
-    if(mRate > 1)
+    if (mRate > 1)
       output = mDownSamplerOutput;
 
     return output;
@@ -403,7 +403,7 @@ public:
 
   void SetOverSampling(EFactor factor)
   {
-    if(factor != mFactor)
+    if (factor != mFactor)
     {
       mFactor = factor;
       mRate = std::pow(2, (int) factor);
@@ -425,7 +425,7 @@ public:
     }
   }
   
-  int GetRate()
+  int GetRate() const
   {
     return mRate;
   }


### PR DESCRIPTION
Add multi-channel NonIntegerResampler class for realtime resampling to a specified rate. This is useful when you have some DSP that needs to run at a specific rate, whatever the host rate.

The class offers 3 resampling modes suitable for quick realtime use, the best quality of which is a Lancsoz resampler, based on MIT licensed code by Paul Walker. This mode can be run using SIMD vectorization, in which case you need to define IPLUG_SIMDE and add the [simde-everywhere](https://github.com/simd-everywhere/simde) include paths to your project