### PR TITLE
ShowMessageBox: fix for switched caption and string on mac

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -296,23 +296,23 @@ EMsgBoxResult IGraphicsMac::ShowMessageBox(const char* str, const char* caption,
   switch (type)
   {
     case kMB_OK:
-      NSRunAlertPanel(msg, @"%@", @"OK", @"", @"", cap);
+      NSRunAlertPanel(cap, @"%@", @"OK", @"", @"", msg);
       result = kOK;
       break;
     case kMB_OKCANCEL:
-      result = NSRunAlertPanel(msg, @"%@", @"OK", @"Cancel", @"", cap);
+      result = NSRunAlertPanel(cap, @"%@", @"OK", @"Cancel", @"", msg);
       result = result ? kOK : kCANCEL;
       break;
     case kMB_YESNO:
-      result = NSRunAlertPanel(msg, @"%@", @"Yes", @"No", @"", cap);
+      result = NSRunAlertPanel(cap, @"%@", @"Yes", @"No", @"", msg);
       result = result ? kYES : kNO;
       break;
     case kMB_RETRYCANCEL:
-      result = NSRunAlertPanel(msg, @"%@", @"Retry", @"Cancel", @"", cap);
+      result = NSRunAlertPanel(cap, @"%@", @"Retry", @"Cancel", @"", msg);
       result = result ? kRETRY : kCANCEL;
       break;
     case kMB_YESNOCANCEL:
-      result = NSRunAlertPanel(msg, @"%@", @"Yes", @"Cancel", @"No", cap);
+      result = NSRunAlertPanel(cap, @"%@", @"Yes", @"Cancel", @"No", msg);
       result = (result == 1) ? kYES : (result == -1) ? kNO : kCANCEL;
       break;
   }


### PR DESCRIPTION
Fix for issue #1070

The following code:
`G.ShowMessageBox("str", "caption", kMB_OK);`
before commit:
<img width="271" alt="messageBox_mac" src="https://github.com/iPlug2/iPlug2/assets/1098215/feb99775-ed4c-4057-aba6-85352180b869">
after commit:
<img width="265" alt="messageBox_mac_fix" src="https://github.com/iPlug2/iPlug2/assets/1098215/d00fc0b4-a3fd-4ba5-bf47-5657d6c534c3">
