### PR TITLE
Add IPlatformView and IPlatformViewControl

### DIFF
--- a/IGraphics/Controls/IPlatformViewControl.h
+++ b/IGraphics/Controls/IPlatformViewControl.h
@@ -1,0 +1,107 @@
+/*
+ ==============================================================================
+
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+
+ See LICENSE.txt for  more info.
+
+ ==============================================================================
+*/
+
+#pragma once
+
+/**
+ * @file
+ * @ingroup Controls
+ * @copydoc IPlatformViewControl
+ */
+
+#include "IControl.h"
+#include "IPlugPlatformView.h"
+
+#include <functional>
+
+BEGIN_IPLUG_NAMESPACE
+BEGIN_IGRAPHICS_NAMESPACE
+
+/** A control that let's you embed a HWND, UIView or NSView inside an IGraphics UI
+ * @ingroup IControls */
+class IPlatformViewControl : public IControl, public IPlatformView
+{
+public:
+  using AttachFunc = std::function<void(void* pParentView)>;
+
+  /** Constructs an IPlatformViewControl
+   * @param bounds The control's bounds
+   * @param opaque Should the  view's background be opaque 
+   * @param attachFunc If you want to attach the sub views in-line */
+  IPlatformViewControl(const IRECT& bounds, bool opaque = true, AttachFunc attachFunc = nullptr)
+  : IControl(bounds)
+  , IPlatformView(opaque)
+  , mAttachFunc(attachFunc)
+  {
+  }
+  
+  ~IPlatformViewControl()
+  {
+    GetUI()->RemovePlatformView(mPlatformView);
+    mPlatformView = nullptr;
+  }
+  
+  void OnAttached() override
+  {
+    mPlatformView = CreatePlatformView(GetUI()->GetWindow(), mRECT.L, mRECT.T, mRECT.W(), mRECT.H(), GetUI()->GetTotalScale());
+    GetUI()->AttachPlatformView(mRECT, mPlatformView);
+    AttachSubViews(mPlatformView);
+  }
+  
+  void Draw(IGraphics& g) override { /* NO-OP */ }
+  
+  void OnMouseDown(float x, float y, const IMouseMod& mod) override { /* NO-OP */ }
+
+  void OnRescale() override
+  {
+    UpdateChildViewBounds();
+  }
+
+  void OnResize() override
+  {
+    UpdateChildViewBounds();
+  }
+  
+  /* Override this method in separate .cpp or .mm files if you want to keep
+   * objective C out of you main layout function
+   */
+  virtual void AttachSubViews(void* pPlatformView)
+  {
+    if (mAttachFunc)
+      mAttachFunc(pPlatformView);
+  }
+  
+  void* GetPlatformView()
+  {
+    return mPlatformView;
+  }
+
+  void Hide(bool hide) override
+  {
+    if (mPlatformView)
+      GetUI()->HidePlatformView(mPlatformView, hide);
+    
+    IControl::Hide(hide);
+  }
+  
+private:
+  void UpdateChildViewBounds()
+  {
+    auto ds = GetUI()->GetDrawScale();
+    SetChildViewBounds(mRECT.L * ds, mRECT.T * ds, mRECT.W() * ds, mRECT.H() * ds, ds);
+  }
+  
+  void* mPlatformView = nullptr;
+  AttachFunc mAttachFunc;
+};
+
+END_IGRAPHICS_NAMESPACE
+END_IPLUG_NAMESPACE
+

--- a/IGraphics/Controls/IWebViewControl.h
+++ b/IGraphics/Controls/IWebViewControl.h
@@ -90,6 +90,14 @@ public:
     UpdateWebViewBounds();
   }
   
+  void Hide(bool hide) override
+  {
+    if (mPlatformView)
+      GetUI()->HidePlatformView(mPlatformView, hide);
+    
+    IControl::Hide(hide);
+  }
+  
 private:
   void UpdateWebViewBounds()
   {

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -801,6 +801,11 @@ public:
   /** Remove a previously attached platform view from the IGraphics view
    * @param pView the platform view to remove, which would be a HWND on Windows, NSView* on macOS or UIView* on iOS */
   virtual void RemovePlatformView(void* pView) {};
+  
+  /** Hide a previously attached platform view from the IGraphics view
+   * @param pView the platform view to remove, which would be a HWND on Windows, NSView* on macOS or UIView* on iOS
+   * @param hide should it be hidden or not */
+  virtual void HidePlatformView(void* pView, bool hide) {};
 
   /** Get the x, y position of the mouse cursor
    * @param x Where the X position will be stored

--- a/IGraphics/Platforms/IGraphicsIOS.h
+++ b/IGraphics/Platforms/IGraphicsIOS.h
@@ -36,6 +36,7 @@ public:
   void PlatformResize(bool parentHasResized) override;
   void AttachPlatformView(const IRECT& r, void* pView) override;
   void RemovePlatformView(void* pView) override;
+  void HidePlatformView(void* pView, bool hide) override;
 
   void GetMouseLocation(float& x, float&y) const override;
 

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -161,6 +161,11 @@ void IGraphicsIOS::RemovePlatformView(void* pView)
   [(UIView*) pView removeFromSuperview];
 }
 
+void IGraphicsIOS::HidePlatformView(void* pView, bool hide)
+{
+  [(UIView*) pView setHidden:hide];
+}
+
 EMsgBoxResult IGraphicsIOS::ShowMessageBox(const char* str, const char* caption, EMsgBoxType type, IMsgBoxCompletionHandlerFunc completionHandler)
 {
   ReleaseMouseCapture();

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -35,6 +35,7 @@ public:
   void PlatformResize(bool parentHasResized) override;
   void AttachPlatformView(const IRECT& r, void* pView) override;
   void RemovePlatformView(void* pView) override;
+  void HidePlatformView(void* pView, bool hide) override;
 
   void HideMouseCursor(bool hide, bool lock) override;
   void MoveMouseCursor(float x, float y) override;

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -124,6 +124,11 @@ void IGraphicsMac::RemovePlatformView(void* pView)
   [(NSView*) pView removeFromSuperview];
 }
 
+void IGraphicsMac::HidePlatformView(void* pView, bool hide)
+{
+  [(NSView*) pView setHidden:hide];
+}
+
 void IGraphicsMac::CloseWindow()
 {
   if (mView)

--- a/IPlug/Extras/PlatformView/IPlugPlatformView.h
+++ b/IPlug/Extras/PlatformView/IPlugPlatformView.h
@@ -1,0 +1,48 @@
+ /*
+ ==============================================================================
+ 
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+ 
+ See LICENSE.txt for  more info.
+ 
+ ==============================================================================
+*/
+
+#pragma once
+
+#include "IPlugPlatform.h"
+#include "wdlstring.h"
+#include <functional>
+
+#if defined OS_MAC
+  #define PLATFORM_VIEW NSView
+  #define PLATFORM_RECT NSRect
+  #define MAKERECT NSMakeRect
+#elif defined OS_IOS
+  #define PLATFORM_VIEW UIView
+  #define PLATFORM_RECT CGRect
+  #define MAKERECT CGRectMake
+#elif defined OS_WIN
+  #define PLATFORM_VIEW HWND
+#endif
+
+BEGIN_IPLUG_NAMESPACE
+
+/** IPlatformView is a base interface for hosting a platform view inside an IPlug plug-in's UI */
+class IPlatformView
+{
+public:
+  IPlatformView(bool opaque = true);
+  virtual ~IPlatformView();
+
+  void* CreatePlatformView(void* pParent, float x, float y, float w, float h, float scale = 1.);
+  void RemovePlatformView();
+
+  void SetChildViewBounds(float x, float y, float w, float h, float scale = 1.);
+  
+private:
+  bool mOpaque = true;
+  void* mPlatformView = nullptr;
+};
+
+END_IPLUG_NAMESPACE

--- a/IPlug/Extras/PlatformView/IPlugPlatformView.mm
+++ b/IPlug/Extras/PlatformView/IPlugPlatformView.mm
@@ -1,0 +1,53 @@
+ /*
+ ==============================================================================
+ 
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+ 
+ See LICENSE.txt for  more info.
+ 
+ ==============================================================================
+*/
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with Arc. Use -fobjc-arc flag
+#endif
+
+#include "IPlugPlatformView.h"
+#include "IPlugPaths.h"
+
+using namespace iplug;
+
+IPlatformView::IPlatformView(bool opaque)
+: mOpaque(opaque)
+{
+}
+
+IPlatformView::~IPlatformView()
+{
+  RemovePlatformView();
+}
+
+void* IPlatformView::CreatePlatformView(void* pParent, float x, float y, float w, float h, float scale)
+{
+  @autoreleasepool {
+    PLATFORM_VIEW* platformView = [[PLATFORM_VIEW alloc] initWithFrame:MAKERECT(x,y,w,h)];
+    mPlatformView = (__bridge_retained void*) platformView;
+  }
+
+  return mPlatformView;
+}
+
+void IPlatformView::RemovePlatformView()
+{
+  @autoreleasepool {
+    PLATFORM_VIEW* platformView = (__bridge_transfer PLATFORM_VIEW*) mPlatformView;
+    [platformView removeFromSuperview];
+  }
+  
+  mPlatformView = nullptr;
+}
+
+void IPlatformView::SetChildViewBounds(float x, float y, float w, float h, float scale)
+{
+  [(__bridge PLATFORM_VIEW*) mPlatformView setFrame: MAKERECT(x, y, w, h) ];
+}


### PR DESCRIPTION
IPlatformView is an interface for hosting a platform view (NSView, UIView, HWND*) inside an IPlug plug-in's UI.

IPlatformViewControl is an IControl that uses IPlatformView.

* this PR only adds macOS/iOS support for now.

A future cleanup could involve making IWebView inherit from IPlatformView