### PR TITLE
Make GetWantsGestures() virtual

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -436,8 +436,8 @@ public:
    * @param func the function to trigger */
   IControl* AttachGestureRecognizer(EGestureType type, IGestureFunc func);
   
-  /** @return /c true if this control supports multiple gestures */
-  bool GetWantsGestures() const { return mGestureFuncs.size() > 0 && !mAnimationFunc; }
+  /** @return /c true if this control supports gestures (override if you are not calling IControl::AttachGestureRecognizer but are overriding OnGesture()) */
+  virtual bool GetWantsGestures() const { return mGestureFuncs.size() > 0 && !mAnimationFunc; }
   
   /** @return the last recognized gesture */
   EGestureType GetLastGesture() const { return mLastGesture; }


### PR DESCRIPTION
As discussed on call - this allows controls to accept gestures in a custom manner.

This has two advantages:

1 - for users who want to still accept gestures whilst an animation is running (currently disallowed)
2 - for users who are bypassing IControl::AttachGestureRecognizer(), attaching directly to IGraphics, and then overriding IConrol::OnGesture()

Both of these seem useful, and there is no effect on previously written code by making this virtual.