### PR TITLE
Incorrect VST key press events in reaper

### DIFF
--- a/IPlug/IPlugStructs.h
+++ b/IPlug/IPlugStructs.h
@@ -615,12 +615,12 @@ struct IKeyPress
   char utf8[5] = { 0 }; // UTF8 key
   bool S, C, A; // SHIFT / CTRL(WIN) or CMD (MAC) / ALT
 
-  /** \todo
-   * @param _utf8 \todo
-   * @param vk \todo
-   * @param s \todo
-   * @param c \todo
-   * @param a \todo */
+  /** IKeyPress Constructor
+   * @param _utf8 UTF8 key
+   * @param vk Windows Virtual Key
+   * @param s Is SHIFT modifier pressed
+   * @param c Is CTRL/CMD modifier pressed
+   * @param a Is ALT modifier pressed */
   IKeyPress(const char* _utf8, int vk, bool s = false, bool c = false, bool a = false)
     : VK(vk)
     , S(s), C(c), A(a)

--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -895,8 +895,14 @@ VstIntPtr VSTCALLBACK IPlugVST2::VSTDispatcher(AEffect *pEffect, VstInt32 opCode
       char str[2];
       str[0] = static_cast<char>(idx);
       str[1] = '\0';
+      
+      // Workaround for Reaper's funky behaviour
+      if (_this->GetHost() == iplug::EHost::kHostReaper && value != VKEY_SPACE)
+      {
+        return 0;
+      }
 
-      int vk = VSTKeyCodeToVK(value, idx);
+      int vk = VSTKeyCodeToVK(static_cast<int>(value), idx);
       int modifiers = (int)opt;
 
       IKeyPress keyPress{ str, static_cast<int>(vk),

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -146,7 +146,62 @@ public:
     *obj = 0;
     return CPluginView::queryInterface(_iid, obj);
   }
-
+  
+  Steinberg::tresult PLUGIN_API onKeyDown (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers) override
+  {
+    // Workaround for Reaper's funky key/keyMsg
+    if (mOwner.GetHost() == iplug::EHost::kHostReaper)
+    {
+      if (keyMsg == Steinberg::VirtualKeyCodes::KEY_SPACE)
+      {
+        iplug::IKeyPress keyPress { " ", 
+          iplug::kVK_SPACE,
+          static_cast<bool>(modifiers & Steinberg::kShiftKey),
+          static_cast<bool>(modifiers & Steinberg::kCommandKey),
+          static_cast<bool>(modifiers & Steinberg::kAlternateKey)};
+        
+        return mOwner.OnKeyDown(keyPress) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
+      }
+      else
+      {
+        return Steinberg::kResultFalse;
+      }
+    }
+    else
+    {
+      return mOwner.OnKeyDown(TranslateKeyMessage(key, keyMsg, modifiers)) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
+    }
+  }
+  
+  Steinberg::tresult PLUGIN_API onKeyUp (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers) override
+  {
+    // Workaround for Reaper's funky key/keyMsg
+    if (mOwner.GetHost() == iplug::EHost::kHostReaper)
+    {
+      if (keyMsg == Steinberg::VirtualKeyCodes::KEY_SPACE)
+      {
+        iplug::IKeyPress keyPress { " ", iplug::kVK_SPACE,
+          static_cast<bool>(modifiers & Steinberg::kShiftKey),
+          static_cast<bool>(modifiers & Steinberg::kCommandKey),
+          static_cast<bool>(modifiers & Steinberg::kAlternateKey)};
+        
+        return mOwner.OnKeyUp(keyPress) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
+      }
+      else
+      {
+        return Steinberg::kResultFalse;
+      }
+    }
+    else
+    {
+      return mOwner.OnKeyUp(TranslateKeyMessage(key, keyMsg, modifiers)) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
+    }
+  }
+  
+  DELEGATE_REFCOUNT(Steinberg::CPluginView)
+  
+#pragma mark -
+  
   static int AsciiToVK(int ascii)
   {
   #ifdef OS_WIN
@@ -248,7 +303,7 @@ public:
     return kVK_NONE;
   };
   
-  static iplug::IKeyPress translateKeyMessage (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers)
+  static iplug::IKeyPress TranslateKeyMessage (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers)
   {
     WDL_String str;
 
@@ -275,18 +330,6 @@ public:
     
     return keyPress;
   }
-  
-  Steinberg::tresult PLUGIN_API onKeyDown (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers) override
-  {
-    return mOwner.OnKeyDown(translateKeyMessage(key, keyMsg, modifiers)) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
-  }
-  
-  Steinberg::tresult PLUGIN_API onKeyUp (Steinberg::char16 key, Steinberg::int16 keyMsg, Steinberg::int16 modifiers) override
-  {
-    return mOwner.OnKeyUp(translateKeyMessage(key, keyMsg, modifiers)) ? Steinberg::kResultTrue : Steinberg::kResultFalse;
-  }
-  
-  DELEGATE_REFCOUNT(Steinberg::CPluginView)
 
   void Resize(int w, int h)
   {


### PR DESCRIPTION
As noted in #707 certain keypresses are getting garbled in Reaper when they are handled via the VST mechanisms. They are handled by that in the first place rather than IGraphics, so that we can for instance catch the space bar in a text entry control before it is handled by the host to start the transport. This is particularly an issue for typing a - sign in an ITextEntryControl. This PR fixes it by only using the Steinberg IPlugView::onKeyDown/Up() overrides for the SPACE bar in Reaper, since that is something we want to catch using the VST methods because it will be blocked from IGraphics, we use IGraphics for other keys in Reaper. The same problem is there in VST2 with reaper, work around that too.