### PR TITLE
mac-opengl render: proper init and exit (fixes issue #1080)

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -580,6 +580,12 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
                                                  name:NSViewFrameDidChangeNotification
                                                object:self];
     #endif
+    #ifdef IGRAPHICS_GL
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(frameDidChange:)
+                                                 name:NSViewGlobalFrameDidChangeNotification
+                                               object:self];
+    #endif
     
 //    [[NSNotificationCenter defaultCenter] addObserver:self
 //                                             selector:@selector(windowResized:) name:NSWindowDidEndLiveResizeNotification
@@ -670,6 +676,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     #endif
     #ifdef IGRAPHICS_GL
     [[self openGLContext] flushBuffer];
+    [NSOpenGLContext clearCurrentContext];
     #endif
   }
 }
@@ -1297,6 +1304,12 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 
   [(CAMetalLayer*)[self layer] setDrawableSize:CGSizeMake(self.frame.size.width * scale,
                                                           self.frame.size.height * scale)];
+}
+#endif
+#ifdef IGRAPHICS_GL
+- (void) frameDidChange:(NSNotification*) pNotification
+{
+  [[self openGLContext] makeCurrentContext];
 }
 #endif
 

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -611,6 +611,9 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
   CGFloat newScale = [pWindow backingScaleFactor];
   
   mGraphics->SetPlatformContext(nullptr);
+#ifdef IGRAPHICS_GL
+  [[self openGLContext] makeCurrentContext];
+#endif
   
   if (newScale != mGraphics->GetScreenScale())
     mGraphics->SetScreenScale(newScale);


### PR DESCRIPTION
The clearCurrentContext solves issue #1080. It is also apparently an accepted solution to various mac+opengl issues on SO, for example:

https://stackoverflow.com/questions/21798018/nsopenglcontext-destroying-textures-of-another-context

Most UI repos out there seem to start render calls with makeCurrentContext and end with clearCurrentContext. That is what I had to go on since Apple's docs don't say why/when it should be used.

The addObserver solves an issue in FL Studio-mac where if a complex iPlug2 gui is opened and closed really quickly, it would crash the FL Studio renderer. Same here, no docs do go on, but it looks like something people have learned is good to do.
