### PR TITLE
IOS make sure that reused cells display correctly enabled

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -128,6 +128,11 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
     cell.userInteractionEnabled = NO;
     cell.textLabel.enabled = NO;
   }
+  else
+  {
+    cell.userInteractionEnabled = YES;
+    cell.textLabel.enabled = YES;
+  }
   
   return cell;
 }

--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -123,16 +123,7 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   else
     cell.accessoryType = pItem->GetSubmenu() ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
 
-  if (!pItem->GetEnabled())
-  {
-    cell.userInteractionEnabled = NO;
-    cell.textLabel.enabled = NO;
-  }
-  else
-  {
-    cell.userInteractionEnabled = YES;
-    cell.textLabel.enabled = YES;
-  }
+  cell.textLabel.enabled = cell.userInteractionEnabled = pItem->GetEnabled();
   
   return cell;
 }


### PR DESCRIPTION
This fixes #1013

The source of the bug is the reuse of the same cellblock, and previously only setting the relevant properties for disabled items. This PR makes sure that properties are set for every call so that the disabled/enabled items are correct.