### PR TITLE
fixed dropped const in IGraphicsWin under c++20 (MSVC)

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -36,7 +36,7 @@ using namespace igraphics;
 #pragma warning(disable:4311) // Pointer size cast mismatch.
 
 static int nWndClassReg = 0;
-static wchar_t* wndClassName = L"IPlugWndClass";
+static const wchar_t* wndClassName = L"IPlugWndClass";
 static double sFPS = 0.0;
 
 #define PARAM_EDIT_ID 99


### PR DESCRIPTION
tiny (tiny and I mean absolutely miniscule) fix to get iPlug2, MSVC and C++20 all living in harmony ( ™️ )
I opened an [issue](https://github.com/iPlug2/iPlug2/issues/1082#issue-2242570652) reporting it, but essentially C++20 must have changed something about assigning string literals to non-const pointers, the fix was just to make `wndClassName` const. Hope it's at all helpful!
