### PR TITLE
Unicode improvements and fixes

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -15,6 +15,7 @@
 #include "IControl.h"
 #include "IPlugParameter.h"
 
+
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 void DefaultAnimationFunc(IControl* pCaller)

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -10,7 +10,6 @@
 
 #include <cmath>
 #include <cstring>
-#define WDL_NO_SUPPORT_UTF8
 #include "dirscan.h"
 
 #include "IControl.h"

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1684,7 +1684,8 @@ WDL_TypedBuf<uint8_t> IGraphics::LoadResource(const char* fileNameOrResID, const
 #endif
   if (resourceFound == EResourceLocation::kAbsolutePath)
   {
-    FILE* fd = fopen(path.Get(), "rb");
+    FILE* fd = fopenUTF8(path.Get(), "rb");
+
     if (!fd)
       return result;
     

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2035,11 +2035,11 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, const char* f
   {
     case kAbsolutePath:
     {
-      HANDLE file = CreateFile(fullPath.Get(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+      HANDLE file = CreateFileW(UTF8AsUTF16(fullPath).Get(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
       PlatformFontPtr ret = nullptr;
       if (file)
       {
-        HANDLE mapping = CreateFileMapping(file, NULL, PAGE_READONLY, 0, 0, NULL);
+        HANDLE mapping = CreateFileMappingW(file, NULL, PAGE_READONLY, 0, 0, NULL);
         if (mapping)
         {
           resSize = (int)GetFileSize(file, nullptr);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1851,24 +1851,13 @@ bool IGraphicsWin::GetTextFromClipboard(WDL_String& str)
     {
       HGLOBAL hglb = GetClipboardData(CF_UNICODETEXT);
       
-      if (hglb != NULL)
+      if (hglb)
       {
-        WCHAR *origStr = (WCHAR*)GlobalLock(hglb);
-        
-        if (origStr != NULL)
-        {
-          // Find out how much space is needed
+        WCHAR *origStr = (WCHAR*) GlobalLock(hglb);
 
-          int newLen = WideCharToMultiByte(CP_UTF8, 0, origStr, -1, 0, 0, NULL, NULL);
-          
-          if (newLen > 0)
-          {
-            WDL_TypedBuf<char> utf8;
-            utf8.Resize(newLen);
-            numChars = WideCharToMultiByte(CP_UTF8, 0, origStr, -1, utf8.Get(), utf8.GetSize(), NULL, NULL);
-            str.Set(utf8.Get());
-          }
-          
+        if (origStr)
+        {
+          UTF16ToUTF8(str, origStr);
           GlobalUnlock(hglb);
         }
       }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1808,9 +1808,7 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
   DWORD inetStatus = 0;
   if (InternetGetConnectedState(&inetStatus, 0))
   {
-    WCHAR urlWide[IPLUG_WIN_MAX_WIDE_PATH];
-    UTF8ToUTF16(urlWide, url, IPLUG_WIN_MAX_WIDE_PATH);
-    if (ShellExecuteW(mPlugWnd, L"open", urlWide, 0, 0, SW_SHOWNORMAL) > HINSTANCE(32))
+    if (ShellExecuteW(mPlugWnd, L"open", UTF8AsUTF16(url).Get(), 0, 0, SW_SHOWNORMAL) > HINSTANCE(32))
     {
       return true;
     }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1921,7 +1921,7 @@ bool IGraphicsWin::SetFilePathInClipboard(const char* path)
 
   // N.B. GHND ensures that the memory is zeroed
 
-  HGLOBAL hGlobal = GlobalAlloc(GHND, sizeof(DROPFILES) + pathWide.GetLength() + 1);
+  HGLOBAL hGlobal = GlobalAlloc(GHND, sizeof(DROPFILES) + (sizeof(wchar_t) * (pathWide.GetLength() + 1)));
 
   if (!hGlobal)
     return false;
@@ -1938,7 +1938,7 @@ bool IGraphicsWin::SetFilePathInClipboard(const char* path)
     pDropFiles->fNC = true;
     pDropFiles->fWide = true;
 
-    memcpy(&pDropFiles[1], pathWide.Get(), pathWide.GetLength());
+    std::copy_n(pathWide.Get(), pathWide.GetLength(), reinterpret_cast<wchar_t*>(&pDropFiles[1]));
 
     GlobalUnlock(hGlobal);
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2301,7 +2301,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 void IGraphicsWin::VBlankNotify()
 {
   mVBlankCount++;
-  ::PostMessage(mVBlankWindow, WM_VBLANK, mVBlankCount, 0);
+  ::PostMessageW(mVBlankWindow, WM_VBLANK, mVBlankCount, 0);
 }
 
 #ifndef NO_IGRAPHICS

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1905,7 +1905,7 @@ bool IGraphicsWin::SetTextInClipboard(const char* str)
       GlobalUnlock(hglbCopy);
 
       // place the handle on the clipboard
-      result = !SetClipboardData(CF_UNICODETEXT, hglbCopy);
+      result = SetClipboardData(CF_UNICODETEXT, hglbCopy);
 
       // free the handle if unsuccessful
       if (!result)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1279,11 +1279,6 @@ IRECT IGraphicsWin::GetWindowRECT()
   return IRECT();
 }
 
-void IGraphicsWin::SetWindowTitle(const char* str)
-{
-  SetWindowTextW(mPlugWnd, UTF8AsUTF16(str).Get());
-}
-
 void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1618,22 +1618,22 @@ void IGraphicsWin::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
     wchar_t extStr[256];
     wchar_t defExtStr[16];
     int i, p, n = strlen(ext);
-    bool seperator = true;
+    bool separator = true;
         
     for (i = 0, p = 0; i < n; ++i)
     {
-      if (seperator)
+      if (separator)
       {
         if (p)
           extStr[p++] = ';';
                 
-        seperator = false;
+        separator = false;
         extStr[p++] = '*';
         extStr[p++] = '.';
       }
 
       if (ext[i] == ' ')
-        seperator = true;
+        separator = true;
       else
         extStr[p++] = ext[i];
     }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -189,7 +189,7 @@ void IGraphicsWin::DestroyEditWindow()
 {
  if (mParamEditWnd)
  {
-   SetWindowLongPtr(mParamEditWnd, GWLP_WNDPROC, (LPARAM) mDefEditProc);
+   SetWindowLongPtrW(mParamEditWnd, GWLP_WNDPROC, (LPARAM) mDefEditProc);
    DestroyWindow(mParamEditWnd);
    mParamEditWnd = nullptr;
    mDefEditProc = nullptr;
@@ -307,7 +307,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   if (msg == WM_CREATE)
   {
     LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lParam;
-    SetWindowLongPtr(hWnd, GWLP_USERDATA, (LPARAM) lpcs->lpCreateParams);
+    SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LPARAM) lpcs->lpCreateParams);
     IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 
     if (pGraphics->mVSYNCEnabled) // use VBLANK thread
@@ -1550,8 +1550,8 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
 
   SetFocus(mParamEditWnd);
 
-  mDefEditProc = (WNDPROC) SetWindowLongPtr(mParamEditWnd, GWLP_WNDPROC, (LONG_PTR) ParamEditProc);
-  SetWindowLongPtr(mParamEditWnd, GWLP_USERDATA, 0xdeadf00b);
+  mDefEditProc = (WNDPROC) SetWindowLongPtrW(mParamEditWnd, GWLP_WNDPROC, (LONG_PTR) ParamEditProc);
+  SetWindowLongPtrW(mParamEditWnd, GWLP_USERDATA, 0xdeadf00b);
 }
 
 bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1196,11 +1196,9 @@ void* IGraphicsWin::OpenWindow(void* pParent)
       if (mTooltipWnd)
       {
         SetWindowPos(mTooltipWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-        TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR)mPlugWnd };
-        ti.lpszText = NULL;
-        SendMessageW(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM) &ti);
+        TOOLINFOW ti = { TTTOOLINFOW_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR) mPlugWnd, {0, 0, 0, 0}, NULL, NULL, 0, NULL };
+        SendMessageW(mTooltipWnd, TTM_ADDTOOLW, 0, (LPARAM) &ti);
         SendMessageW(mTooltipWnd, TTM_SETMAXTIPWIDTH, 0, TOOLTIPWND_MAXWIDTH);
-        ok = true;
       }
     }
 
@@ -1808,9 +1806,9 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
 void IGraphicsWin::SetTooltip(const char* tooltip)
 {
   UTF8AsUTF16 utf16Tip(tooltip);
-  TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, 0, mPlugWnd, (UINT_PTR) mPlugWnd };
+  TOOLINFOW ti = { TTTOOLINFOW_V2_SIZE, 0, mPlugWnd, (UINT_PTR) mPlugWnd, {0, 0, 0, 0}, NULL, NULL, 0, NULL };
   ti.lpszText = const_cast<wchar_t*>(utf16Tip.Get());
-  SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXT, 0, (LPARAM) &ti);
+  SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXTW, 0, (LPARAM) &ti);
 }
 
 void IGraphicsWin::ShowTooltip()

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1281,7 +1281,7 @@ IRECT IGraphicsWin::GetWindowRECT()
 
 void IGraphicsWin::SetWindowTitle(const char* str)
 {
-  SetWindowText(mPlugWnd, str);
+  SetWindowTextW(mPlugWnd, UTF8AsUTF16(str).Get());
 }
 
 void IGraphicsWin::CloseWindow()
@@ -1756,7 +1756,7 @@ static UINT_PTR CALLBACK CCHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM
     if (cc && cc->lCustData)
     {
       char* str = (char*) cc->lCustData;
-      SetWindowText(hdlg, str);
+      SetWindowTextW(hdlg, UTF8AsUTF16(str).Get());
       UINT uiSetRGB;
       uiSetRGB = RegisterWindowMessage(SETRGBSTRING);
       SendMessage(hdlg, uiSetRGB, 0, (LPARAM) cc->rgbResult);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1561,10 +1561,9 @@ bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)
   if (path.GetLength())
   {
     WCHAR winDir[IPLUG_WIN_MAX_WIDE_PATH];
-    WCHAR explorerWide[IPLUG_WIN_MAX_WIDE_PATH];
     UINT len = GetSystemDirectoryW(winDir, IPLUG_WIN_MAX_WIDE_PATH);
-    
-    if (len || !(len > MAX_PATH - 2))
+
+    if (len && !(len > MAX_PATH - 2))
     {
       winDir[len]   = L'\\';
       winDir[++len] = L'\0';
@@ -1578,10 +1577,9 @@ bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)
       explorerParams.Append(path.Get());
       explorerParams.Append("\\\"");
       
-      UTF8ToUTF16(explorerWide, explorerParams.Get(), IPLUG_WIN_MAX_WIDE_PATH);
       HINSTANCE result;
       
-      if ((result=::ShellExecuteW(NULL, L"open", L"explorer.exe", explorerWide, winDir, SW_SHOWNORMAL)) <= (HINSTANCE) 32)
+      if ((result=::ShellExecuteW(NULL, L"open", L"explorer.exe", UTF8AsUTF16(explorerParams).Get(), winDir, SW_SHOWNORMAL)) <= (HINSTANCE) 32)
         success = true;
     }
   }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -333,7 +333,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
   if (!pGraphics || hWnd != pGraphics->mPlugWnd)
   {
-    return DefWindowProc(hWnd, msg, wParam, lParam);
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
   }
 
   if (pGraphics->mParamEditWnd && pGraphics->mParamEditMsg == kEditing)
@@ -343,7 +343,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       pGraphics->mParamEditMsg = kCancel;
       return 0;
     }
-    return DefWindowProc(hWnd, msg, wParam, lParam);
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
   }
   
   auto IsTouchEvent = []() {
@@ -613,7 +613,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       {
         HWND rootHWnd = GetAncestor( hWnd, GA_ROOT);
         SendMessageW(rootHWnd, msg, wParam, lParam);
-        return DefWindowProc(hWnd, msg, wParam, lParam);
+        return DefWindowProcW(hWnd, msg, wParam, lParam);
       }
       else
         return 0;
@@ -739,7 +739,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       return 0;
     }
   }
-  return DefWindowProc(hWnd, msg, wParam, lParam);
+  return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
 // static
@@ -813,7 +813,7 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
       {
         LPARAM lres;
         // find out if the original control wants it
-        lres = CallWindowProc(pGraphics->mDefEditProc, hWnd, WM_GETDLGCODE, wParam, lParam);
+        lres = CallWindowProcW(pGraphics->mDefEditProc, hWnd, WM_GETDLGCODE, wParam, lParam);
         // add in that we want it if it is a return keydown
         if (lParam && ((MSG*)lParam)->message == WM_KEYDOWN  &&  wParam == VK_RETURN)
         {
@@ -838,9 +838,9 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
         break;  // Else let the default proc handle it.
       }
     }
-    return CallWindowProc(pGraphics->mDefEditProc, hWnd, msg, wParam, lParam);
+    return CallWindowProcW(pGraphics->mDefEditProc, hWnd, msg, wParam, lParam);
   }
-  return DefWindowProc(hWnd, msg, wParam, lParam);
+  return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
 IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -204,7 +204,7 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   DWORD msgCount = vBlankCount;
   DWORD curCount = mVBlankCount;
 
-  if(mVSYNCEnabled)
+  if (mVSYNCEnabled)
   {
     // skip until the actual vblank is at a certain number.
     if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > mVBlankCount)
@@ -287,7 +287,7 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
       // Force a redraw right now
       UpdateWindow(mPlugWnd);
 
-      if(mVSYNCEnabled)
+      if (mVSYNCEnabled)
       {
         // Check and see if we are still in this frame.
         curCount = mVBlankCount;
@@ -312,7 +312,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     SetWindowLongPtr(hWnd, GWLP_USERDATA, (LPARAM)(lpcs->lpCreateParams));
     IGraphicsWin* pGraphics = (IGraphicsWin*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
 
-    if(pGraphics->mVSYNCEnabled) // use VBLANK thread
+    if (pGraphics->mVSYNCEnabled) // use VBLANK thread
     {
       assert((pGraphics->FPS() == 60) && "If you want to run at frame rates other than 60FPS");
       pGraphics->StartVBlankThread(hWnd);
@@ -603,7 +603,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
         const float scale = pGraphics->GetTotalScale();
 
-        if(msg == WM_KEYDOWN)
+        if (msg == WM_KEYDOWN)
           handle = pGraphics->OnKeyDown(p.x / scale, p.y / scale, keyPress);
         else
           handle = pGraphics->OnKeyUp(p.x / scale, p.y / scale, keyPress);
@@ -683,7 +683,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
     case WM_CTLCOLOREDIT:
     {
-      if(!pGraphics->mParamEditWnd)
+      if (!pGraphics->mParamEditWnd)
         return 0;
 
       const IText& text = pGraphics->mEditText;
@@ -715,7 +715,8 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       if (numDroppedFiles==1) 
       {
         pGraphics->OnDrop(&pathPtrs[0][0], p.x / scale, p.y / scale);
-      } else 
+      }
+      else 
       {
         pGraphics->OnDropMultiple(pathPtrs, p.x / scale, p.y / scale);
       }
@@ -753,11 +754,11 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
       case WM_CHAR:
       {
         // limit to numbers for text entry on appropriate parameters
-        if(pGraphics->mEditParam)
+        if (pGraphics->mEditParam)
         {
           char c = wParam;
 
-          if(c == 0x08) break; // backspace
+          if (c == 0x08) break; // backspace
 
           switch (pGraphics->mEditParam->Type())
           {
@@ -922,12 +923,12 @@ void IGraphicsWin::PlatformResize(bool parentHasResized)
 
     SetWindowPos(mPlugWnd, 0, 0, 0, dlgW + dw, dlgH + dh, SETPOS_FLAGS);
 
-    if(pParent && !parentHasResized)
+    if (pParent && !parentHasResized)
     {
       SetWindowPos(pParent, 0, 0, 0, parentW + dw, parentH + dh, SETPOS_FLAGS);
     }
 
-    if(pGrandparent && !parentHasResized)
+    if (pGrandparent && !parentHasResized)
     {
       SetWindowPos(pGrandparent, 0, 0, 0, grandparentW + dw, grandparentH + dh, SETPOS_FLAGS);
     }
@@ -1123,7 +1124,7 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* text, const char* caption
   
   EMsgBoxResult result = static_cast<EMsgBoxResult>(MessageBox(GetMainWnd(), text, caption, static_cast<int>(type)));
   
-  if(completionHandler)
+  if (completionHandler)
     completionHandler(result);
   
   return result;
@@ -1287,7 +1288,7 @@ void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)
   {
-    if(mVSYNCEnabled)
+    if (mVSYNCEnabled)
       StopVBlankThread();
     else
       KillTimer(mPlugWnd, IPLUG_TIMER_ID);
@@ -1341,14 +1342,14 @@ IPopupMenu* IGraphicsWin::GetItemMenu(long idx, long& idxInMenu, long& offsetIdx
 
   IPopupMenu* pMenu = nullptr;
 
-  for(int i = 0; i< baseMenu.NItems(); i++)
+  for (int i = 0; i< baseMenu.NItems(); i++)
   {
     IPopupMenu::Item* pMenuItem = baseMenu.GetItem(i);
-    if(pMenuItem->GetSubmenu())
+    if (pMenuItem->GetSubmenu())
     {
       pMenu = GetItemMenu(idx, idxInMenu, offsetIdx, *pMenuItem->GetSubmenu());
 
-      if(pMenu)
+      if (pMenu)
         break;
     }
   }
@@ -1368,7 +1369,7 @@ HMENU IGraphicsWin::CreateMenu(IPopupMenu& menu, long* pOffsetIdx)
   *pOffsetIdx += nItems;
   long inc = 0;
 
-  for(int i = 0; i < nItems; i++)
+  for (int i = 0; i < nItems; i++)
   {
     IPopupMenu::Item* pMenuItem = menu.GetItem(i);
 
@@ -1449,7 +1450,7 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT 
   long offsetIdx = 0;
   HMENU hMenu = CreateMenu(menu, &offsetIdx);
 
-  if(hMenu)
+  if (hMenu)
   {
     IPopupMenu* result = nullptr;
 
@@ -1480,7 +1481,7 @@ IPopupMenu* IGraphicsWin::CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT 
               result->SetChosenItemIdx(idx);
                 
               //synchronous
-              if(pReturnMenu && pReturnMenu->GetFunction())
+              if (pReturnMenu && pReturnMenu->GetFunction())
                 pReturnMenu->ExecFunction();
             }
           }
@@ -1572,7 +1573,7 @@ bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)
       
       WDL_String explorerParams;
       
-      if(select)
+      if (select)
         explorerParams.Append("/select,");
       
       explorerParams.Append("\"");
@@ -1790,7 +1791,7 @@ bool IGraphicsWin::PromptForColor(IColor& color, const char* prompt, IColorPicke
     color.G = GetGValue(cc.rgbResult);
     color.B = GetBValue(cc.rgbResult);
     
-    if(func)
+    if (func)
       func(color);
     
     return true;
@@ -1856,7 +1857,7 @@ bool IGraphicsWin::GetTextFromClipboard(WDL_String& str)
   
   if (IsClipboardFormatAvailable(CF_UNICODETEXT))
   {
-    if(OpenClipboard(0))
+    if (OpenClipboard(0))
     {
       HGLOBAL hglb = GetClipboardData(CF_UNICODETEXT);
       

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1709,24 +1709,24 @@ void IGraphicsWin::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
 
 void IGraphicsWin::PromptForDirectory(WDL_String& dir, IFileDialogCompletionHandlerFunc completionHandler)
 {
-  BROWSEINFO bi;
+  BROWSEINFOW bi;
   memset(&bi, 0, sizeof(bi));
   
   bi.ulFlags   = BIF_USENEWUI;
   bi.hwndOwner = mPlugWnd;
-  bi.lpszTitle = "Choose a Directory";
+  bi.lpszTitle = L"Choose a Directory";
   
   // must call this if using BIF_USENEWUI
   ::OleInitialize(NULL);
-  LPITEMIDLIST pIDL = ::SHBrowseForFolder(&bi);
+  LPITEMIDLIST pIDL = ::SHBrowseForFolderW(&bi);
   
   if (pIDL != NULL)
   {
-    char buffer[_MAX_PATH] = {'\0'};
+    wchar_t buffer[_MAX_PATH] = {'\0'};
     
-    if (::SHGetPathFromIDList(pIDL, buffer) != 0)
+    if (::SHGetPathFromIDListW(pIDL, buffer) != 0)
     {
-      dir.Set(buffer);
+      dir.Set(UTF16AsUTF8(buffer).Get());
       dir.Append("\\");
     }
     

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -704,7 +704,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       std::vector<const char*> pathPtrs(numDroppedFiles);
       for (int i = 0; i < numDroppedFiles; i++) 
       {
-        wchar_t pathBufferW[1025];
+        wchar_t pathBufferW[1025] = {'\0'};
         DragQueryFileW(hdrop, i, pathBufferW, 1024);
         strncpy(pathBuffers[i].data(), UTF16AsUTF8(pathBufferW).Get(), 1024);
         pathPtrs[i] = pathBuffers[i].data();
@@ -1220,7 +1220,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
 static void GetWndClassName(HWND hWnd, WDL_String* pStr)
 {
-  wchar_t cStrW[MAX_CLASSNAME_LEN] = { '\0' };
+  wchar_t cStrW[MAX_CLASSNAME_LEN] = {'\0'};
   GetClassNameW(hWnd, cStrW, MAX_CLASSNAME_LEN);
   pStr->Set(UTF16AsUTF8(cStrW).Get());
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -814,7 +814,7 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
         // find out if the original control wants it
         lres = CallWindowProcW(pGraphics->mDefEditProc, hWnd, WM_GETDLGCODE, wParam, lParam);
         // add in that we want it if it is a return keydown
-        if (lParam && ((MSG*)lParam)->message == WM_KEYDOWN  &&  wParam == VK_RETURN)
+        if (lParam && ((MSG*)lParam)->message == WM_KEYDOWN && wParam == VK_RETURN)
         {
           lres |= DLGC_WANTMESSAGE;
         }
@@ -1507,7 +1507,7 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
 
   DWORD editStyle;
 
-  switch ( text.mAlign )
+  switch (text.mAlign)
   {
     case EAlign::Near:    editStyle = ES_LEFT;   break;
     case EAlign::Far:     editStyle = ES_RIGHT;  break;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1753,11 +1753,11 @@ static UINT_PTR CALLBACK CCHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM
 {
   if (uiMsg == WM_INITDIALOG && lParam)
   {
-    CHOOSECOLOR* cc = (CHOOSECOLOR*) lParam;
+    CHOOSECOLORW* cc = (CHOOSECOLORW*) lParam;
     if (cc && cc->lCustData)
     {
-      char* str = (char*) cc->lCustData;
-      SetWindowTextW(hdlg, UTF8AsUTF16(str).Get());
+      const wchar_t* strWide = (const wchar_t*) cc->lCustData;
+      SetWindowTextW(hdlg, strWide);
       UINT uiSetRGB;
       uiSetRGB = RegisterWindowMessageW(SETRGBSTRINGW);
       SendMessageW(hdlg, uiSetRGB, 0, (LPARAM) cc->rgbResult);
@@ -1773,20 +1773,22 @@ bool IGraphicsWin::PromptForColor(IColor& color, const char* prompt, IColorPicke
   if (!mPlugWnd)
     return false;
 
+  UTF8AsUTF16 promptWide(prompt);
+
   const COLORREF w = RGB(255, 255, 255);
   static COLORREF customColorStorage[16] = { w, w, w, w, w, w, w, w, w, w, w, w, w, w, w, w };
   
-  CHOOSECOLOR cc;
-  memset(&cc, 0, sizeof(CHOOSECOLOR));
-  cc.lStructSize = sizeof(CHOOSECOLOR);
+  CHOOSECOLORW cc;
+  memset(&cc, 0, sizeof(CHOOSECOLORW));
+  cc.lStructSize = sizeof(CHOOSECOLORW);
   cc.hwndOwner = mPlugWnd;
   cc.rgbResult = RGB(color.R, color.G, color.B);
   cc.lpCustColors = customColorStorage;
-  cc.lCustData = (LPARAM) prompt;
+  cc.lCustData = (LPARAM) promptWide.Get();
   cc.lpfnHook = CCHookProc;
   cc.Flags = CC_RGBINIT | CC_ANYCOLOR | CC_FULLOPEN | CC_SOLIDCOLOR | CC_ENABLEHOOK;
 
-  if (ChooseColor(&cc))
+  if (ChooseColorW(&cc))
   {
     color.R = GetRValue(cc.rgbResult);
     color.G = GetGValue(cc.rgbResult);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1843,8 +1843,8 @@ void IGraphicsWin::HideTooltip()
 
 bool IGraphicsWin::GetTextFromClipboard(WDL_String& str)
 {
-  int numChars = 0;
-  
+  bool result = false;
+
   if (IsClipboardFormatAvailable(CF_UNICODETEXT))
   {
     if (OpenClipboard(0))
@@ -1859,6 +1859,7 @@ bool IGraphicsWin::GetTextFromClipboard(WDL_String& str)
         {
           UTF16ToUTF8(str, origStr);
           GlobalUnlock(hglb);
+          result = true;
         }
       }
     }
@@ -1866,10 +1867,10 @@ bool IGraphicsWin::GetTextFromClipboard(WDL_String& str)
     CloseClipboard();
   }
   
-  if (!numChars)
+  if (!result)
     str.Set("");
   
-  return numChars;
+  return result;
 }
 
 bool IGraphicsWin::SetTextInClipboard(const char* str)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -612,7 +612,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       if (!handle)
       {
         HWND rootHWnd = GetAncestor( hWnd, GA_ROOT);
-        SendMessage(rootHWnd, msg, wParam, lParam);
+        SendMessageW(rootHWnd, msg, wParam, lParam);
         return DefWindowProc(hWnd, msg, wParam, lParam);
       }
       else
@@ -1191,15 +1191,15 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
     if (InitCommonControlsEx(&iccex))
     {
-      mTooltipWnd = CreateWindowEx(0, TOOLTIPS_CLASS, NULL, WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TTS_NOPREFIX | TTS_ALWAYSTIP,
+      mTooltipWnd = CreateWindowExW(0, TOOLTIPS_CLASSW, NULL, WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TTS_NOPREFIX | TTS_ALWAYSTIP,
                                    CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, mPlugWnd, NULL, mHInstance, NULL);
       if (mTooltipWnd)
       {
         SetWindowPos(mTooltipWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-        TOOLINFO ti = { TTTOOLINFOA_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR)mPlugWnd };
-        ti.lpszText = (LPTSTR)NULL;
-        SendMessage(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM)&ti);
-        SendMessage(mTooltipWnd, TTM_SETMAXTIPWIDTH, 0, TOOLTIPWND_MAXWIDTH);
+        TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR)mPlugWnd };
+        ti.lpszText = NULL;
+        SendMessageW(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM)&ti);
+        SendMessageW(mTooltipWnd, TTM_SETMAXTIPWIDTH, 0, TOOLTIPWND_MAXWIDTH);
         ok = true;
       }
     }
@@ -1537,16 +1537,16 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
   mEditText = text;
   mEditRECT = bounds;
 
-  SendMessage(mParamEditWnd, EM_LIMITTEXT, (WPARAM) length, 0);
-  SendMessage(mParamEditWnd, WM_SETFONT, (WPARAM)mEditFont, 0);
-  SendMessage(mParamEditWnd, EM_SETSEL, 0, -1);
+  SendMessageW(mParamEditWnd, EM_LIMITTEXT, (WPARAM) length, 0);
+  SendMessageW(mParamEditWnd, WM_SETFONT, (WPARAM)mEditFont, 0);
+  SendMessageW(mParamEditWnd, EM_SETSEL, 0, -1);
 
   if (text.mVAlign == EVAlign::Middle)
   {
     double size = text.mSize * scale;
     double offset = (scaledBounds.H() - size) / 2.0;
     RECT formatRect{0, (LONG) offset, (LONG) scaledBounds.W() + 1, (LONG) scaledBounds.H() + 1};
-    SendMessage(mParamEditWnd, EM_SETRECT, 0, (LPARAM)&formatRect);
+    SendMessageW(mParamEditWnd, EM_SETRECT, 0, (LPARAM)&formatRect);
   }
 
   SetFocus(mParamEditWnd);
@@ -1758,7 +1758,7 @@ static UINT_PTR CALLBACK CCHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM
       SetWindowTextW(hdlg, UTF8AsUTF16(str).Get());
       UINT uiSetRGB;
       uiSetRGB = RegisterWindowMessage(SETRGBSTRING);
-      SendMessage(hdlg, uiSetRGB, 0, (LPARAM) cc->rgbResult);
+      SendMessageW(hdlg, uiSetRGB, 0, (LPARAM) cc->rgbResult);
     }
   }
   return 0;
@@ -1823,9 +1823,10 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
 
 void IGraphicsWin::SetTooltip(const char* tooltip)
 {
-  TOOLINFO ti = { TTTOOLINFOA_V2_SIZE, 0, mPlugWnd, (UINT_PTR)mPlugWnd };
-  ti.lpszText = (LPTSTR)tooltip;
-  SendMessage(mTooltipWnd, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
+  UTF8AsUTF16 utf16Tip(tooltip);
+  TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, 0, mPlugWnd, (UINT_PTR)mPlugWnd };
+  ti.lpszText = const_cast<wchar_t*>(utf16Tip.Get());
+  SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
 }
 
 void IGraphicsWin::ShowTooltip()

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -698,14 +698,16 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     {
       HDROP hdrop = (HDROP)wParam;
 
-      int numDroppedFiles = DragQueryFile(hdrop, -1, nullptr, 0);
+      int numDroppedFiles = DragQueryFileW(hdrop, -1, nullptr, 0);
 
       std::vector<std::vector<char>> pathBuffers(numDroppedFiles, std::vector<char>(1025, 0));
       std::vector<const char*> pathPtrs(numDroppedFiles);
       for (int i = 0; i < numDroppedFiles; i++) 
       {
-        DragQueryFile(hdrop, i, &pathBuffers[i][0], 1024);
-        pathPtrs[i] = &pathBuffers[i][0];
+        wchar_t pathBufferW[1025];
+        DragQueryFileW(hdrop, i, pathBufferW, 1024);
+        strncpy(pathBuffers[i].data(), UTF16AsUTF8(pathBufferW).Get(), 1024);
+        pathPtrs[i] = pathBuffers[i].data();
       }
       POINT p;
       DragQueryPoint(hdrop, &p);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1375,7 +1375,7 @@ HMENU IGraphicsWin::CreateMenu(IPopupMenu& menu, long* pOffsetIdx)
 
     if (pMenuItem->GetIsSeparator())
     {
-      AppendMenu(hMenu, MF_SEPARATOR, 0, 0);
+      AppendMenuW(hMenu, MF_SEPARATOR, 0, 0);
     }
     else
     {
@@ -1431,12 +1431,12 @@ HMENU IGraphicsWin::CreateMenu(IPopupMenu& menu, long* pOffsetIdx)
         HMENU submenu = CreateMenu(*pMenuItem->GetSubmenu(), pOffsetIdx);
         if (submenu)
         {
-          AppendMenu(hMenu, flags|MF_POPUP, (UINT_PTR)submenu, (const TCHAR*)entryText.Get());
+          AppendMenuW(hMenu, flags|MF_POPUP, (UINT_PTR)submenu, UTF8AsUTF16(entryText).Get());
         }
       }
       else
       {
-        AppendMenu(hMenu, flags, offset + inc, entryText.Get());
+        AppendMenuW(hMenu, flags, offset + inc, UTF8AsUTF16(entryText).Get());
       }
     }
     inc++;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1759,7 +1759,7 @@ static UINT_PTR CALLBACK CCHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM
       char* str = (char*) cc->lCustData;
       SetWindowTextW(hdlg, UTF8AsUTF16(str).Get());
       UINT uiSetRGB;
-      uiSetRGB = RegisterWindowMessage(SETRGBSTRING);
+      uiSetRGB = RegisterWindowMessageW(SETRGBSTRINGW);
       SendMessageW(hdlg, uiSetRGB, 0, (LPARAM) cc->rgbResult);
     }
   }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -306,7 +306,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 {
   if (msg == WM_CREATE)
   {
-    LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lParam;
+    CREATESTRUCTW* lpcs = (CREATESTRUCTW *) lParam;
     SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LPARAM) lpcs->lpCreateParams);
     IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1518,10 +1518,7 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
   const float scale = GetTotalScale();
   IRECT scaledBounds = bounds.GetScaled(scale);
 
-  WCHAR strWide[MAX_PARAM_DISPLAY_LEN];
-  UTF8ToUTF16(strWide, str, MAX_PARAM_DISPLAY_LEN);
-
-  mParamEditWnd = CreateWindowW(L"EDIT", strWide, ES_AUTOHSCROLL /*only works for left aligned text*/ | WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE | ES_MULTILINE | editStyle,
+  mParamEditWnd = CreateWindowW(L"EDIT", UTF8AsUTF16(str).Get(), ES_AUTOHSCROLL /*only works for left aligned text*/ | WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE | ES_MULTILINE | editStyle,
     scaledBounds.L, scaledBounds.T, scaledBounds.W()+1, scaledBounds.H()+1,
     mPlugWnd, (HMENU) PARAM_EDIT_ID, mHInstance, 0);
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1187,7 +1187,6 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   if (mPlugWnd && TooltipsEnabled())
   {
-    bool ok = false;
     static const INITCOMMONCONTROLSEX iccex = { sizeof(INITCOMMONCONTROLSEX), ICC_TAB_CLASSES };
 
     if (InitCommonControlsEx(&iccex))
@@ -1205,8 +1204,8 @@ void* IGraphicsWin::OpenWindow(void* pParent)
       }
     }
 
-    if (!ok)
-      EnableTooltips(ok);
+    if (!mTooltipWnd)
+      EnableTooltips(false);
 
 #ifdef IGRAPHICS_GL
     wglMakeCurrent(NULL, NULL);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1805,9 +1805,9 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
 
 void IGraphicsWin::SetTooltip(const char* tooltip)
 {
-  UTF8AsUTF16 utf16Tip(tooltip);
+  UTF8AsUTF16 tipWide(tooltip);
   TOOLINFOW ti = { TTTOOLINFOW_V2_SIZE, 0, mPlugWnd, (UINT_PTR) mPlugWnd, {0, 0, 0, 0}, NULL, NULL, 0, NULL };
-  ti.lpszText = const_cast<wchar_t*>(utf16Tip.Get());
+  ti.lpszText = const_cast<wchar_t*>(tipWide.Get());
   SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXTW, 0, (LPARAM) &ti);
 }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1124,7 +1124,7 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* text, const char* caption
 {
   ReleaseMouseCapture();
   
-  EMsgBoxResult result = static_cast<EMsgBoxResult>(MessageBox(GetMainWnd(), text, caption, static_cast<int>(type)));
+  EMsgBoxResult result = static_cast<EMsgBoxResult>(MessageBoxW(GetMainWnd(), UTF8AsUTF16(text).Get(), UTF8AsUTF16(caption).Get(), static_cast<int>(type)));
   
   if (completionHandler)
     completionHandler(result);
@@ -1802,7 +1802,7 @@ bool IGraphicsWin::PromptForColor(IColor& color, const char* prompt, IColorPicke
 
 bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const char* confirmMsg, const char* errMsgOnFailure)
 {
-  if (confirmMsg && MessageBox(mPlugWnd, confirmMsg, msgWindowTitle, MB_YESNO) != IDYES)
+  if (confirmMsg && MessageBoxW(mPlugWnd, UTF8AsUTF16(confirmMsg).Get(), UTF8AsUTF16(msgWindowTitle).Get(), MB_YESNO) != IDYES)
   {
     return false;
   }
@@ -1818,7 +1818,7 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
   }
   if (errMsgOnFailure)
   {
-    MessageBox(mPlugWnd, errMsgOnFailure, msgWindowTitle, MB_OK);
+    MessageBoxW(mPlugWnd, UTF8AsUTF16(errMsgOnFailure).Get(), UTF8AsUTF16(msgWindowTitle).Get(), MB_OK);
   }
   return false;
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -35,7 +35,7 @@ using namespace igraphics;
 #pragma warning(disable:4311) // Pointer size cast mismatch.
 
 static int nWndClassReg = 0;
-static const char* wndClassName = "IPlugWndClass";
+static wchar_t* wndClassName = L"IPlugWndClass";
 static double sFPS = 0.0;
 
 #define PARAM_EDIT_ID 99
@@ -1150,11 +1150,11 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   if (nWndClassReg++ == 0)
   {
-    WNDCLASS wndClass = { CS_DBLCLKS | CS_OWNDC, WndProc, 0, 0, mHInstance, 0, 0, 0, 0, wndClassName };
-    RegisterClass(&wndClass);
+    WNDCLASSW wndClass = { CS_DBLCLKS | CS_OWNDC, WndProc, 0, 0, mHInstance, 0, 0, 0, 0, wndClassName };
+    RegisterClassW(&wndClass);
   }
 
-  mPlugWnd = CreateWindow(wndClassName, "IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
+  mPlugWnd = CreateWindowW(wndClassName, L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 
   HDC dc = GetDC(mPlugWnd);
   SetPlatformContext(dc);
@@ -1177,7 +1177,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   if (!mPlugWnd && --nWndClassReg == 0)
   {
-    UnregisterClass(wndClassName, mHInstance);
+    UnregisterClassW(wndClassName, mHInstance);
   }
   else
   {
@@ -1218,10 +1218,9 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
 static void GetWndClassName(HWND hWnd, WDL_String* pStr)
 {
-  char cStr[MAX_CLASSNAME_LEN];
-  cStr[0] = '\0';
-  GetClassName(hWnd, cStr, MAX_CLASSNAME_LEN);
-  pStr->Set(cStr);
+  wchar_t cStrW[MAX_CLASSNAME_LEN] = { '\0' };
+  GetClassNameW(hWnd, cStrW, MAX_CLASSNAME_LEN);
+  pStr->Set(UTF16AsUTF8(cStrW).Get());
 }
 
 BOOL CALLBACK IGraphicsWin::FindMainWindow(HWND hWnd, LPARAM lParam)
@@ -1319,7 +1318,7 @@ void IGraphicsWin::CloseWindow()
 
     if (--nWndClassReg == 0)
     {
-      UnregisterClass(wndClassName, mHInstance);
+      UnregisterClassW(wndClassName, mHInstance);
     }
   }
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1926,7 +1926,9 @@ bool IGraphicsWin::SetFilePathInClipboard(const char* path)
 
   UTF8AsUTF16 pathWide(path);
 
-  HGLOBAL hGlobal = GlobalAlloc(GHND, sizeof(DROPFILES) + pathWide.GetLength());
+  // N.B. GHND ensures that the memory is zeroed
+
+  HGLOBAL hGlobal = GlobalAlloc(GHND, sizeof(DROPFILES) + pathWide.GetLength() + 1);
 
   if (!hGlobal)
     return false;
@@ -1943,11 +1945,11 @@ bool IGraphicsWin::SetFilePathInClipboard(const char* path)
     pDropFiles->fNC = true;
     pDropFiles->fWide = true;
 
-    memcpy(pDropFiles + 1, pathWide.Get(), pathWide.GetLength());
+    memcpy(&pDropFiles[1], pathWide.Get(), pathWide.GetLength());
 
     GlobalUnlock(hGlobal);
 
-    result = !SetClipboardData(CF_HDROP, hGlobal);
+    result = SetClipboardData(CF_HDROP, hGlobal);
   }
 
   // free the handle if unsuccessful

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -309,7 +309,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   if (msg == WM_CREATE)
   {
     LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lParam;
-    SetWindowLongPtr(hWnd, GWLP_USERDATA, (LPARAM)(lpcs->lpCreateParams));
+    SetWindowLongPtr(hWnd, GWLP_USERDATA, (LPARAM) lpcs->lpCreateParams);
     IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 
     if (pGraphics->mVSYNCEnabled) // use VBLANK thread
@@ -696,12 +696,13 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     }
     case WM_DROPFILES:
     {
-      HDROP hdrop = (HDROP)wParam;
+      HDROP hdrop = (HDROP) wParam;
 
       int numDroppedFiles = DragQueryFileW(hdrop, -1, nullptr, 0);
 
       std::vector<std::vector<char>> pathBuffers(numDroppedFiles, std::vector<char>(1025, 0));
       std::vector<const char*> pathPtrs(numDroppedFiles);
+
       for (int i = 0; i < numDroppedFiles; i++) 
       {
         wchar_t pathBufferW[1025] = {'\0'};
@@ -1200,13 +1201,14 @@ void* IGraphicsWin::OpenWindow(void* pParent)
         SetWindowPos(mTooltipWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
         TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, TTF_IDISHWND | TTF_SUBCLASS, mPlugWnd, (UINT_PTR)mPlugWnd };
         ti.lpszText = NULL;
-        SendMessageW(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM)&ti);
+        SendMessageW(mTooltipWnd, TTM_ADDTOOL, 0, (LPARAM) &ti);
         SendMessageW(mTooltipWnd, TTM_SETMAXTIPWIDTH, 0, TOOLTIPWND_MAXWIDTH);
         ok = true;
       }
     }
 
-    if (!ok) EnableTooltips(ok);
+    if (!ok)
+      EnableTooltips(ok);
 
 #ifdef IGRAPHICS_GL
     wglMakeCurrent(NULL, NULL);
@@ -1540,7 +1542,7 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
   mEditRECT = bounds;
 
   SendMessageW(mParamEditWnd, EM_LIMITTEXT, (WPARAM) length, 0);
-  SendMessageW(mParamEditWnd, WM_SETFONT, (WPARAM)mEditFont, 0);
+  SendMessageW(mParamEditWnd, WM_SETFONT, (WPARAM) mEditFont, 0);
   SendMessageW(mParamEditWnd, EM_SETSEL, 0, -1);
 
   if (text.mVAlign == EVAlign::Middle)
@@ -1548,7 +1550,7 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
     double size = text.mSize * scale;
     double offset = (scaledBounds.H() - size) / 2.0;
     RECT formatRect{0, (LONG) offset, (LONG) scaledBounds.W() + 1, (LONG) scaledBounds.H() + 1};
-    SendMessageW(mParamEditWnd, EM_SETRECT, 0, (LPARAM)&formatRect);
+    SendMessageW(mParamEditWnd, EM_SETRECT, 0, (LPARAM) &formatRect);
   }
 
   SetFocus(mParamEditWnd);
@@ -1828,9 +1830,9 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
 void IGraphicsWin::SetTooltip(const char* tooltip)
 {
   UTF8AsUTF16 utf16Tip(tooltip);
-  TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, 0, mPlugWnd, (UINT_PTR)mPlugWnd };
+  TOOLINFOW ti = { TTTOOLINFOA_V2_SIZE, 0, mPlugWnd, (UINT_PTR) mPlugWnd };
   ti.lpszText = const_cast<wchar_t*>(utf16Tip.Get());
-  SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
+  SendMessageW(mTooltipWnd, TTM_UPDATETIPTEXT, 0, (LPARAM) &ti);
 }
 
 void IGraphicsWin::ShowTooltip()
@@ -1935,9 +1937,7 @@ bool IGraphicsWin::SetTextInClipboard(const char* str)
 bool IGraphicsWin::SetFilePathInClipboard(const char* path)
 {
   if (!OpenClipboard(mMainWnd))
-  {
     return false;
-  }
 
   EmptyClipboard();
 
@@ -1947,7 +1947,7 @@ bool IGraphicsWin::SetFilePathInClipboard(const char* path)
   if (!hGlobal)
     return false;
 
-  DROPFILES* pDropFiles = (DROPFILES*)GlobalLock(hGlobal);
+  DROPFILES* pDropFiles = (DROPFILES*) GlobalLock(hGlobal);
 
   if (!pDropFiles) 
   {
@@ -2046,7 +2046,7 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, const char* f
         HANDLE mapping = CreateFileMappingW(file, NULL, PAGE_READONLY, 0, 0, NULL);
         if (mapping)
         {
-          resSize = (int)GetFileSize(file, nullptr);
+          resSize = (int) GetFileSize(file, nullptr);
           pFontMem = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
           ret = LoadPlatformFont(fontID, pFontMem, resSize);
           UnmapViewOfFile(pFontMem);
@@ -2122,7 +2122,7 @@ void IGraphicsWin::CachePlatformFont(const char* fontID, const PlatformFontPtr& 
 
 DWORD WINAPI VBlankRun(LPVOID lpParam)
 {
-  IGraphicsWin* pGraphics = (IGraphicsWin*)lpParam;
+  IGraphicsWin* pGraphics = (IGraphicsWin*) lpParam;
   return pGraphics->OnVBlankRun();
 }
 
@@ -2158,16 +2158,22 @@ void IGraphicsWin::StopVBlankThread()
 // structs to use
 typedef UINT32 D3DKMT_HANDLE;
 typedef UINT D3DDDI_VIDEO_PRESENT_SOURCE_ID;
-typedef struct _D3DKMT_OPENADAPTERFROMHDC {
+
+typedef struct _D3DKMT_OPENADAPTERFROMHDC
+{
   HDC                            hDc;
   D3DKMT_HANDLE                  hAdapter;
   LUID                           AdapterLuid;
   D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
 } D3DKMT_OPENADAPTERFROMHDC;
-typedef struct _D3DKMT_CLOSEADAPTER {
+
+typedef struct _D3DKMT_CLOSEADAPTER
+{
   D3DKMT_HANDLE hAdapter;
 } D3DKMT_CLOSEADAPTER;
-typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT {
+
+typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT
+{
   D3DKMT_HANDLE                  hAdapter;
   D3DKMT_HANDLE                  hDevice;
   D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
@@ -2197,11 +2203,12 @@ DWORD IGraphicsWin::OnVBlankRun()
   D3DKMTCloseAdapter pClose = nullptr;
   D3DKMTWaitForVerticalBlankEvent pWait = nullptr;
   HINSTANCE hInst = LoadLibraryW(L"gdi32.dll");
+
   if (hInst != nullptr)
   {
-    pOpen  = (D3DKMTOpenAdapterFromHdc)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromHdc");
-    pClose = (D3DKMTCloseAdapter)GetProcAddress((HMODULE)hInst, "D3DKMTCloseAdapter");
-    pWait  = (D3DKMTWaitForVerticalBlankEvent)GetProcAddress((HMODULE)hInst, "D3DKMTWaitForVerticalBlankEvent");
+    pOpen  = (D3DKMTOpenAdapterFromHdc) GetProcAddress((HMODULE) hInst, "D3DKMTOpenAdapterFromHdc");
+    pClose = (D3DKMTCloseAdapter) GetProcAddress((HMODULE) hInst, "D3DKMTCloseAdapter");
+    pWait  = (D3DKMTWaitForVerticalBlankEvent) GetProcAddress((HMODULE) hInst, "D3DKMTWaitForVerticalBlankEvent");
   }
 
   // if we don't get bindings to the methods we will fallback

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2192,7 +2192,7 @@ DWORD IGraphicsWin::OnVBlankRun()
   D3DKMTOpenAdapterFromHdc pOpen = nullptr;
   D3DKMTCloseAdapter pClose = nullptr;
   D3DKMTWaitForVerticalBlankEvent pWait = nullptr;
-  HINSTANCE hInst = LoadLibrary("gdi32.dll");
+  HINSTANCE hInst = LoadLibraryW(L"gdi32.dll");
   if (hInst != nullptr)
   {
     pOpen  = (D3DKMTOpenAdapterFromHdc)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromHdc");

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1597,29 +1597,23 @@ void IGraphicsWin::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
     return;
   }
     
-  wchar_t fnCStr[_MAX_PATH];
-  wchar_t dirCStr[_MAX_PATH];
+  wchar_t fileNameWide[_MAX_PATH];
     
-  if (fileName.GetLength())
-    UTF8ToUTF16(fnCStr, fileName.Get(), _MAX_PATH);
-  else
-    fnCStr[0] = '\0';
-    
-  dirCStr[0] = '\0';
-    
+  UTF8ToUTF16(fileNameWide, fileName.Get(), _MAX_PATH);
+
   //if (!path.GetLength())
   //  DesktopPath(path);
-    
-  UTF8ToUTF16(dirCStr, path.Get(), _MAX_PATH);
-    
+
+  UTF8AsUTF16 directoryWide(path);
+
   OPENFILENAMEW ofn;
   memset(&ofn, 0, sizeof(OPENFILENAMEW));
     
   ofn.lStructSize = sizeof(OPENFILENAMEW);
   ofn.hwndOwner = (HWND) GetWindow();
-  ofn.lpstrFile = fnCStr;
+  ofn.lpstrFile = fileNameWide;
   ofn.nMaxFile = _MAX_PATH - 1;
-  ofn.lpstrInitialDir = dirCStr;
+  ofn.lpstrInitialDir = directoryWide.Get();
   ofn.Flags = OFN_PATHMUSTEXIST;
     
   if (CStringHasContents(ext))
@@ -1679,8 +1673,7 @@ void IGraphicsWin::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
     char drive[_MAX_DRIVE];
     char directoryOutCStr[_MAX_PATH];
     
-    WDL_String tempUTF8;
-    UTF16ToUTF8(tempUTF8, ofn.lpstrFile);
+    UTF16AsUTF8 tempUTF8(ofn.lpstrFile);
     
     if (_splitpath_s(tempUTF8.Get(), drive, sizeof(drive), directoryOutCStr, sizeof(directoryOutCStr), NULL, 0, NULL, 0) == 0)
     {

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -310,7 +310,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   {
     LPCREATESTRUCT lpcs = (LPCREATESTRUCT)lParam;
     SetWindowLongPtr(hWnd, GWLP_USERDATA, (LPARAM)(lpcs->lpCreateParams));
-    IGraphicsWin* pGraphics = (IGraphicsWin*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
+    IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 
     if (pGraphics->mVSYNCEnabled) // use VBLANK thread
     {
@@ -329,7 +329,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     return 0;
   }
 
-  IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtr(hWnd, GWLP_USERDATA);
+  IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 
   if (!pGraphics || hWnd != pGraphics->mPlugWnd)
   {
@@ -745,7 +745,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 // static
 LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-  IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtr(GetParent(hWnd), GWLP_USERDATA);
+  IGraphicsWin* pGraphics = (IGraphicsWin*) GetWindowLongPtrW(GetParent(hWnd), GWLP_USERDATA);
 
   if (pGraphics && pGraphics->mParamEditWnd && pGraphics->mParamEditWnd == hWnd)
   {
@@ -885,8 +885,8 @@ static bool IsChildWindow(HWND pWnd)
 {
   if (pWnd)
   {
-    int style = GetWindowLong(pWnd, GWL_STYLE);
-    int exStyle = GetWindowLong(pWnd, GWL_EXSTYLE);
+    int style = GetWindowLongW(pWnd, GWL_STYLE);
+    int exStyle = GetWindowLongW(pWnd, GWL_EXSTYLE);
     return ((style & WS_CHILD) && !(exStyle & WS_EX_MDICHILD));
   }
   return false;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -228,11 +228,9 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
     {
       case kCommit:
       {
-        WCHAR wtxt[MAX_WIN32_PARAM_LEN];
-        WDL_String tempUTF8;
-        SendMessageW(mParamEditWnd, WM_GETTEXT, MAX_WIN32_PARAM_LEN, (LPARAM)wtxt);
-        UTF16ToUTF8(tempUTF8, wtxt);
-        SetControlValueAfterTextEdit(tempUTF8.Get());
+        WCHAR strWide[MAX_WIN32_PARAM_LEN];
+        SendMessageW(mParamEditWnd, WM_GETTEXT, MAX_WIN32_PARAM_LEN, (LPARAM) strWide);
+        SetControlValueAfterTextEdit(UTF16AsUTF8(strWide).Get());
         DestroyEditWindow();
         break;
       }

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -67,7 +67,7 @@ public:
   IPopupMenu* GetItemMenu(long idx, long& idxInMenu, long& offsetIdx, IPopupMenu& baseMenu);
   HMENU CreateMenu(IPopupMenu& menu, long* pOffsetIdx);
 
-  bool OpenURL(const char* url, const char* msgWindowTitle, const char* confirmMsg, const char* errMsgOnFailure);
+  bool OpenURL(const char* url, const char* msgWindowTitle, const char* confirmMsg, const char* errMsgOnFailure) override;
 
   void* GetWindow() override { return mPlugWnd; }
   HWND GetParentWindow() const { return mParentWnd; }

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -85,7 +85,6 @@ public:
 
   bool PlatformSupportsMultiTouch() const override;
 
-  
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
   static LRESULT CALLBACK ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
   static BOOL CALLBACK FindMainWindow(HWND hWnd, LPARAM lParam);
@@ -147,6 +146,7 @@ private:
   void StartVBlankThread(HWND hWnd);
   void StopVBlankThread();
   void VBlankNotify();
+    
   HWND mVBlankWindow = 0; // Window to post messages to for every vsync
   volatile bool mVBlankShutdown = false; // Flag to indiciate that the vsync thread should shutdown
   HANDLE mVBlankThread = INVALID_HANDLE_VALUE; //ID of thread.

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -70,8 +70,6 @@ public:
   bool OpenURL(const char* url, const char* msgWindowTitle, const char* confirmMsg, const char* errMsgOnFailure) override;
 
   void* GetWindow() override { return mPlugWnd; }
-  HWND GetMainWnd();
-  IRECT GetWindowRECT();
 
   const char* GetPlatformAPIStr() override { return "win32"; };
 
@@ -94,6 +92,9 @@ protected:
   void SetTooltip(const char* tooltip);
   void ShowTooltip();
   void HideTooltip();
+    
+  HWND GetMainWnd();
+  IRECT GetWindowRECT();
 
 private:
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -70,12 +70,8 @@ public:
   bool OpenURL(const char* url, const char* msgWindowTitle, const char* confirmMsg, const char* errMsgOnFailure) override;
 
   void* GetWindow() override { return mPlugWnd; }
-  HWND GetParentWindow() const { return mParentWnd; }
   HWND GetMainWnd();
-  void SetMainWndClassName(const char* name) { mMainWndClassName.Set(name); }
-//  void GetMainWndClassName(char* name) { strcpy(name, mMainWndClassName.Get()); }
   IRECT GetWindowRECT();
-  void SetWindowTitle(const char* str);
 
   const char* GetPlatformAPIStr() override { return "win32"; };
 

--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -43,22 +43,13 @@ BEGIN_IPLUG_NAMESPACE
   #elif defined OS_WIN
     static void DBGMSG(const char* format, ...)
     {
-      char buf[4096], * p = buf;
+      char buf[4096];
       va_list args;
-      int     n;
+      int n;
 
       va_start(args, format);
-      n = _vsnprintf(p, sizeof buf - 3, format, args); // buf-3 is room for CR/LF/NUL
+      n = vsnprintf_s(buf, sizeof buf, sizeof buf - 1, format, args);
       va_end(args);
-
-      p += (n < 0) ? sizeof buf - 3 : n;
-
-      while (p > buf&& isspace(p[-1]))
-        *--p = '\0';
-
-      *p++ = '\r';
-      *p++ = '\n';
-      *p = '\0';
 
       OutputDebugStringW(UTF8AsUTF16(buf).Get());
     }

--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -87,7 +87,7 @@ BEGIN_IPLUG_NAMESPACE
       char logFilePath[MAX_MACOS_PATH_LEN];
       snprintf(logFilePath, MAX_MACOS_PATH_LEN, "%s/%s", getenv("HOME"), LOGFILE);
   #endif
-      mFP = fopen(logFilePath, "w");
+      mFP = fopenUTF8(logFilePath, "w");
       assert(mFP);
       
       DBGMSG("Logging to %s\n", logFilePath);

--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -41,11 +41,6 @@ BEGIN_IPLUG_NAMESPACE
   #if defined(OS_MAC) || defined(OS_LINUX) || defined(OS_WEB) || defined(OS_IOS)
     #define DBGMSG(...) printf(__VA_ARGS__)
   #elif defined OS_WIN
-    #ifdef OutputDebugString
-    #undef OutputDebugString
-    #define OutputDebugString OutputDebugStringA
-    #endif
-
     static void DBGMSG(const char* format, ...)
     {
       char buf[4096], * p = buf;
@@ -65,7 +60,7 @@ BEGIN_IPLUG_NAMESPACE
       *p++ = '\n';
       *p = '\0';
 
-      OutputDebugString(buf);
+      OutputDebugStringW(UTF8AsUTF16(buf).Get());
     }
   #endif
 #endif

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -30,33 +30,6 @@ BEGIN_IPLUG_NAMESPACE
 #if defined OS_WIN
 #pragma mark - OS_WIN
 
-// Unicode helpers
-void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
-{
-  int requiredSize = MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
-
-  if (requiredSize > 0 && requiredSize <= maxLen)
-  {
-    MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, utf16Str, requiredSize);
-    return;
-  }
-
-  utf16Str[0] = 0;
-}
-
-void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str)
-{
-  int requiredSize = WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, NULL, 0, NULL, NULL);
-
-  if (requiredSize > 0 && utf8Str.SetLen(requiredSize))
-  {
-    WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, utf8Str.Get(), requiredSize, NULL, NULL);
-    return;
-  }
-
-  utf8Str.Set("");
-}
-
  // Helper for getting a known folder in UTF8
 void GetKnownFolder(WDL_String &path, int identifier, int flags = 0)
 {

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -41,7 +41,7 @@ void GetKnownFolder(WDL_String &path, int identifier, int flags = 0)
 
 static void GetModulePath(HMODULE hModule, WDL_String& path)
 {
-  wchar_t pathCStrW[MAX_WIN32_PATH_LEN] = { '\0' };
+  wchar_t pathCStrW[MAX_WIN32_PATH_LEN] = {'\0'};
 
   path.Set("");
 

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -157,6 +157,7 @@ static BOOL CALLBACK EnumResNameProc(HMODULE module, LPCWSTR type, LPWSTR name, 
 
       if (strcmp(searchName.Get(), strippedName.Get()) == 0) // if we are looking for a resource with this name
       {
+        UTF16ToUTF8(search->mName, name);
         search->mFound = true;
         return false;
       }
@@ -184,7 +185,7 @@ EResourceLocation LocateResource(const char* name, const char* type, WDL_String&
 
     if (search.mFound)
     {
-      result.SetFormatted(MAX_PATH, "\"%s\"", search.mName.Get());
+      result.Set(search.mName.Get());
       return EResourceLocation::kWinBinary;
     }
     else

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -181,7 +181,7 @@ EResourceLocation LocateResource(const char* name, const char* type, WDL_String&
 
     HMODULE hInstance = static_cast<HMODULE>(pHInstance);
 
-    EnumResourceNamesW(hInstance, typeUpper.Get(), EnumResNameProc, (LONG_PTR)&search);
+    EnumResourceNamesW(hInstance, typeUpper.Get(), EnumResNameProc, (LONG_PTR) &search);
 
     if (search.mFound)
     {

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -41,22 +41,25 @@ void GetKnownFolder(WDL_String &path, int identifier, int flags = 0)
 
 static void GetModulePath(HMODULE hModule, WDL_String& path)
 {
+  wchar_t pathCStrW[MAX_WIN32_PATH_LEN] = { '\0' };
+
   path.Set("");
-  char pathCStr[MAX_WIN32_PATH_LEN];
-  pathCStr[0] = '\0';
-  if (GetModuleFileName(hModule, pathCStr, MAX_WIN32_PATH_LEN))
+
+  if (GetModuleFileNameW(hModule, pathCStrW, MAX_WIN32_PATH_LEN))
   {
+    UTF16AsUTF8 pathTemp(pathCStrW);
+
     int s = -1;
-    for (int i = 0; i < strlen(pathCStr); ++i)
+    for (int i = 0; i < strlen(pathTemp.Get()); ++i)
     {
-      if (pathCStr[i] == '\\')
+      if (pathTemp.Get()[i] == '\\')
       {
         s = i;
       }
     }
-    if (s >= 0 && s + 1 < strlen(pathCStr))
+    if (s >= 0 && s + 1 < strlen(pathTemp.Get()))
     {
-      path.Set(pathCStr, s + 1);
+      path.Set(pathTemp.Get(), s + 1);
     }
   }
 }
@@ -122,20 +125,40 @@ void WebViewCachePath(WDL_String& path)
   path.Append("\\iPlug2\\WebViewCache"); // tmp
 }
 
-static BOOL EnumResNameProc(HANDLE module, LPCTSTR type, LPTSTR name, LONG_PTR param)
+struct WinResourceSearch
 {
-  if (IS_INTRESOURCE(name)) return true; // integer resources not wanted
-  else {
-    WDL_String* search = (WDL_String*)param;
-    if (search != 0 && name != 0)
+  WinResourceSearch(const char* name)
+  : mName(name)
+  {
+  }
+
+  WDL_String mName;
+  bool mFound = false;
+};
+
+static BOOL CALLBACK EnumResNameProc(HMODULE module, LPCWSTR type, LPWSTR name, LONG_PTR param)
+{
+  if (IS_INTRESOURCE(name))
+    return true; // integer resources not wanted
+  else
+  {
+    WinResourceSearch* search = reinterpret_cast<WinResourceSearch*>(param);
+   
+    if (search != nullptr && name != nullptr)
     {
+      WDL_String searchName(search->mName);
+
       //strip off extra quotes
-      WDL_String strippedName(strlwr(name + 1));
+      WDL_String strippedName((UTF16AsUTF8(name).Get() + 1));
       strippedName.SetLen(strippedName.GetLength() - 1);
 
-      if (strcmp(strlwr(search->Get()), strippedName.Get()) == 0) // if we are looking for a resource with this name
+      // convert both to lower case
+      _strlwr(strippedName.Get());
+      _strlwr(searchName.Get());
+
+      if (strcmp(searchName.Get(), strippedName.Get()) == 0) // if we are looking for a resource with this name
       {
-        search->SetFormatted(strippedName.GetLength() + 7, "found: %s", strippedName.Get());
+        search->mFound = true;
         return false;
       }
     }
@@ -144,25 +167,33 @@ static BOOL EnumResNameProc(HANDLE module, LPCTSTR type, LPTSTR name, LONG_PTR p
   return true; // keep enumerating
 }
 
+static UTF8AsUTF16 TypeToUpper(const char* type)
+{
+  WDL_String typeUpper(type);
+  _strupr(typeUpper.Get());
+
+  return type;
+}
+
 EResourceLocation LocateResource(const char* name, const char* type, WDL_String& result, const char*, void* pHInstance, const char*)
 {
   if (CStringHasContents(name))
   {
-    WDL_String search(name);
-    WDL_String typeUpper(type);
+    WinResourceSearch search(name);
+    auto typeUpper = TypeToUpper(type);
 
     HMODULE hInstance = static_cast<HMODULE>(pHInstance);
 
-    EnumResourceNames(hInstance, _strupr(typeUpper.Get()), (ENUMRESNAMEPROC)EnumResNameProc, (LONG_PTR)&search);
+    EnumResourceNamesW(hInstance, typeUpper.Get(), EnumResNameProc, (LONG_PTR)&search);
 
-    if (strstr(search.Get(), "found: ") != 0)
+    if (search.mFound)
     {
-      result.SetFormatted(MAX_PATH, "\"%s\"", search.Get() + 7, search.GetLength() - 7); // 7 = strlen("found: ")
+      result.SetFormatted(MAX_PATH, "\"%s\"", search.mName.Get());
       return EResourceLocation::kWinBinary;
     }
     else
     {
-      if (PathFileExists(name))
+      if (PathFileExistsW(UTF8AsUTF16(name).Get()))
       {
         result.Set(name);
         return EResourceLocation::kAbsolutePath;
@@ -174,11 +205,11 @@ EResourceLocation LocateResource(const char* name, const char* type, WDL_String&
 
 const void* LoadWinResource(const char* resid, const char* type, int& sizeInBytes, void* pHInstance)
 {
-  WDL_String typeUpper(type);
+  auto typeUpper = TypeToUpper(type);
 
   HMODULE hInstance = static_cast<HMODULE>(pHInstance);
 
-  HRSRC hResource = FindResource(hInstance, resid, _strupr(typeUpper.Get()));
+  HRSRC hResource = FindResourceW(hInstance, UTF8AsUTF16(resid).Get(), typeUpper.Get());
 
   if (!hResource)
     return NULL;

--- a/IPlug/IPlugPaths.cpp
+++ b/IPlug/IPlugPaths.cpp
@@ -128,8 +128,8 @@ void WebViewCachePath(WDL_String& path)
 struct WinResourceSearch
 {
   WinResourceSearch(const char* name)
-  : mName(name)
   {
+    UTF16ToUTF8(mName, UTF8AsUTF16(name).ToLowerCase().Get());
   }
 
   WDL_String mName;
@@ -152,9 +152,8 @@ static BOOL CALLBACK EnumResNameProc(HMODULE module, LPCWSTR type, LPWSTR name, 
       WDL_String strippedName((UTF16AsUTF8(name).Get() + 1));
       strippedName.SetLen(strippedName.GetLength() - 1);
 
-      // convert both to lower case
-      _strlwr(strippedName.Get());
-      _strlwr(searchName.Get());
+      // convert the stripped name to lower case (the search is already lower case)
+      UTF16ToUTF8(strippedName, UTF8AsUTF16(strippedName).ToLowerCase().Get());
 
       if (strcmp(searchName.Get(), strippedName.Get()) == 0) // if we are looking for a resource with this name
       {
@@ -169,10 +168,7 @@ static BOOL CALLBACK EnumResNameProc(HMODULE module, LPCWSTR type, LPWSTR name, 
 
 static UTF8AsUTF16 TypeToUpper(const char* type)
 {
-  WDL_String typeUpper(type);
-  _strupr(typeUpper.Get());
-
-  return type;
+  return UTF8AsUTF16(type).ToUpperCase();
 }
 
 EResourceLocation LocateResource(const char* name, const char* type, WDL_String& result, const char*, void* pHInstance, const char*)

--- a/IPlug/IPlugPaths.h
+++ b/IPlug/IPlugPaths.h
@@ -27,13 +27,6 @@ using PluginIDType = HMODULE;
 using PluginIDType = void *;
 #endif
 
-#if defined OS_WIN
-#include <windows.h>
- // Unicode helpers
-void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen);
-void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str);
-#endif
-
 /** Get the path to the host binary 
 * @param path WDL_String reference where the path will be put on success or empty string on failure */
 extern void HostPath(WDL_String& path, const char* bundleID = 0);

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -537,7 +537,7 @@ void IPluginBase::DumpMakePresetSrc(const char* filename) const
   {
     sDumped = true;
     int i, n = NParams();
-    FILE* fp = fopen(filename, "a");
+    FILE* fp = fopenUTF8(filename, "a");
     
     if (!fp)
       return;
@@ -581,7 +581,7 @@ void IPluginBase::DumpMakePresetFromNamedParamsSrc(const char* filename, const c
   {
     sDumped = true;
     int i, n = NParams();
-    FILE* fp = fopen(filename, "a");
+    FILE* fp = fopenUTF8(filename, "a");
     
     if (!fp)
       return;
@@ -618,7 +618,7 @@ void IPluginBase::DumpMakePresetFromNamedParamsSrc(const char* filename, const c
 
 void IPluginBase::DumpPresetBlob(const char* filename) const
 {
-  FILE* fp = fopen(filename, "a");
+  FILE* fp = fopenUTF8(filename, "a");
   
   if (!fp)
     return;
@@ -645,7 +645,7 @@ bool IPluginBase::SavePresetAsFXP(const char* file) const
 {
   if (CStringHasContents(file))
   {
-    FILE* fp = fopen(file, "wb");
+    FILE* fp = fopenUTF8(file, "wb");
     
     IByteChunk pgm;
     
@@ -718,7 +718,7 @@ bool IPluginBase::SaveBankAsFXB(const char* file) const
 {
   if (CStringHasContents(file))
   {
-    FILE* fp = fopen(file, "wb");
+    FILE* fp = fopenUTF8(file, "wb");
     
     IByteChunk bnk;
     
@@ -823,7 +823,7 @@ bool IPluginBase::LoadPresetFromFXP(const char* file)
 {
   if (CStringHasContents(file))
   {
-    FILE* fp = fopen(file, "rb");
+    FILE* fp = fopenUTF8(file, "rb");
     
     if (fp)
     {
@@ -914,7 +914,7 @@ bool IPluginBase::LoadBankFromFXB(const char* file)
 {
   if (CStringHasContents(file))
   {
-    FILE* fp = fopen(file, "rb");
+    FILE* fp = fopenUTF8(file, "rb");
     
     if (fp)
     {

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -31,6 +31,7 @@
 #include "IPlugPlatform.h"
 
 #ifdef OS_WIN
+#include <windows.h>
 #pragma warning(disable:4018 4267)	// size_t/signed/unsigned mismatch..
 #pragma warning(disable:4800)		// if (pointer) ...
 #pragma warning(disable:4805)		// Compare bool and BOOL.
@@ -311,6 +312,36 @@ static void MidiNoteName(double midiPitch, WDL_String& noteName, bool cents = fa
     noteName.SetFormatted(32, "%s%i", noteNames[pitchClass], octave);
   }
 }
+
+#if defined OS_WIN
+
+static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
+{
+  int requiredSize = MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+
+  if (requiredSize > 0 && requiredSize <= maxLen)
+  {
+    MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, utf16Str, requiredSize);
+    return;
+  }
+
+  utf16Str[0] = 0;
+}
+
+static void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str)
+{
+  int requiredSize = WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, NULL, 0, NULL, NULL);
+
+  if (requiredSize > 0 && utf8Str.SetLen(requiredSize))
+  {
+    WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, utf8Str.Get(), requiredSize, NULL, NULL);
+    return;
+  }
+
+  utf8Str.Set("");
+}
+
+#endif
 
 END_IPLUG_NAMESPACE
 

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <cctype>
 
+#include "heapbuf.h"
 #include "wdlstring.h"
 
 #include "IPlugConstants.h"
@@ -341,6 +342,42 @@ static void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str)
   utf8Str.Set("");
 }
 
+class UTF8AsUTF16
+{
+public:
+
+  UTF8AsUTF16(const char* utf8Str)
+  {
+    mUTF16Str.Resize(MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0));
+    UTF8ToUTF16(mUTF16Str.Get(), utf8Str, mUTF16Str.GetSize());
+  }
+
+  UTF8AsUTF16(WDL_String utf8Str) : UTF8AsUTF16(utf8Str.Get())
+  {
+  }
+
+  const wchar_t* Get() { return mUTF16Str.Get(); }
+
+private:
+
+  WDL_TypedBuf<wchar_t> mUTF16Str;
+};
+
+class UTF16AsUTF8
+{
+public:
+
+  UTF16AsUTF8(const wchar_t* utf16Str)
+  {
+    UTF16ToUTF8(mUTF8Str, utf16Str);
+  }
+
+  const char* Get() { return mUTF8Str.Get(); }
+
+private:
+
+  WDL_String mUTF8Str;
+};
 #endif
 
 END_IPLUG_NAMESPACE

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -357,7 +357,7 @@ public:
     UTF8ToUTF16(mUTF16Str.Get(), utf8Str, mUTF16Str.GetSize());
   }
 
-  UTF8AsUTF16(WDL_String utf8Str) : UTF8AsUTF16(utf8Str.Get())
+  UTF8AsUTF16(const WDL_String& utf8Str) : UTF8AsUTF16(utf8Str.Get())
   {
   }
 

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -325,10 +325,10 @@ static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
 {
   int requiredSize = UTF8ToUTF16Len(utf8Str);
 
-  if (requiredSize > 0 && requiredSize <= maxLen)
+  if (requiredSize <= maxLen)
   {
-    MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, utf16Str, requiredSize);
-    return;
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, utf16Str, requiredSize))
+      return;
   }
 
   utf16Str[0] = '\0';

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -399,6 +399,23 @@ private:
 };
 #endif
 
+
+#if defined OS_WIN
+
+static FILE* fopenUTF8(const char* path, const char* mode)
+{
+  return _wfopen(UTF8AsUTF16(path).Get(), UTF8AsUTF16(mode).Get());
+}
+
+#else
+
+static FILE* fopenUTF8(const char* path, const char* mode)
+{
+  return fopen(path, mode);
+}
+
+#endif
+
 END_IPLUG_NAMESPACE
 
 /**@}*/

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -318,7 +318,7 @@ static void MidiNoteName(double midiPitch, WDL_String& noteName, bool cents = fa
 
 static int UTF8ToUTF16Len(const char* utf8Str)
 {
-  return MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+  return std::max(MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0), 1);
 }
 
 static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -364,6 +364,18 @@ public:
   const wchar_t* Get() const { return mUTF16Str.Get(); }
   int GetLength() const { return mUTF16Str.GetSize(); }
 
+  UTF8AsUTF16& ToUpperCase()
+  {
+    _wcsupr(mUTF16Str.Get());
+    return *this;
+  }
+
+  UTF8AsUTF16& ToLowerCase()
+  {
+    _wcslwr(mUTF16Str.Get());
+    return *this;
+  }
+
 private:
 
   WDL_TypedBuf<wchar_t> mUTF16Str;

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -316,9 +316,14 @@ static void MidiNoteName(double midiPitch, WDL_String& noteName, bool cents = fa
 
 #if defined OS_WIN
 
+static int UTF8ToUTF16Len(const char* utf8Str)
+{
+  return MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+}
+
 static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
 {
-  int requiredSize = MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+  int requiredSize = UTF8ToUTF16Len(utf8Str);
 
   if (requiredSize > 0 && requiredSize <= maxLen)
   {
@@ -326,7 +331,7 @@ static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
     return;
   }
 
-  utf16Str[0] = 0;
+  utf16Str[0] = '\0';
 }
 
 static void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str)
@@ -348,7 +353,7 @@ public:
 
   UTF8AsUTF16(const char* utf8Str)
   {
-    mUTF16Str.Resize(MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0));
+    mUTF16Str.Resize(UTF8ToUTF16Len(utf8Str));
     UTF8ToUTF16(mUTF16Str.Get(), utf8Str, mUTF16Str.GetSize());
   }
 
@@ -356,7 +361,8 @@ public:
   {
   }
 
-  const wchar_t* Get() { return mUTF16Str.Get(); }
+  const wchar_t* Get() const { return mUTF16Str.Get(); }
+  int GetLength() const { return mUTF16Str.GetSize(); }
 
 private:
 
@@ -372,7 +378,8 @@ public:
     UTF16ToUTF8(mUTF8Str, utf16Str);
   }
 
-  const char* Get() { return mUTF8Str.Get(); }
+  const char* Get() const { return mUTF8Str.Get(); }
+  int GetLength() const { return mUTF8Str.GetLength(); }
 
 private:
 

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -321,26 +321,26 @@ static int UTF8ToUTF16Len(const char* utf8Str)
   return std::max(MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0), 1);
 }
 
-static void UTF8ToUTF16(wchar_t* utf16Str, const char* utf8Str, int maxLen)
+static void UTF8ToUTF16(wchar_t* wideStr, const char* utf8Str, int maxLen)
 {
   int requiredSize = UTF8ToUTF16Len(utf8Str);
 
   if (requiredSize <= maxLen)
   {
-    if (MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, utf16Str, requiredSize))
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, wideStr, requiredSize))
       return;
   }
 
-  utf16Str[0] = '\0';
+  wideStr[0] = '\0';
 }
 
-static void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* utf16Str)
+static void UTF16ToUTF8(WDL_String& utf8Str, const wchar_t* wideStr)
 {
-  int requiredSize = WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, NULL, 0, NULL, NULL);
+  int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wideStr, -1, NULL, 0, NULL, NULL);
 
   if (requiredSize > 0 && utf8Str.SetLen(requiredSize))
   {
-    WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, utf8Str.Get(), requiredSize, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, wideStr, -1, utf8Str.Get(), requiredSize, NULL, NULL);
     return;
   }
 
@@ -385,9 +385,9 @@ class UTF16AsUTF8
 {
 public:
 
-  UTF16AsUTF8(const wchar_t* utf16Str)
+  UTF16AsUTF8(const wchar_t* wideStr)
   {
-    UTF16ToUTF8(mUTF8Str, utf16Str);
+    UTF16ToUTF8(mUTF8Str, wideStr);
   }
 
   const char* Get() const { return mUTF8Str.Get(); }

--- a/IPlug/IPlug_include_in_plug_src.h
+++ b/IPlug/IPlug_include_in_plug_src.h
@@ -41,7 +41,7 @@
   {
     if (!__GetDpiForWindow)
     {
-      HINSTANCE h = LoadLibraryA("user32.dll");
+      HINSTANCE h = LoadLibraryW(L"user32.dll");
       if (h) *(void **)&__GetDpiForWindow = GetProcAddress(h, "GetDpiForWindow");
 
       if (!__GetDpiForWindow)


### PR DESCRIPTION
This PR replaces #1006 and is focused on improving unicode support for windows.

In general iPlug2 treats strings as UTF8, but this is not natively supported under windows, so conversion between UTF8 and UTF16 is needed to account for the changes. Here we explicitly call windows functions in their wide version (ending W()), rather than the ANSI version (ending A()) and perform manual conversion. We avoid the macro versions that switch based on the settings of UNICODE and _UNICODE. This makes settings relating to unicode (or macro definitions) irrelevant to which functions iPlug2 makes use of, but leaves developers free to use that for other purposes.

