### PR TITLE
WebView: crash when rapidly closing/reopening window in FLStudio on windows

### DIFF
--- a/IPlug/Extras/WebView/IPlugWebView.cpp
+++ b/IPlug/Extras/WebView/IPlugWebView.cpp
@@ -66,6 +66,10 @@ void* IWebView::OpenWebView(void* pParent, float x, float y, float w, float h, f
               mWebViewCtrlr = controller;
               mWebViewCtrlr->get_CoreWebView2(&mWebViewWnd);
             }
+            
+            if (mWebViewWnd == nullptr) {
+              return S_OK;
+            }
 
             mWebViewCtrlr->put_IsVisible(mShowOnLoad);
 


### PR DESCRIPTION
fixes https://github.com/iPlug2/iPlug2/issues/1062

I am still new, so this is a bit of a pragmatic fix. As far as I understand the issue I was having, when opening the plugin in FL Studio, this loading code is executed. Buf if the plugin is closed very quickly, this callback seems to get called anyway. So without some kind of check whether the state is still valid, this function may run into problems. And the check I came up with was 

```cpp
if (mWebViewWnd == nullptr) {
  return S_OK;
}
```

I couldn't test this code on any machine except my dev machine (Windows 11, VST3, FL Studio 21), but I don't see how it could cause problems on other machines.

Hope it helps, love your library <3