### PR TITLE
Fixed memory leak when closing opengl window on macos (fix for issue #1060)

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -131,7 +131,8 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
       
 #ifdef IGRAPHICS_GL
-    [[pView openGLContext] makeCurrentContext];
+    [[pView pixelFormat] release];
+    [[pView openGLContext] release];
 #endif
       
     [pView removeAllToolTips];


### PR DESCRIPTION
Releasing these resources fixes the leak.