### PR TITLE
Update IGraphicsMac_view.mm - getMouseLeft

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -681,14 +681,18 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
   }
 }
 
-- (IMouseInfo) getMouseLeft: (NSEvent*) pEvent
-{
-  IMouseInfo info;
-  [self getMouseXY:pEvent : info.x : info.y];
-  int mods = (int) [pEvent modifierFlags];
-  info.ms = IMouseMod(true, (mods & NSCommandKeyMask), (mods & NSShiftKeyMask), (mods & NSControlKeyMask), (mods & NSAlternateKeyMask));
+- (IMouseInfo) getMouseLeft: (NSEvent*) pEvent {
+    IMouseInfo info;
+    [self getMouseXY:pEvent : info.x : info.y];
+    int mods = (int) [pEvent modifierFlags];
 
-  return info;
+    info.ms = IMouseMod(([pEvent type] == NSEventTypeLeftMouseDown) || ([pEvent type] == NSEventTypeLeftMouseDragged),
+                        (mods & NSCommandKeyMask),
+                        (mods & NSShiftKeyMask),
+                        (mods & NSControlKeyMask),
+                        (mods & NSAlternateKeyMask));
+
+    return info;
 }
 
 - (IMouseInfo) getMouseRight: (NSEvent*) pEvent


### PR DESCRIPTION
Hi guys,
This PR addresses this [issue](https://github.com/iPlug2/iPlug2/issues/1021)

### Problem
The getMouseLeft function in IGraphicsMac_view.mm incorrectly sets the left mouse button state to always true, regardless of its actual state.

### Changes
- Updated the `getMouseLeft` method to use `NSEvent` for determining the actual state of the left mouse button.

### Code Update
```objc
- (IMouseInfo) getMouseLeft: (NSEvent*) pEvent {
    IMouseInfo info;
    [self getMouseXY:pEvent : info.x : info.y];
    int mods = (int) [pEvent modifierFlags];

    info.ms = IMouseMod(([pEvent type] == NSEventTypeLeftMouseDown) || ([pEvent type] == NSEventTypeLeftMouseDragged),
                        (mods & NSCommandKeyMask),
                        (mods & NSShiftKeyMask),
                        (mods & NSControlKeyMask),
                        (mods & NSAlternateKeyMask));

    return info;
}