### PR TITLE
compiling with regular clang on windows

### DIFF
--- a/Documentation/cmake-docs.md
+++ b/Documentation/cmake-docs.md
@@ -1,0 +1,106 @@
+# CMake and iPlug2
+
+This documentation should help those trying to build iPlug2 projects using
+CMake. iPlug2 is a complex project and building it correctly on all supported
+platforms, with different compilers, IDEs, and plugin types complicates things
+even more.
+
+
+## Loading iPlug2's CMake scripts
+Loading iPlug2's CMake code is fairly easy, just a few lines.
+
+```
+set(IPLUG2_DIR path/to/iPlug2)
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED COMPONENTS APP VST3 NanoVG)
+```
+
+The first line isn't strictly necessary, but it allows you to change the location
+of the iPlug2 directory without changing your code by adding
+`-DIPLUG2_DIR=/my/real/path/to/iPlug2` on the cmake command line. The `include`
+tells CMake where to find the rest of the iPlug2 CMake scripts and sets some
+other variables. Finally `find_package` actually loads the build scripts, and
+requests support for building standalone applications and VST3 plugins using
+the NanoVG graphics backend.
+
+## Adding a Target
+Building an application with iPlug2 isn't to different from normal CMake.
+First add source files and resource files.
+```
+set(SRC_FILES
+  config.h
+  IPlugInstrument.h
+  IPlugInstrument.cpp
+  IPlugInstrument_DSP.h)
+set(RES_FILES
+  resources/fonts/Roboto-Regular.ttf)
+```
+
+Create a target using those files, notice that both source files *and* resources are included as "source files". iPlug2 copies any files listed as resource files to the correct locations, but many platforms also need them to be listed as source files.
+```
+add_executable(App WIN32 MACOSX_BUNDLE ${SRC_FILES} ${RES_FILES})
+```
+
+The next step is to set properties and link libraries. iPlug2 has a convenient function for this named `iplug_target_add(...)`. This example links `iPlug2_NANOVG` and `iPlug2_GL2` to use the NanoVG graphics backend with OpenGL 2. It also links `iPlug2_Synth` to include code from `iPlug2/IPlug/Extras/Synth`.
+```
+iplug_target_add(App PUBLIC
+  INCLUDE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/resources
+  LINK iPlug2_Synth iPlug2_NANOVG iPlug2_GL2
+  RESOURCE ${RES_FILES}
+)
+```
+The above code is equivalent to
+```
+target_include_directories(App PUBLIC ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/resources)
+target_link_libraries(App PUBLIC iPlug2_Synth iPlug2_NANOVG iPlug2_GL)
+set_property(TARGET ${target} APPEND PROPERTY RESOURCE ${RES_FILES})
+```
+Finally call `iplug_configure_target(...)` to make sure it builds correctly (this is required for all plugins/apps/etc.).
+```
+iplug_configure_target(App app)
+```
+
+Below is the code for the VST3 version. `SRC_FILES` and `RES_FILES` don't need to be re-defined. 
+```
+add_library(VST3 MODULE ${SRC_FILES} ${RES_FILES})
+iplug_target_add(VST3 PUBLIC
+  INCLUDE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/resources
+  LINK iPlug2_Synth iPlug2_NANOVG iPlug2_GL2
+  RESOURCE ${RES_FILES}
+)
+iplug_configure_target(VST3 vst3)
+```
+
+## Components
+iPlug2 supports many different configurations and a single project won't require
+all of them. To help keep things organized only components that are listed
+in `find_package` will be loaded (with some exceptions). 
+
+List of components:
+* APP - Support for standalone applications
+* AU - Support for Audio Unit v2 and Audio Unit v3 plugins (ignored on non-Apple platforms)
+* VST2 - Support for VST2 plugins
+* VST3 - Support for VST3 plugins
+* NanoVG - NanoVG graphics backend (Not yet a component)
+* Skia - Skia graphics backend
+
+
+
+## CMake Variables
+This is a list of common variables you might want to set when building with
+CMake. To set one use `-DMY_VARIABLE=value` on the CMake command line, or
+change the value using the CMake GUI.
+
+* `CMAKE_BUILD_TYPE=<Debug|Release>`: Useful for Makefile and Ninja generators
+  otherwise CMake will default to not including debug data.
+* `VST2_SDK=<path>`: Path to the VST2_SDK directory (it should be named VST2_SDK).
+  Defaults to `iPlug2/Dependencies/IPlug/VST2_SDK`.
+* `VST3_SDK=<path>`: Path to the VST3_SDK directory (it should be named VST3_SDK).
+  `iPlug2/Dependencies/IPlug/VST3_SDK`
+* `VST2_INSTALL_PATH=<path>`: Path to install VST2 plugins. The default is almost
+  always correct, but you might have an unusual setup.
+* `VST3_INSTALL_PATH=<path>`: Path to install VST3 plugins. The default is almost
+  always correct, but you might have an unusual setup.
+* `PLUG_NAME=<name>`: Name of the plugin (e.g. IPlugInstrument). This defaults
+  to the CMake project name.
+

--- a/Examples/IPlugEffect/CMakeLists.txt
+++ b/Examples/IPlugEffect/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+cmake_policy(SET CMP0091 NEW)
+
+#########
+
+
+# To setup the build (change CMAKE_BUILD_TYPE as desired):
+#   mkdir build-mac
+#   cd build-mac
+#   cmake .. -DCMAKE_BUILD_TYPE=Debug
+# To build the APP version:
+#   cmake --build . --target app -j
+# To build the VST3 version:
+#   cmake --build . --target vst3 -j
+# To build the AUv2 version
+#   cmake --build . --target auv2 -j
+
+project(IPlugEffect VERSION 1.0.0 LANGUAGES C CXX)
+
+set(IPLUG2_DIR ${CMAKE_SOURCE_DIR}/../..)
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2)
+#find_package(iPlug2 REQUIRED COMPONENTS Skia)
+
+set(PROJECT_DIR "${CMAKE_SOURCE_DIR}")
+set(SRC_FILES
+  "${PROJECT_DIR}/config.h"
+  "${PROJECT_DIR}/IPlugEffect.h"
+  "${PROJECT_DIR}/IPlugEffect.cpp"
+)
+source_group(TREE ${PROJECT_DIR} FILES ${SRC_FILES})
+
+set(RESOURCES
+  "${PROJECT_DIR}/resources/fonts/Roboto-Regular.ttf"
+)
+
+# While not required, creating a base interface for includes and settings seems like a good idea.
+add_library(_base INTERFACE)
+# iplug_target_add() is a shorthand function for adding sources and include directories,
+# linking libraries, adding resources, setting compile options, etc.
+iplug_target_add(_base INTERFACE
+  INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources
+  LINK iPlug2_NanoVG_GL2
+  FEATURE cxx_std_17)
+
+# For typing convenience the TARGET name is put into a variable.
+set(TARGET app)
+add_executable(${TARGET} WIN32 MACOSX_BUNDLE ${SRC_FILES})
+iplug_target_add(${TARGET} PUBLIC LINK iPlug2_APP _base RESOURCE ${RESOURCES})
+iplug_configure_target(${TARGET} app)
+
+#set(TARGET vst2)
+#add_library(${TARGET} MODULE ${SRC_FILES})
+#iplug_target_add(${TARGET} PUBLIC LINK iPlug2_VST2 _base RESOURCE ${RESOURCES})
+#iplug_configure_target(${TARGET} vst2)
+
+set(TARGET vst3)
+add_library(${TARGET} MODULE ${SRC_FILES})
+iplug_target_add(${TARGET} PUBLIC LINK iPlug2_VST3 _base RESOURCE ${RESOURCES})
+iplug_configure_target(${TARGET} vst3)
+
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(TARGET auv2)
+  add_library(${TARGET} MODULE ${SRC_FILES})
+  iplug_target_add(${TARGET} PUBLIC LINK iPlug2_AUv2 _base RESOURCE ${RESOURCES})
+  iplug_configure_target(${TARGET} auv2)
+endif()
+
+if (WIN32)
+  set(CMAKE_RC_FLAGS "/I${PROJECT_DIR}/resources /I${PROJECT_DIR}/resources/fonts /I${PROJECT_DIR}/resources/img ${CMAKE_RC_FLAGS}")
+endif()

--- a/Scripts/cmake/APP.cmake
+++ b/Scripts/cmake/APP.cmake
@@ -1,0 +1,158 @@
+cmake_minimum_required(VERSION 3.11)
+
+add_library(iPlug2_APP INTERFACE)
+set(sdk ${IPLUG2_DIR}/IPlug/APP)
+set(_src
+  ${sdk}/IPlugAPP.cpp 
+  ${sdk}/IPlugAPP_dialog.cpp 
+  ${sdk}/IPlugAPP_host.cpp 
+  ${sdk}/IPlugAPP_main.cpp
+  ${IPLUG_DEPS}/RTAudio/RtAudio.cpp
+  ${IPLUG_DEPS}/RTMidi/RtMidi.cpp
+)
+set(_inc
+  ${sdk} 
+  ${IPLUG_DEPS}/RTAudio
+  ${IPLUG_DEPS}/RTAudio/include
+  ${IPLUG_DEPS}/RTMidi
+  ${IPLUG_DEPS}/RTMidi/include
+)
+set(_def "APP_API" "IPLUG_EDITOR=1" "IPLUG_DSP=1" )
+
+# Link Windows sound libraies if on Windows
+if (WIN32)
+  iplug_target_add(iPlug2_APP INTERFACE
+    DEFINE "__WINDOWS_DS__" "__WINDOWS_MM__" "__WINDOWS_ASIO__"
+    SOURCE
+      ${IPLUG_DEPS}/RTAudio/include/asio.cpp
+      ${IPLUG_DEPS}/RTAudio/include/asiodrivers.cpp
+      ${IPLUG_DEPS}/RTAudio/include/asiolist.cpp
+      ${IPLUG_DEPS}/RTAudio/include/iasiothiscallresolver.cpp
+      ${IPLUG_DEPS}/RTMidi/rtmidi_c.cpp
+    LINK dsound.lib winmm.lib
+  )
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  # Some source files here combine C++ and Objective-C, so we tell clang how to compile them
+  set_property(SOURCE ${_src} PROPERTY LANGUAGE "OBJCXX")
+  iplug_target_add(iPlug2_APP INTERFACE
+    DEFINE "__MACOSX_CORE__" "SWELL_COMPILED"
+    LINK "-framework AppKit" "-framework CoreMIDI" "-framework CoreAudio"
+    SOURCE 
+      "${WDL_DIR}/swell/swell-appstub.mm"
+      "${WDL_DIR}/swell/swellappmain.mm"
+      "${WDL_DIR}/swell/swell-ini.cpp"
+      "${WDL_DIR}/swell/swell-dlg.mm"
+      "${WDL_DIR}/swell/swell-kb.mm"
+      "${WDL_DIR}/swell/swell-miscdlg.mm"
+      "${WDL_DIR}/swell/swell-menu.mm"
+      "${WDL_DIR}/swell/swell-wnd.mm"
+      "${WDL_DIR}/swell/swell.cpp"
+      "${WDL_DIR}/swell/swell-misc.mm"
+      "${WDL_DIR}/swell/swell-gdi.mm"
+  )
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  pkg_check_modules(Glib_20 REQUIRED IMPORTED_TARGET "glib-2.0")
+  pkg_check_modules(Gtk_30 REQUIRED IMPORTED_TARGET "gtk+-3.0")
+  pkg_check_modules(Gdk_30 REQUIRED IMPORTED_TARGET "gdk-3.0")
+  pkg_check_modules(Alsa IMPORTED_TARGET "alsa")
+  pkg_check_modules(Jack IMPORTED_TARGET "jack")
+  pkg_check_modules(PulseAudio IMPORTED_TARGET "libpulse")
+  pkg_check_modules(PulseAudioSimple IMPORTED_TARGET "libpulse-simple")
+
+  set(IPLUG_APP_ALSA 1 CACHE BOOL "Use ALSA on Linux")
+  set(IPLUG_APP_JACK 1 CACHE BOOL "Use JACK on Linux")
+  set(IPLUG_APP_PULSE 1 CACHE BOOL "Use Pulse Audio on Linux")
+
+  # Build and link Swell properly on Linux. This uses GTK+ 3.0 and X11
+  set(swell_src
+    swell.h
+    swell.cpp
+    swell-appstub-generic.cpp
+    swell-dlg-generic.cpp
+    swell-gdi-generic.cpp
+    swell-gdi-lice.cpp
+    swell-ini.cpp
+    swell-kb-generic.cpp
+    swell-menu-generic.cpp
+    swell-miscdlg-generic.cpp
+    swell-misc-generic.cpp
+    swell-wnd-generic.cpp
+    swell-generic-gdk.cpp
+  )
+  list(TRANSFORM swell_src PREPEND "${WDL_DIR}/swell/")
+
+  iplug_target_add(iPlug2_APP INTERFACE
+    DEFINE "SWELL_COMPILED" "SWELL_SUPPORT_GTK" "SWELL_TARGET_GDK=3" SWELL_LICE_GDI SWELL_FREETYPE "_FILE_OFFSET_BITS=64" WDL_ALLOW_UNSIGNED_DEFAULT_CHAR
+    INCLUDE 
+      "${WDL_DIR}/swell/"
+      "${WDL_DIR}/lice/"
+    LINK 
+      LICE_Core LICE_PNG LICE_ZLIB PkgConfig::Gtk_30 PkgConfig::Gdk_30 PkgConfig::Glib_20 "X11" "Xi"
+    SOURCE
+      ${swell_src}
+      ${CMAKE_SOURCE_DIR}/resources/main.rc_mac_dlg
+      ${CMAKE_SOURCE_DIR}/resources/main.rc_mac_menu
+  )
+
+  # RtAudio
+  if (IPLUG_APP_ALSA)
+    iplug_target_add(iPlug2_APP INTERFACE
+      DEFINE "__LINUX_ALSA__" LINK PkgConfig::Alsa)
+  endif()
+  if (IPLUG_APP_JACK)
+    iplug_target_add(iPlug2_APP INTERFACE
+      DEFINE "__UNIX_JACK__" LINK PkgConfig::Jack)
+  endif()
+  if (IPLUG_APP_PULSE)
+    iplug_target_add(iPlug2_APP INTERFACE
+      DEFINE "__LINUX_PULSE__" LINK PkgConfig::PulseAudio PkgConfig::PulseAudioSimple)
+  endif()
+  
+else()
+  message(FATAL_ERROR "APP not supported on platform ${CMAKE_SYSTEM_NAME}")
+endif()
+
+iplug_target_add(iPlug2_APP INTERFACE INCLUDE ${_inc} DEFINE ${_def} SOURCE ${_src} LINK iPlug2_Core)
+iplug_source_tree(iPlug2_APP)
+
+macro(iplug_configure_app target)
+  iplug_target_add(${target} PUBLIC LINK iPlug2_APP)
+
+  if (WIN32)
+    set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}-app/resources")
+
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${PLUG_NAME}"
+      RUNTIME_OUTPUT_DIRECTORY "${PLUG_NAME}-app"
+    )
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND "${CMAKE_BINARY_DIR}/postbuild-win.bat"
+      ARGS "\"$<TARGET_FILE:${target}>\"" "\".exe\""
+    )
+    
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.app/Contents/Resources")
+    # Set the Info.plist file and add required resources
+    set(_res 
+      "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}.icns"
+      "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-macOS-MainMenu.xib")
+    source_group("Resources" FILES ${_res})
+    iplug_target_add(${target} PUBLIC SOURCE ${_res} RESOURCE ${_res})
+    set_target_properties(${target} PROPERTIES 
+      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-macOS-Info.plist")
+
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}-app/resources")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${PLUG_NAME}"
+      RUNTIME_OUTPUT_DIRECTORY "${PLUG_NAME}-app"
+    )
+    
+  endif()
+
+  if (res_dir)
+    iplug_target_bundle_resources(${target} "${res_dir}")
+  endif()
+endmacro()

--- a/Scripts/cmake/APP.cmake
+++ b/Scripts/cmake/APP.cmake
@@ -92,8 +92,8 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
       LICE_Core LICE_PNG LICE_ZLIB PkgConfig::Gtk_30 PkgConfig::Gdk_30 PkgConfig::Glib_20 "X11" "Xi"
     SOURCE
       ${swell_src}
-      ${CMAKE_SOURCE_DIR}/resources/main.rc_mac_dlg
-      ${CMAKE_SOURCE_DIR}/resources/main.rc_mac_menu
+      ${PLUG_RESOURCES_DIR}/main.rc_mac_dlg
+      ${PLUG_RESOURCES_DIR}/main.rc_mac_menu
   )
 
   # RtAudio
@@ -136,12 +136,12 @@ macro(iplug_configure_app target)
     set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.app/Contents/Resources")
     # Set the Info.plist file and add required resources
     set(_res 
-      "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}.icns"
-      "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-macOS-MainMenu.xib")
+      "${PLUG_RESOURCES_DIR}/${PLUG_NAME}.icns"
+      "${PLUG_RESOURCES_DIR}/${PLUG_NAME}-macOS-MainMenu.xib")
     source_group("Resources" FILES ${_res})
     iplug_target_add(${target} PUBLIC SOURCE ${_res} RESOURCE ${_res})
     set_target_properties(${target} PROPERTIES 
-      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-macOS-Info.plist")
+      MACOSX_BUNDLE_INFO_PLIST "${PLUG_RESOURCES_DIR}/${PLUG_NAME}-macOS-Info.plist")
 
   elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}-app/resources")

--- a/Scripts/cmake/AUv2.cmake
+++ b/Scripts/cmake/AUv2.cmake
@@ -38,7 +38,7 @@ function(iplug_configure_auv2 target)
   set_target_properties(${target} PROPERTIES
     BUNDLE TRUE
     MACOSX_BUNDLE TRUE
-    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-AU-Info.plist
+    MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${PLUG_NAME}-AU-Info.plist
     BUNDLE_EXTENSION "component"
     PREFIX ""
     SUFFIX "")

--- a/Scripts/cmake/AUv2.cmake
+++ b/Scripts/cmake/AUv2.cmake
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.11)
+
+set(AUv2_INSTALL_PATH "$ENV{HOME}/Library/Audio/Plug-Ins/Components")
+
+#################
+# Audio Unit v2 #
+#################
+
+find_library(AUDIOUNIT_LIB AudioUnit)
+find_library(COREAUDIO_LIB CoreAudio)
+
+add_library(iPlug2_AUv2 INTERFACE)
+set(_sdk ${IPLUG2_DIR}/IPlug/AUv2)
+iplug_target_add(iPlug2_AUv2 INTERFACE
+  DEFINE "AU_API" "IPLUG_EDITOR=1" "IPLUG_DSP=1" "SWELL_CLEANUP_ON_UNLOAD"
+  LINK iPlug2_Core ${AUDIOUNIT_LIB} ${COREAUDIO_LIB} "-framework CoreMidi" "-framework AudioToolbox"
+  INCLUDE ${_sdk}
+  SOURCE 
+    ${_sdk}/dfx-au-utilities.c
+    ${_sdk}/IPlugAU.cpp
+    ${_sdk}/IPlugAU.r
+    ${_sdk}/IPlugAU_view_factory.mm
+  )
+iplug_source_tree(iPlug2_AUv2)
+
+function(iplug_configure_auv2 target)
+  iplug_target_add(${target} PUBLIC LINK iPlug2_AUv2)
+
+  if (CMAKE_GENERATOR STREQUAL "Xcode")
+    set(out_dir "${CMAKE_BINARY_DIR}/$<CONFIG>/${PLUG_NAME}.component")
+    set(res_dir "")
+  else()
+    set(out_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.component")
+    set(res_dir "${out_dir}/Contents/Resources")
+  endif()
+  set(install_dir "${AUv2_INSTALL_PATH}/${PLUG_NAME}.component")
+  
+  set_target_properties(${target} PROPERTIES
+    BUNDLE TRUE
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-AU-Info.plist
+    BUNDLE_EXTENSION "component"
+    PREFIX ""
+    SUFFIX "")
+
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy_directory" "${out_dir}" "${install_dir}")
+    
+  set(PKGINFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.component/Contents/PkgInfo")
+  file(WRITE ${PKGINFO_FILE} "BNDL????")
+  add_custom_command(TARGET ${TARGET} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E touch ${PKGINFO_FILE})
+
+  if (res_dir)
+    iplug_target_bundle_resources(${target} "${res_dir}")
+  endif()
+endfunction(iplug_configure_auv2)

--- a/Scripts/cmake/FindiPlug2.cmake
+++ b/Scripts/cmake/FindiPlug2.cmake
@@ -237,7 +237,7 @@ set(BUILD_DEPS ${IPLUG2_DIR}/Dependencies/Build)
 add_library(iPlug2_Core INTERFACE)
 
 # Make sure we define DEBUG for debug builds
-set(_def "NOMINMAX" "$<$<CONFIG:Debug>:DEBUG>")
+set(_def "NOMINMAX" "$<$<CONFIG:Debug>:DEBUG>" "$<$<CONFIG:Debug>:_DEBUG>")
 set(_opts "")
 set(_lib "")
 set(_inc
@@ -272,6 +272,14 @@ set(_src
   ${sdk}/IPlugTimer.cpp
   ${sdk}/IPlugUtilities.h
 )
+
+if (NOT PLUG_RESOURCES_DIR)
+  set(PLUG_RESOURCES_DIR ${CMAKE_SOURCE_DIR}/resources)
+  message("Setting PLUG_RESOURCES_DIR to ${PLUG_RESOURCES_DIR}")
+endif()
+
+set(plugin_build_dir "${CMAKE_BINARY_DIR}/out")
+file(MAKE_DIRECTORY ${plugin_build_dir})
 
 # Platform Settings
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
@@ -387,7 +395,7 @@ function(iplug_configure_target target target_type)
   if (WIN32)
     # On Windows ours fonts are included in the RC file, meaning we need to include main.rc
     # in ALL our builds. Yay for platform-specific bundling!
-    set(_res "${CMAKE_SOURCE_DIR}/resources/main.rc")
+    set(_res "${PLUG_RESOURCES_DIR}/main.rc")
     iplug_target_add(${target} PUBLIC RESOURCE ${_res})
     source_group("Resources" FILES ${_res})
     target_compile_options(${TARGET} PRIVATE /Zi)

--- a/Scripts/cmake/FindiPlug2.cmake
+++ b/Scripts/cmake/FindiPlug2.cmake
@@ -1,0 +1,472 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+cmake_minimum_required(VERSION 3.11)
+cmake_policy(SET CMP0076 NEW)
+
+set(iPlug2_FOUND 1)
+
+set(IPLUG_APP_NAME ${CMAKE_PROJECT_NAME} CACHE STRING "Name of the VST/AU/App/etc.")
+set(PLUG_NAME ${CMAKE_PROJECT_NAME} CACHE STRING "Name of the VST/AU/App/etc.")
+
+if (WIN32)
+  # Need to determine processor arch for postbuild-win.bat
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
+    set(PROCESSOR_ARCH "x64" CACHE STRING "Processor architecture")
+  else()
+    set(PROCESSOR_ARCH "Win32" CACHE STRING "Processor architecture")
+  endif()
+  set(OS_WINDOWS 1)
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  find_program( IBTOOL ibtool HINTS "/usr/bin" "${OSX_DEVELOPER_ROOT}/usr/bin" )
+  if ( ${IBTOOL} STREQUAL "IBTOOL-NOTFOUND" )
+    message( "ibtool can not be found" SEND_ERROR )
+  endif()
+  set(OS_MAC 1)
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  find_package(PkgConfig REQUIRED)
+  set(OS_LINUX 1)
+
+else()
+  message("Unsupported platform" FATAL_ERROR)
+endif()
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
+# CHECK_CXX_COMPILER_FLAG("/arch:AVX" COMPILER_OPT_ARCH_AVX_SUPPORTED)
+
+#! iplug_target_add : Helper function to add sources, include directories, etc.
+# 
+# This helper function combines calls to target_include_directories, target_sources,
+# target_compile_definitions, target_compile_options, target_link_libraries,
+# add_dependencies, and target_compile_features into a single function call. 
+# This means you don't have to re-type the target name so many times, and makes it
+# clearer exactly what you're adding to a given target.
+# 
+# \arg:target The name of the target
+# \arg:set_type <PUBLIC | PRIVATE | INTERFACE>
+# \group:INCLUDE List of include directories
+# \group:SOURCE List of source files
+# \group:DEFINE Compiler definitions
+# \group:OPTION Compile options
+# \group:LINK Link libraries (including other targets)
+# \group:DEPEND Add dependencies on other targets
+# \group:FEATURE Add compile features
+function(iplug_target_add target set_type)
+  cmake_parse_arguments("cfg" "" "" "INCLUDE;SOURCE;DEFINE;OPTION;LINK;LINK_DIR;DEPEND;FEATURE;RESOURCE" ${ARGN})
+  #message("CALL iplug_add_interface ${target}")
+  if (cfg_INCLUDE)
+    target_include_directories(${target} ${set_type} ${cfg_INCLUDE})
+  endif()
+  if (cfg_SOURCE)
+    target_sources(${target} ${set_type} ${cfg_SOURCE})
+  endif()
+  if (cfg_DEFINE)
+    target_compile_definitions(${target} ${set_type} ${cfg_DEFINE})
+  endif()
+  if (cfg_OPTION)
+    target_compile_options(${target} ${set_type} ${cfg_OPTION})
+  endif()
+  if (cfg_LINK)
+    target_link_libraries(${target} ${set_type} ${cfg_LINK})
+  endif()
+  if (cfg_LINK_DIR)
+    target_link_directories(${target} ${set_type} ${cfg_LINK_DIR})
+  endif()
+  if (cfg_DEPEND)
+    add_dependencies(${target} ${set_type} ${cfg_DEPEND})
+  endif()
+  if (cfg_FEATURE)
+    target_compile_features(${target} ${set_type} ${cfg_FEATURE})
+  endif()
+  if (cfg_RESOURCE)
+    set_property(TARGET ${target} APPEND PROPERTY RESOURCE ${cfg_RESOURCE})
+  endif()
+  if (cfg_UNUSED)
+    message("Unused arguments ${cfg_UNUSED}" FATAL_ERROR)
+  endif()
+endfunction()
+
+macro(iplug_ternary VAR val_true val_false)
+  if (${ARGN})
+    set(${VAR} ${val_true})
+  else()
+    set(${VAR} ${val_false})
+  endif()
+endmacro()
+
+macro(iplug_source_tree target)
+  get_target_property(_tmp ${target} INTERFACE_SOURCES)
+  if (NOT "${_tmp}" STREQUAL "_tmp-NOTFOUND")
+    source_group(TREE ${IPLUG2_DIR} PREFIX "IPlug" FILES ${_tmp})
+  endif()
+endmacro()
+
+#! iplug_find_path : An alternative to find_file and find_path that allows a default value.
+# 
+# \arg:VAR Variable name to set
+# \flag:DIR Search for a directory (cannot be used with FILE)
+# \flag:FILE Search for a file (cannot be used with DIR)
+# \flag:REQUIRED If this is set and there is no default cmake will abort with an error
+# \param:DEFAULT_IDX If the path can't be found use the path in PATHS at index DEFAULT_IDX,
+#                    negative values start from the end
+# \param:DEFAULT If the path can't be found use this path instead
+# \param:DOC Documentation string. If this is set the value will be set as a cache variable
+# \group:PATHS List of paths to search for
+function(iplug_find_path VAR)
+  cmake_parse_arguments("arg" "REQUIRED;DIR;FILE" "DEFAULT_IDX;DEFAULT;DOC" "PATHS" ${ARGN})
+  if (NOT arg_DIR AND NOT arg_FILE)
+    message("ERROR: iplug_find_path MUST specify either DIR or FILE as an argument" FATAL_ERROR)
+  endif()
+
+  set(out 0)
+  foreach (pt ${arg_PATHS})
+    if (EXISTS ${pt})
+      iplug_ternary(is_dir 1 0 IS_DIRECTORY ${pt})
+      #message("Found path ${pt} and is_dir=${is_dir}")
+
+      if ( (arg_FILE AND NOT ${is_dir}) OR (arg_DIR AND ${is_dir}) )
+        set(out ${pt})
+        break()
+      endif()
+    endif()
+  endforeach()
+
+  # Handle various default options
+  if ((NOT out) AND (arg_DEFAULT))
+    set(out ${arg_DEFAULT})
+  endif()
+  if ((NOT out) AND NOT ("${arg_DEFAULT_IDX}" STREQUAL ""))
+    list(GET arg_PATHS "${arg_DEFAULT_IDX}" out)
+  endif()
+
+  # Determine cache type for the variable
+  iplug_ternary(_cache_type PATH FILEPATH ${arg_DIR})
+  # Handle required
+  if ((NOT out) AND (arg_REQUIRED))
+    set(${VAR} "${VAR}-NOTFOUND" CACHE ${_cache_type} ${arg_DOC}})
+    message(FATAL_ERROR "Path ${VAR} not found!")
+  endif()
+  # Set cache var or var in parent scope
+  if (arg_DOC)
+    set(${VAR} ${out} CACHE ${_cache_type} ${arg_DOC})
+  else()
+    set(${VAR} ${out} PARENT_SCOPE)
+  endif()
+endfunction(iplug_find_path)
+
+#! iplug_target_bundle_resource : Internal function to copy all resources to the output directory
+# 
+# This pulls the list of resources from the target's RESOURCE property. Currently
+# resources will be copied directly into res_dir unless the resource is a font
+# or image, this is to comply with iPlug2's resource finding code.
+#
+# \arg:target The target to apply the changes on
+# \arg:res_dir Directory to copy the resources into
+function(iplug_target_bundle_resources target res_dir)
+  get_property(resources TARGET ${target} PROPERTY RESOURCE)
+  if (CMAKE_GENERATOR STREQUAL "Xcode")
+    # On Xcode we mark each file as non-compiled
+    foreach (res ${resources})
+      get_filename_component(fn "${res}" NAME)
+      set(file_type "file")
+      if (fn MATCHES ".*\\.xib")
+        set(file_type "file.xib")
+      endif()
+      set_property(SOURCE ${res} PROPERTY XCODE_LAST_KNOWN_FILE_TYPE ${file_type})
+    endforeach()
+  else()
+    # Without Xcode we manually copy resources.
+    foreach (res ${resources})
+      
+      get_filename_component(fn "${res}" NAME)
+      # Default is to simply copy the file, some file types may need special
+      # handling in which case they set copy to FALSE.
+      set(copy TRUE)
+
+      set(dst "${res_dir}/${fn}")
+      if (NOT APPLE)
+        if (fn MATCHES ".*\\.ttf")
+          set(dst "${res_dir}/fonts/${fn}")
+        elseif ((fn MATCHES ".*\\.png") OR (fn MATCHES ".*\\.svg"))
+          set(dst "${res_dir}/img/${fn}")
+        endif()
+      else()
+
+        # Apple but no Xcode? Manually compile xib files
+        if (fn MATCHES ".*\\.xib")
+          get_filename_component(tmp "${res}" NAME_WE)
+          set(dst "${res_dir}/${tmp}.nib")
+          add_custom_command(OUTPUT ${dst}
+            COMMAND ${IBTOOL} ARGS "--errors" "--warnings" "--notices" "--compile" "${dst}" "${res}"
+            MAIN_DEPENDENCY "${res}")
+          set(copy FALSE)
+        endif()
+      endif()
+
+      target_sources(${target} PUBLIC "${dst}")
+
+      if (copy)
+        add_custom_command(OUTPUT "${dst}"
+          COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy" "${res}" "${dst}"
+          MAIN_DEPENDENCY "${res}")
+      endif()
+    endforeach()
+  endif()
+endfunction()
+
+############################
+# General iPlug2 Interface #
+############################
+
+set(IPLUG_SRC ${IPLUG2_DIR}/IPlug)
+set(IGRAPHICS_SRC ${IPLUG2_DIR}/IGraphics)
+set(WDL_DIR ${IPLUG2_DIR}/WDL)
+set(IPLUG_DEPS ${IPLUG2_DIR}/Dependencies/IPlug)
+set(IGRAPHICS_DEPS ${IPLUG2_DIR}/Dependencies/IGraphics)
+set(BUILD_DEPS ${IPLUG2_DIR}/Dependencies/Build)
+
+# Core iPlug2 interface. All targets MUST link to this.
+add_library(iPlug2_Core INTERFACE)
+
+# Make sure we define DEBUG for debug builds
+set(_def "NOMINMAX" "$<$<CONFIG:Debug>:DEBUG>")
+set(_opts "")
+set(_lib "")
+set(_inc
+  # iPlug2
+  ${WDL_DIR}
+  ${WDL_DIR}/libpng
+  ${WDL_DIR}/zlib
+  ${IPLUG_SRC}
+  ${IPLUG_SRC}/Extras
+)
+
+set(sdk ${IPLUG_SRC})
+set(_src
+  ${sdk}/IPlugAPIBase.h
+  ${sdk}/IPlugAPIBase.cpp
+  ${sdk}/IPlugConstants.h
+  ${sdk}/IPlugEditorDelegate.h
+  ${sdk}/IPlugLogger.h
+  ${sdk}/IPlugMidi.h
+  ${sdk}/IPlugParameter.h
+  ${sdk}/IPlugParameter.cpp
+  ${sdk}/IPlugPaths.h
+  ${sdk}/IPlugPaths.cpp
+  ${sdk}/IPlugPlatform.h
+  ${sdk}/IPlugPluginBase.h
+  ${sdk}/IPlugPluginBase.cpp
+  ${sdk}/IPlugProcessor.h
+  ${sdk}/IPlugProcessor.cpp
+  ${sdk}/IPlugQueue.h
+  ${sdk}/IPlugStructs.h
+  ${sdk}/IPlugTimer.h
+  ${sdk}/IPlugTimer.cpp
+  ${sdk}/IPlugUtilities.h
+)
+
+# Platform Settings
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  target_link_libraries(iPlug2_Core INTERFACE "Shlwapi.lib" "comctl32.lib" "wininet.lib")
+  # postbuild-win.bat is used by VST2/VST3/AAX on Windows, so we just always configure it on Windows
+  # Note: For visual studio, we COULD use $(TargetPath) for the target, but for all other generators, no.
+  set(create_bundle_script "${IPLUG2_DIR}/Scripts/create_bundle.bat")
+  configure_file("${IPLUG2_DIR}/Scripts/postbuild-win.bat.in" "${CMAKE_BINARY_DIR}/postbuild-win.bat")
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  list(APPEND _inc
+    ${WDL_DIR}/swell
+  )
+  list(APPEND _lib "pthread" "rt")
+  list(APPEND _opts "-Wno-multichar")
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(CMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf-with-dsym")
+  list(APPEND _src 
+    ${IPLUG_SRC}/IPlugPaths.mm
+  )
+  list(APPEND _inc ${WDL_DIR}/swell)
+  list(APPEND _lib
+    "-framework CoreFoundation" "-framework CoreData" "-framework Foundation" "-framework CoreServices"
+  )
+  list(APPEND _opts "-Wno-deprecated-declarations"  "-Wno-c++11-narrowing" "-Wno-unused-command-line-argument")
+else()
+  message("Unhandled system ${CMAKE_SYSTEM_NAME}" FATAL_ERROR)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  list(APPEND _def "_CRT_SECURE_NO_WARNINGS" "_CRT_SECURE_NO_DEPRECATE" "_CRT_NONSTDC_NO_DEPRECATE" "NOMINMAX" "_MBCS")
+  list(APPEND _opts "/wd4996" "/wd4250" "/wd4018" "/wd4267" "/wd4068" "/MT$<$<CONFIG:Debug>:d>")
+endif()
+
+# Set certain compiler flags, specifically errors if there are undefined symbols
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  list(APPEND _opts "-Wl,--no-undefined")
+endif()
+
+# Use advanced SIMD instructions when available.
+# if (COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
+#   list(APPEND _opts "-march=native")
+# elseif(COMPILER_OPT_ARCH_AVX_SUPPORTED)
+#   list(APPEND _opts "/arch:AVX")
+# endif()
+
+source_group(TREE ${IPLUG2_DIR} PREFIX "IPlug" FILES ${_src})
+iplug_target_add(iPlug2_Core INTERFACE DEFINE ${_def} INCLUDE ${_inc} SOURCE ${_src} OPTION ${_opts} LINK ${_lib})
+
+#############
+# IGraphics #
+#############
+
+# We include this first because APP requires LICE.
+include("${IPLUG2_CMAKE_DIR}/IGraphics.cmake")
+
+####################
+# Reaper Extension #
+####################
+
+add_library(iPlug2_REAPER INTERFACE)
+set(_sdk ${IPLUG2_DIR}/IPlug/ReaperExt)
+iplug_target_add(iPlug2_REAPER INTERFACE
+  INCLUDE "${_sdk}" "${IPLUG_DEPS}/IPlug/Reaper"
+  SOURCE "${_sdk}/ReaperExtBase.cpp"
+  DEFINE "REAPER_PLUGIN"
+  LINK iPlug2_VST2
+)
+
+###############################
+# Minor Configuration Targets #
+###############################
+
+add_library(iPlug2_Faust INTERFACE)
+iplug_target_add(iPlug2_Faust INTERFACE
+  INCLUDE "${IPLUG2_DIR}/IPlug/Extras/Faust" "${FAUST_INCLUDE_DIR}"
+)
+
+add_library(iPlug2_FaustGen INTERFACE)
+iplug_target_add(iPlug2_FaustGen INTERFACE
+  SOURCE "${IPLUG_SRC}/Extras/Faust/IPlugFaustGen.cpp"
+  LINK iPlug2_Faust)
+iplug_source_tree(iPlug2_FaustGen)
+
+add_library(iPlug2_HIIR INTERFACE)
+iplug_target_add(iPlug2_HIIR INTERFACE
+  INCLUDE ${IPLUG_SRC}/Extras/HIIR
+  SOURCE "${IPLUG_SRC}/Extras/HIIR/PolyphaseIIR2Designer.cpp")
+iplug_source_tree(iPlug2_HIIR)
+
+add_library(iPlug2_OSC INTERFACE)
+iplug_target_add(iPlug2_OSC INTERFACE
+  INCLUDE ${IPLUG_SRC}/Extras/OSC
+  SOURCE ${IPLUG_SRC}/Extras/OSC/IPlugOSC_msg.cpp)
+iplug_source_tree(iPlug2_OSC)
+
+add_library(iPlug2_Synth INTERFACE)
+iplug_target_add(iPlug2_Synth INTERFACE
+  INCLUDE ${IPLUG_SRC}/Extras/Synth
+  SOURCE
+    "${IPLUG_SRC}/Extras/Synth/MidiSynth.cpp"
+    "${IPLUG_SRC}/Extras/Synth/VoiceAllocator.cpp")
+iplug_source_tree(iPlug2_Synth)
+
+
+#! iplug_configure_target : Configure a target for the given output type
+#
+function(iplug_configure_target target target_type)
+  set_property(TARGET ${target} PROPERTY CXX_STANDARD ${IPLUG2_CXX_STANDARD})
+
+  # ALL Configurations
+  if (WIN32)
+    # On Windows ours fonts are included in the RC file, meaning we need to include main.rc
+    # in ALL our builds. Yay for platform-specific bundling!
+    set(_res "${CMAKE_SOURCE_DIR}/resources/main.rc")
+    iplug_target_add(${target} PUBLIC RESOURCE ${_res})
+    source_group("Resources" FILES ${_res})
+    target_compile_options(${TARGET} PRIVATE /Zi)
+    set_target_properties(${TARGET} PROPERTIES
+      COMPILE_PDB_NAME "${TARGET}_${PROCESSOR_ARCH}"
+    )
+    
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin") 
+    # For MacOS we make sure the output name is the same as the app name.
+    # This is basically required for bundles.
+    set_property(TARGET ${target} PROPERTY OUTPUT_NAME "${PLUG_NAME}")
+
+  # elseif (OS_LINUX)
+
+  #   # Fix LICE linking
+  #   get_target_property(libs ${target} LINK_LIBRARIES)
+  #   if ("${libs}" MATCHES "iPlug2_LICE")
+  #     if ("${target_type}" STREQUAL "app")
+  #       target_link_libraries(${target} PUBLIC iPlug2_LICE_APP)
+  #     else()
+  #       target_link_libraries(${target} PUBLIC iPlug2_LICE_Normal)
+  #     endif()
+  #   endif()
+
+  endif()
+  
+  if ("${target_type}" STREQUAL "aax")
+    if (NOT TARGET iPlug2_AAX)
+      include("${IPLUG2_CMAKE_DIR}/AAX.cmake")
+    endif()
+    iplug_configure_aax(${target})
+  elseif ("${target_type}" STREQUAL "app")
+    if (NOT TARGET iPlug2_APP)
+      include("${IPLUG2_CMAKE_DIR}/APP.cmake")
+    endif()
+    iplug_configure_app(${target})
+  elseif ("${target_type}" STREQUAL "auv2")
+    if (NOT TARGET iPlug2_AUv2)
+      include("${IPLUG2_CMAKE_DIR}/AUv2.cmake")
+    endif()
+    iplug_configure_auv2(${target})
+  elseif ("${target_type}" STREQUAL "auv3")
+    if (NOT TARGET iPlug2_AUv3)
+      include("${IPLUG2_CMAKE_DIR}/AUv3.cmake")
+    endif()
+    iplug_configure_auv3(${target})
+  # elseif ("${target_type}" STREQUAL "lv2")
+  #   if (NOT TARGET iPlug2_LV2)
+  #     include("${IPLUG2_CMAKE_DIR}/LV2.cmake")
+  #   endif()
+  #   iplug_configure_lv2(${target})
+  # elseif ("${target_type}" STREQUAL "reaper")
+  #   iplug_conifgure_reaper(${target})
+  elseif ("${target_type}" STREQUAL "vst2")
+    if (NOT TARGET iPlug2_VST2)
+      include("${IPLUG2_CMAKE_DIR}/VST2.cmake")
+    endif()
+    iplug_configure_vst2(${target})
+  elseif ("${target_type}" STREQUAL "vst3")
+    if (NOT TARGET iPlug2_VST3)
+      include("${IPLUG2_CMAKE_DIR}/VST3.cmake")
+    endif()
+    iplug_configure_vst3(${target})
+  elseif ("${target_type}" STREQUAL "clap")
+    if (NOT TARGET iPlug2_CLAP)
+      include("${IPLUG2_CMAKE_DIR}/CLAP.cmake")
+    endif()
+    iplug_configure_clap(${target})
+  elseif ("${target_type}" STREQUAL "web")
+    if (NOT TARGET iPlug2_WEB)
+      include("${IPLUG2_CMAKE_DIR}/WEB.cmake")
+    endif()
+    iplug_configure_web(${target})
+  elseif ("${target_type}" STREQUAL "wam")
+    if (NOT TARGET iPlug2_WAM)
+      include("${IPLUG2_CMAKE_DIR}/WEB.cmake")
+    endif()
+    iplug_configure_wam(${target})
+  else()
+    message("Unknown target type \'${target_type}\' for target '${target}'" FATAL_ERROR)
+  endif()
+endfunction()

--- a/Scripts/cmake/FindiPlug2.cmake
+++ b/Scripts/cmake/FindiPlug2.cmake
@@ -398,7 +398,17 @@ function(iplug_configure_target target target_type)
     set(_res "${PLUG_RESOURCES_DIR}/main.rc")
     iplug_target_add(${target} PUBLIC RESOURCE ${_res})
     source_group("Resources" FILES ${_res})
-    target_compile_options(${TARGET} PRIVATE /Zi)
+    # This assumes msvc-like cli interface (msvc or clang-cl) which breaks clang on windows.
+    #target_compile_options(${TARGET} PRIVATE /Zi)
+    if(${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC) 
+      # message(STATUS "Using MSVC-Like frontend")
+      # /Zi tells the compiler to generate pdb files
+      target_compile_options(${TARGET} PRIVATE /Zi)
+    else() # Assumes GNU-Like - but I haven't checked this with g++
+      # message(STATUS "Using GNU-Like frontend")
+      # credit to rovingeye from tap
+      target_compile_options(${TARGET} PRIVATE -DEBUG)
+    endif()
     set_target_properties(${TARGET} PROPERTIES
       COMPILE_PDB_NAME "${TARGET}_${PROCESSOR_ARCH}"
     )

--- a/Scripts/cmake/IGraphics.cmake
+++ b/Scripts/cmake/IGraphics.cmake
@@ -1,0 +1,256 @@
+cmake_minimum_required(VERSION 3.11)
+
+
+##################
+# IGraphics Core #
+##################
+
+add_library(iPlug2_IGraphicsCore INTERFACE)
+set(_def "IPLUG_EDITOR=1")
+set(_lib "")
+set(_inc
+  # IGraphics
+  ${IGRAPHICS_SRC}
+  ${IGRAPHICS_SRC}/Controls
+  ${IGRAPHICS_SRC}/Drawing
+  ${IGRAPHICS_SRC}/Platforms
+  ${IGRAPHICS_SRC}/Extras
+  ${IGRAPHICS_DEPS}/MetalNanoVG/src
+  ${IGRAPHICS_DEPS}/NanoSVG/src
+  ${IGRAPHICS_DEPS}/NanoVG/src
+  ${IGRAPHICS_DEPS}/STB
+  ${IGRAPHICS_DEPS}/yoga
+  ${IGRAPHICS_DEPS}/yoga/yoga
+  ${IPLUG2_DIR}/Dependencies/Build/src
+  ${IPLUG2_DIR}/Dependencies/Build/src/freetype/include
+)
+set(_src
+  ${IGRAPHICS_SRC}/IControl.cpp
+  ${IGRAPHICS_SRC}/IGraphics.cpp
+  ${IGRAPHICS_SRC}/IGraphicsEditorDelegate.cpp
+  ${IGRAPHICS_SRC}/Controls/IControls.cpp
+  ${IGRAPHICS_SRC}/Controls/IPopupMenuControl.cpp
+  ${IGRAPHICS_SRC}/Controls/ITextEntryControl.cpp
+)
+
+# Platform Settings
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  list(APPEND _src ${IGRAPHICS_SRC}/Platforms/IGraphicsWin.cpp)
+
+# elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+#   list(APPEND _src
+#     ${IGRAPHICS_SRC}/Platforms/IGraphicsLinux.cpp
+#     ${IGRAPHICS_DEPS}/xcbt/xcbt.c
+#   )
+#   list(APPEND _inc
+#     ${IGRAPHICS_DEPS}/xcbt
+#   )
+#   list(APPEND _lib "xcb" "xcb-xfixes" "xcb-icccm" "dl" "fontconfig" "freetype")
+#   set_property(SOURCE ${IGRAPHICS_DEPS}/xcbt/xcbt.c PROPERTY LANGUAGE C)
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  list(APPEND _src 
+    ${IGRAPHICS_SRC}/Platforms/IGraphicsMac.mm
+    ${IGRAPHICS_SRC}/Platforms/IGraphicsMac_view.mm
+    ${IGRAPHICS_SRC}/Platforms/IGraphicsCoreText.mm
+  )
+  list(APPEND _inc ${WDL_DIR}/swell)
+  list(APPEND _lib
+    "-framework Cocoa" "-framework Carbon" "-framework Metal" "-framework MetalKit" "-framework QuartzCore" "-framework OpenGL" "-framework Accelerate"
+  )
+  list(APPEND _opts "-Wno-deprecated-declarations")
+else()
+  message("Unhandled system ${CMAKE_SYSTEM_NAME}" FATAL_ERROR)
+endif()
+
+source_group(TREE ${IPLUG2_DIR} PREFIX "IPlug" FILES ${_src})
+iplug_target_add(iPlug2_IGraphicsCore INTERFACE DEFINE ${_def} INCLUDE ${_inc} SOURCE ${_src} LINK ${_lib})
+
+
+###############
+# No Graphics #
+###############
+
+add_library(iPlug2_NoGraphics INTERFACE)
+iplug_target_add(iPlug2_NoGraphics INTERFACE DEFINE "NO_IGRAPHICS=1")
+
+#######################
+# OpenGL Dependencies #
+#######################
+
+set(_glx_inc "")
+set(_glx_src "")
+# if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+#   set(_glx_inc ${IGRAPHICS_DEPS}/glad_GLX/include ${IGRAPHICS_DEPS}/glad_GLX/src)
+#   set(_glx_src ${IGRAPHICS_DEPS}/glad_GLX/src/glad_glx.c)
+# endif()
+
+add_library(iPlug2_GL2 INTERFACE)
+iplug_target_add(iPlug2_GL2 INTERFACE
+  INCLUDE 
+    ${IGRAPHICS_DEPS}/glad_GL2/include ${IGRAPHICS_DEPS}/glad_GL2/src ${_glx_inc}
+  SOURCE
+    ${_glx_src}
+  DEFINE "IGRAPHICS_GL2"
+)
+iplug_source_tree(iPlug2_GL2)
+
+add_library(iPlug2_GL3 INTERFACE)
+iplug_target_add(iPlug2_GL3 INTERFACE
+  INCLUDE
+    ${IGRAPHICS_DEPS}/glad_GL3/include ${IGRAPHICS_DEPS}/glad_GL3/src ${_glx_inc}
+  SOURCE
+    ${_glx_src}
+  DEFINE "IGRAPHICS_GL3"
+)
+iplug_source_tree(iPlug2_GL3)
+
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  add_library(iPlug2_MTL INTERFACE)
+  iplug_target_add(iPlug2_MTL INTERFACE
+    DEFINE "IGRAPHICS_METAL"
+  )
+  iplug_source_tree(iPlug2_MTL)
+endif()
+
+
+##########
+# NanoVG #
+##########
+
+add_library(iPlug2_NanoVG INTERFACE)
+iplug_target_add(iPlug2_NanoVG INTERFACE
+  DEFINE "IGRAPHICS_NANOVG"
+  LINK iPlug2_IGraphicsCore
+)
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(_src ${IGRAPHICS_SRC}/Drawing/IGraphicsNanoVG_src.m  )
+  iplug_target_add(iPlug2_NanoVG INTERFACE SOURCE ${_src})
+  set_property (SOURCE ${_src} APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
+endif()
+iplug_source_tree(iPlug2_NanoVG)
+
+add_library(iPlug2_NanoVG_GL2 INTERFACE)
+target_link_libraries(iPlug2_NanoVG_GL2 INTERFACE iPlug2_NanoVG iPlug2_GL2)
+
+add_library(iPlug2_NanoVG_GL3 INTERFACE)
+target_link_libraries(iPlug2_NanoVG_GL3 INTERFACE iPlug2_NanoVG iPlug2_GL3)
+
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  add_library(iPlug2_NanoVG_MTL INTERFACE)
+  target_link_libraries(iPlug2_NanoVG_MTL INTERFACE iPlug2_NanoVG iPlug2_MTL)
+endif()
+
+########
+# Skia #
+########
+
+if (Skia IN_LIST iPlug2_FIND_COMPONENTS)
+
+  add_library(iPlug2_Skia INTERFACE)
+  iplug_target_add(iPlug2_Skia INTERFACE 
+    DEFINE "IGRAPHICS_SKIA"
+    LINK iPlug2_IGraphicsCore)
+
+  if (WIN32)
+    set(sdk "${BUILD_DEPS}/win/${PROCESSOR_ARCH}/$<IF:$<CONFIG:DEBUG>,Debug,Release>")
+    iplug_target_add(iPlug2_Skia INTERFACE
+      LINK
+        "${sdk}/libpng.lib"
+        "${sdk}/skia.lib"
+        "${sdk}/skottie.lib"
+        "${sdk}/skparagraph.lib"
+        "${sdk}/sksg.lib"
+        "${sdk}/skshaper.lib"
+        "${sdk}/skunicode.lib"
+        "${sdk}/svg.lib"
+        "${sdk}/zlib.lib")
+
+  elseif (OS_MAC)
+    set(sdk "${BUILD_DEPS}/mac/lib")
+    iplug_target_add(iPlug2_Skia INTERFACE
+      LINK
+        "${sdk}/libskia.a"
+        "${sdk}/libskottie.a"
+        "${sdk}/libskparagraph.a"
+        "${sdk}/libsksg.a"
+        "${sdk}/libskshaper.a"
+        "${sdk}/libskunicode.a"
+        "${sdk}/libsvg.a")
+
+  # elseif (OS_LINUX)
+  #   set(sdk "${IPLUG_DEPS}/../Build/linux/lib")
+  #   iplug_target_add(iPlug2_Skia INTERFACE
+  #     LINK 
+  #     "${sdk}/libskia.a"
+  #     "${sdk}/libskottie.a"
+  #     "${sdk}/libskparagraph.a"
+  #     "${sdk}/libsksg.a"
+  #     "${sdk}/libskshaper.a"
+  #     "${sdk}/libskunicode.a"
+  #     "${sdk}/libsvg.a")
+
+  endif()
+
+  iplug_target_add(iPlug2_Skia INTERFACE
+    INCLUDE
+      ${BUILD_DEPS}/src/skia/
+      ${BUILD_DEPS}/src/skia/include/core
+      ${BUILD_DEPS}/src/skia/include/config
+      ${BUILD_DEPS}/src/skia/include/effects
+      ${BUILD_DEPS}/src/skia/include/gpu
+      ${BUILD_DEPS}/src/skia/include/utils
+      ${BUILD_DEPS}/src/skia/include/utils/mac # should be included on mac only?
+      ${BUILD_DEPS}/src/skia/modules/svg
+      ${BUILD_DEPS}/src/skia/modules/svg/include)
+
+  add_library(iPlug2_Skia_GL2 INTERFACE)
+  target_link_libraries(iPlug2_Skia_GL2 INTERFACE iPlug2_Skia iPlug2_GL2)
+
+  add_library(iPlug2_Skia_GL3 INTERFACE)
+  target_link_libraries(iPlug2_Skia_GL3 INTERFACE iPlug2_Skia iPlug2_GL3)
+
+  add_library(iPlug2_Skia_MTL INTERFACE)
+  target_link_libraries(iPlug2_Skia_MTL INTERFACE iPlug2_Skia iPlug2_MTL)
+
+  add_library(iPlug2_Skia_CPU INTERFACE)
+  iplug_target_add(iPlug2_Skia_CPU INTERFACE DEFINE "IGRAPHICS_CPU" LINK iPlug2_Skia)
+endif()
+
+########
+# LICE (required for Linux) #
+########
+
+# include("${IPLUG2_CMAKE_DIR}/LICE.cmake")
+
+# # LICE build is different between APP and all other targets when using swell.
+# # Link to iPlug2_LICE and we'll fix it in configure.
+# add_library(iPlug2_LICE INTERFACE)
+# iplug_target_add(iPlug2_LICE INTERFACE
+#   DEFINE "IGRAPHICS_LICE" "SWELL_EXTRA_MINIMAL" "SWELL_LICE_GDI" "SWELL_FREETYPE"
+#   LINK iPlug2_IGraphicsCore LICE_Core LICE_PNG LICE_ZLIB "dl" "pthread"
+# )
+
+# set(swell_src
+#   swell.h
+#   swell.cpp
+#   swell-dlg-generic.cpp
+#   swell-gdi-generic.cpp
+#   swell-ini.cpp
+#   swell-menu-generic.cpp
+#   swell-wnd-generic.cpp
+#   swell-gdi-lice.cpp
+# )
+# list(TRANSFORM swell_src PREPEND "${WDL_DIR}/swell/")
+
+# if (OS_LINUX)
+#   pkg_check_modules(Freetype2 REQUIRED IMPORTED_TARGET "freetype2")
+#   iplug_target_add(iPlug2_LICE INTERFACE
+#     INCLUDE 
+#       ${IGRAPHICS_DEPS}/glad_GL2/include
+#       ${IGRAPHICS_DEPS}/glad_GL2/src
+#       ${_glx_inc}
+#     SOURCE ${_glx_src}
+#     LINK PkgConfig::Freetype2
+#   )  
+# endif()

--- a/Scripts/cmake/LICE.cmake
+++ b/Scripts/cmake/LICE.cmake
@@ -1,0 +1,231 @@
+cmake_minimum_required(VERSION 3.11)
+
+set(LICE_SRC "${WDL_DIR}/lice/")
+set(_src
+  curverasterbuffer.h
+  lice_arc.cpp
+  lice_bezier.h
+  lice_bmp.cpp
+  lice_colorspace.cpp
+  lice_combine.h
+  lice.cpp
+  lice_extended.h
+  lice.h
+  lice_ico.cpp
+  lice_image.cpp
+  lice_import.h
+  lice_line.cpp
+  lice_lvg.cpp
+  lice_palette.cpp
+  lice_pcx.cpp  
+  lice_texgen.cpp
+  lice_text.cpp
+  lice_text.h
+  lice_textnew.cpp
+)
+list(TRANSFORM _src PREPEND "${LICE_SRC}")
+add_library(LICE_Core INTERFACE)
+iplug_target_add(LICE_Core INTERFACE
+  SOURCE ${_src}
+  INCLUDE
+    "${WDL_DIR}/swell"
+    "${WDL_DIR}/lice"
+)
+
+
+set(_src
+  lice_glbitmap.cpp
+  lice_glbitmap.h
+  lice_gl_ctx.cpp
+  lice_gl_ctx.h
+)
+list(TRANSFORM _src PREPEND "${LICE_SRC}")
+add_library(LICE_GL INTERFACE)
+iplug_target_add(LICE_GL INTERFACE SOURCE ${_src})
+
+
+set(_src
+  lice_gif.cpp
+  lice_gif_write.cpp
+)
+list(TRANSFORM _src PREPEND "${LICE_SRC}")
+set(_src2
+  dgif_lib.c
+  egif_lib.c
+  gif_hash.c
+  gifalloc.c
+)
+list(TRANSFORM _src2 PREPEND "${WDL_DIR}/giflib/")
+add_library(LICE_GIF INTERFACE)
+iplug_target_add(LICE_GIF INTERFACE SOURCE ${_src} ${_src2})
+
+
+set(_src
+  lice_png.cpp
+  lice_png_write.cpp
+)
+list(TRANSFORM _src PREPEND "${LICE_SRC}")
+set(_src2
+  png.c
+  pngconf.h
+  pngdebug.h
+  pngerror.c
+  pngget.c
+  png.h
+  pnginfo.h
+  pnglibconf.h
+  pnglibconf.h.prebuilt
+  pngmem.c
+  pngpread.c
+  pngpriv.h
+  pngread.c
+  pngrio.c
+  pngrtran.c
+  pngrutil.c
+  pngset.c
+  pngstruct.h
+  pngtrans.c
+  pngwio.c
+  pngwrite.c
+  pngwtran.c
+  pngwutil.c
+)
+list(TRANSFORM _src2 PREPEND "${WDL_DIR}/libpng/")
+add_library(LICE_PNG INTERFACE)
+iplug_target_add(LICE_PNG INTERFACE
+  DEFINE "PNG_WRITE_SUPPORTED"
+  SOURCE ${_src} ${_src2}
+)
+
+
+set(_src
+  libxml_tinyxml.cpp
+  libxml_tinyxml.h
+  svgtiny_colors.c
+  tinystr.cpp
+  tinystr.h
+  tinyxml.cpp
+  tinyxmlerror.cpp
+  tinyxml.h
+  tinyxmlparser.cpp
+)
+list(TRANSFORM _src PREPEND "${WDL_DIR}/tinyxml/")
+add_library(LICE_TinyXML INTERFACE)
+iplug_target_add(LICE_TinyXML INTERFACE SOURCE "${_src}")
+
+
+add_library(LICE_SVG INTERFACE)
+iplug_target_add(LICE_SVG INTERFACE
+  SOURCE
+    "${LICE_SRC}/lice_svg.cpp"
+  LINK
+    LICE_TinyXML
+)
+
+
+set(_src
+  lice_jpg.cpp
+  lice_jpg_write.cpp
+)
+list(TRANSFORM _src PREPEND "${LICE_SRC}")
+set(_src2
+  jcapimin.c
+  jcapistd.c
+  jccoefct.c
+  jccolor.c
+  jcdctmgr.c
+  jchuff.c
+  jchuff.h
+  jcinit.c
+  jcmainct.c
+  jcmarker.c
+  jcmaster.c
+  jcomapi.c
+  jconfig.h
+  jcparam.c
+  jcphuff.c
+  jcprepct.c
+  jcsample.c
+  jctrans.c
+  jdapimin.c
+  jdapistd.c
+  jdatadst.c
+  jdatasrc.c
+  jdcoefct.c
+  jdcolor.c
+  jdct.h
+  jddctmgr.c
+  jdhuff.c
+  jdhuff.h
+  jdinput.c
+  jdmainct.c
+  jdmarker.c
+  jdmaster.c
+  jdmerge.c
+  jdphuff.c
+  jdpostct.c
+  jdsample.c
+  jdtrans.c
+  jerror.c
+  jerror.h
+  jfdctflt.c
+  jfdctfst.c
+  jfdctint.c
+  jidctflt.c
+  jidctfst.c
+  jidctint.c
+  jidctred.c
+  jinclude.h
+  jmemmgr.c
+  jmemnobs.c
+  jmemsys.h
+  jmorecfg.h
+  jpegint.h
+  jpeglib.h
+  jquant1.c
+  jquant2.c
+  jutils.c
+  jversion.h
+)
+list(TRANSFORM _src2 PREPEND "${WDL_DIR}/jpeglib/")
+add_library(LICE_JPEG INTERFACE)
+iplug_target_add(LICE_JPEG INTERFACE SOURCE ${_src} ${_src2})
+
+set(_src
+  adler32.c
+  compress.c
+  crc32.c
+  crc32.h
+  deflate.c
+  deflate.h
+  gzclose.c
+  gzguts.h
+  gzlib.c
+  gzread.c
+  gzwrite.c
+  infback.c
+  inffast.c
+  inffast.h
+  inffixed.h
+  inflate.c
+  inflate.h
+  inftrees.c
+  inftrees.h
+  ioapi.c
+  ioapi.h
+  trees.c
+  trees.h
+  uncompr.c
+  unzip.c
+  unzip.h
+  zconf.h
+  zip.c
+  zip.h
+  zlib.h
+  zlib_import.h
+  zutil.c
+  zutil.h
+)
+list(TRANSFORM _src PREPEND "${WDL_DIR}/zlib/")
+add_library(LICE_ZLIB INTERFACE)
+iplug_target_add(LICE_ZLIB INTERFACE SOURCE ${_src})

--- a/Scripts/cmake/VST2.cmake
+++ b/Scripts/cmake/VST2.cmake
@@ -1,0 +1,105 @@
+cmake_minimum_required(VERSION 3.11)
+
+set(VST2_SDK "${IPLUG2_DIR}/Dependencies/IPlug/VST2_SDK" CACHE PATH "VST2 SDK directory.")
+
+if (OS_WIN)
+  set(fn "VstPlugins")
+  if (PROCESSOR_ARCH STREQUAL "Win32")
+    set(_paths "$ENV{ProgramFiles(x86)}/${fn}" "$ENV{ProgramFiles(x86)}/Steinberg/${fn}")
+  endif()
+  # Append this for x86, x64, and ARM I guess
+  list(APPEND _paths "'$ENV{ProgramFiles}/${fn}'" "'$ENV{ProgramFiles}/Steinberg/${fn}'")
+elseif (OS_MAC)
+  set(fn "VST")
+  set(_paths "$ENV{HOME}/Library/Audio/Plug-Ins/${fn}" "/Library/Audio/Plug-Ins/${fn}")
+elseif (OS_LINUX)
+  set(_paths "$ENV{HOME}/.vst" "/usr/local/lib/vst" "/usr/local/vst")
+endif()
+
+iplug_find_path(VST2_INSTALL_PATH REQUIRED DIR DEFAULT_IDX 0 
+  DOC "Path to install VST2 plugins"
+  PATHS ${_paths})
+
+set(sdk ${IPLUG2_DIR}/IPlug/VST2)
+add_library(iPlug2_VST2 INTERFACE)
+iplug_target_add(iPlug2_VST2 INTERFACE
+  INCLUDE ${sdk} ${VST2_SDK}
+  SOURCE ${sdk}/IPlugVST2.cpp
+  DEFINE "VST2_API" "VST_FORCE_DEPRECATED" "IPLUG_DSP=1" "IPLUG_EDITOR=1"
+  LINK iPlug2_Core
+)
+# if (OS_LINUX)
+#   iplug_target_add(iPlug2_VST2 INTERFACE
+#     DEFINE "SMTG_OS_LINUX"
+#   )
+#   # CMake doesn't like __cdecl, so instead of having people modify their aeffect.h
+#   # file, just redefine __cdecl.
+#   if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+#     iplug_target_add(iPlug2_VST2 INTERFACE DEFINE "__cdecl=__attribute__((__cdecl__))")
+#   endif()
+# endif()
+
+list(APPEND IPLUG2_TARGETS iPlug2_VST2)
+
+function(iplug_configure_vst2 target)
+  iplug_target_add(${target} PUBLIC LINK iPlug2_VST2)
+
+  if (WIN32)
+    set(out_dir "${CMAKE_BINARY_DIR}/${target}")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${IPLUG_APP_NAME}"
+      LIBRARY_OUTPUT_DIRECTORY "${out_dir}"
+      PREFIX ""
+      SUFFIX ".dll"
+    )
+    set(res_dir "${CMAKE_BINARY_DIR}/${target}/resources")
+
+    # After building, we run the post-build script
+    add_custom_command(TARGET ${target} POST_BUILD 
+      COMMAND "${CMAKE_BINARY_DIR}/postbuild-win.bat" 
+      ARGS "\"$<TARGET_FILE:${target}>\"" "\".dll\""
+    )
+    
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-VST2-Info.plist
+      BUNDLE_EXTENSION "vst"
+      PREFIX ""
+      SUFFIX "")
+
+    set(install_dir "${VST2_INSTALL_PATH}/${PLUG_NAME}.vst")
+
+    if (CMAKE_GENERATOR STREQUAL "Xcode")
+      set(out_dir "${CMAKE_BINARY_DIR}/$<CONFIG>/${PLUG_NAME}.vst")
+      set(res_dir "")
+    else()
+      set(out_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst")
+      set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst/Contents/Resources")
+    endif()
+
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy_directory" "${out_dir}" "${install_dir}")
+
+
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(out_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst2")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${PLUG_NAME}"
+      LIBRARY_OUTPUT_DIRECTORY "${out_dir}"
+      PREFIX ""
+      SUFFIX ".so"
+    )
+    set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst2/resources")
+
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy_directory" "${out_dir}" "${VST2_INSTALL_PATH}/${PLUG_NAME}")
+  endif()
+
+  # Handle resources
+  if (res_dir)
+    iplug_target_bundle_resources(${target} "${res_dir}")
+  endif()
+
+endfunction()

--- a/Scripts/cmake/VST2.cmake
+++ b/Scripts/cmake/VST2.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 
 set(VST2_SDK "${IPLUG2_DIR}/Dependencies/IPlug/VST2_SDK" CACHE PATH "VST2 SDK directory.")
 
-if (OS_WIN)
+if (WIN32)
   set(fn "VstPlugins")
   if (PROCESSOR_ARCH STREQUAL "Win32")
     set(_paths "$ENV{ProgramFiles(x86)}/${fn}" "$ENV{ProgramFiles(x86)}/Steinberg/${fn}")
@@ -64,7 +64,7 @@ function(iplug_configure_vst2 target)
     set_target_properties(${target} PROPERTIES
       BUNDLE TRUE
       MACOSX_BUNDLE TRUE
-      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-VST2-Info.plist
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${PLUG_NAME}-VST2-Info.plist
       BUNDLE_EXTENSION "vst"
       PREFIX ""
       SUFFIX "")

--- a/Scripts/cmake/VST3.cmake
+++ b/Scripts/cmake/VST3.cmake
@@ -187,7 +187,7 @@ function(iplug_configure_vst3 target)
     set_target_properties(${target} PROPERTIES 
       BUNDLE TRUE
       MACOSX_BUNDLE TRUE
-      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-VST3-Info.plist
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${PLUG_NAME}-VST3-Info.plist
       BUNDLE_EXTENSION "vst3"
       PREFIX ""
       SUFFIX ""

--- a/Scripts/cmake/VST3.cmake
+++ b/Scripts/cmake/VST3.cmake
@@ -1,0 +1,228 @@
+cmake_minimum_required(VERSION 3.11)
+
+set(VST3_SDK "${IPLUG2_DIR}/Dependencies/IPlug/VST3_SDK" CACHE PATH "VST3 SDK directory.")
+set(vst3_target_arch "")
+
+if (WIN32)
+  set(fn "VST3")
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "X86")
+    # $ENV{CommonProgramFiles} ???
+    set(_paths "C:/Program Files (x86)/Common Files/${fn}" "C:/Program Files/Common Files/${fn}")
+    set(vst3_target_arch "x86")
+  elseif ((CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "AMD64") OR (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "IA64"))
+    set(_paths "C:/Program Files/Common Files/${fn}")
+    set(vst3_target_arch "x86_64")
+  endif()
+  set(vst3_target_arch "${vst3_target_arch}-win")
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(_paths "$ENV{HOME}/Library/Audio/Plug-Ins/VST3" "/Library/Audio/Plug-Ins/VST3")
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(_paths "$ENV{HOME}/.vst3")
+  set(vst3_target_arch "${CMAKE_SYSTEM_PROCESSOR}-linux")
+endif()
+
+iplug_find_path(VST3_INSTALL_PATH REQUIRED DIR DEFAULT_IDX 0 
+  DOC "Path to install VST3 plugins"
+  PATHS ${_paths})
+
+set(IPLUG2_VST_ICON 
+  "${IPLUG2_DIR}/Dependencies/IPlug/VST3_SDK/doc/artwork/VST_Logo_Steinberg.ico"
+  CACHE FILEPATH "Path to VST3 plugin icon"
+)
+
+##########################
+# VST3 Interface Library #
+##########################
+
+add_library(iPlug2_VST3 INTERFACE)
+set(sdk ${IPLUG2_DIR}/IPlug/VST3)
+set(_src
+  "${sdk}/IPlugVST3.h"
+  "${sdk}/IPlugVST3.cpp"
+  "${sdk}/IPlugVST3_Common.h"
+  "${sdk}/IPlugVST3_Controller.h"
+  "${sdk}/IPlugVST3_Controller.cpp"
+  "${sdk}/IPlugVST3_ControllerBase.h"
+  "${sdk}/IPlugVST3_Defs.h"
+  "${sdk}/IPlugVST3_Parameter.h"
+  "${sdk}/IPlugVST3_Processor.h"
+  #"${sdk}/IPlugVST3_Processor.cpp"
+  "${sdk}/IPlugVST3_ProcessorBase.h"
+  "${sdk}/IPlugVST3_ProcessorBase.cpp"
+  "${sdk}/IPlugVST3_View.h"
+  )
+
+list(APPEND _inc ${sdk})
+iplug_target_add(iPlug2_VST3 INTERFACE
+  SOURCE ${_src}
+  INCLUDE "${sdk}"
+  DEFINE "VST3_API" "IPLUG_DSP=1"
+  LINK iPlug2_Core
+)
+
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  target_sources(iPlug2_VST3 INTERFACE "${sdk}/IPlugVST3_RunLoop.cpp")
+endif()
+
+source_group(TREE ${IPLUG2_DIR} PREFIX IPlug/VST3 FILES ${_src})
+
+############
+# VST3 SDK #
+############
+
+set(_src "")
+set(_def "")
+set(_inf "")
+
+set(sdk "${VST3_SDK}/base/source")
+list(APPEND _src
+  "${sdk}/baseiids.cpp"
+  "${sdk}/classfactoryhelpers.h"
+  "${sdk}/fbuffer.cpp"
+  "${sdk}/fbuffer.h"
+  "${sdk}/fcleanup.h"
+  "${sdk}/fcommandline.h"
+  "${sdk}/fdebug.cpp"
+  "${sdk}/fdebug.h"
+  "${sdk}/fdynlib.cpp"
+  "${sdk}/fdynlib.h"
+  "${sdk}/fobject.cpp"
+  "${sdk}/fobject.h"
+  "${sdk}/fstdmethods.h"
+  "${sdk}/fstreamer.cpp"
+  "${sdk}/fstreamer.h"
+  "${sdk}/fstring.cpp"
+  "${sdk}/fstring.h"
+  "${sdk}/hexbinary.h"
+  
+  "${sdk}/updatehandler.cpp"
+  "${sdk}/updatehandler.h"
+)
+# Timer isn't implemented on Linux
+if (NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
+  list(APPEND _src
+    "${sdk}/timer.cpp"
+    "${sdk}/timer.h"
+  )
+  
+else()
+  list(APPEND _def "SMTG_OS_LINUX")
+endif()
+
+set(sdk "${VST3_SDK}/base/thread")
+list(APPEND _src
+  "${sdk}/include/fcondition.h"
+  "${sdk}/include/flock.h"
+  "${sdk}/source/fcondition.cpp"
+  "${sdk}/source/flock.cpp"
+)
+set(sdk "${VST3_SDK}/pluginterfaces/base")
+list(APPEND _src
+  "${sdk}/conststringtable.cpp"
+  "${sdk}/coreiids.cpp"
+  "${sdk}/funknown.cpp"
+  "${sdk}/ustring.cpp"
+)
+# In the public.sdk dir we only add specific sources.
+set(sdk ${VST3_SDK}/public.sdk/source)
+list(APPEND _src
+  "${sdk}/common/commoniids.cpp"
+  "${sdk}/common/memorystream.cpp"
+  "${sdk}/common/pluginview.cpp" 
+  "${sdk}/vst/vstaudioeffect.cpp"
+  "${sdk}/vst/vstbus.cpp" 
+  "${sdk}/vst/vstcomponent.cpp"
+  "${sdk}/vst/vstcomponentbase.cpp" 
+  "${sdk}/vst/vstinitiids.cpp"
+  "${sdk}/vst/vstparameters.cpp"
+  "${sdk}/vst/vstsinglecomponenteffect.cpp"
+)
+
+# Platform-dependent stuff
+if (WIN32)
+  list(APPEND _src "${sdk}/main/dllmain.cpp" "${sdk}/main/pluginfactory.cpp" "${sdk}/common/threadchecker_win32.cpp")
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  list(APPEND _def "SWELL_CLEANUP_ON_UNLOAD")
+  list(APPEND _src "${sdk}/main/macmain.cpp" "${sdk}/main/pluginfactory.cpp")
+  list(APPEND _inf "${sdk}/main/macexport.exp")
+
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  list(APPEND _src "${sdk}/main/linuxmain.cpp" "${sdk}/main/pluginfactory.cpp")
+
+endif()
+
+set(tgt iPlug2_VST3)
+target_sources(${tgt} INTERFACE ${_src})
+target_include_directories(${tgt} INTERFACE "${VST3_SDK}")
+target_compile_definitions(${tgt} INTERFACE "$<IF:$<CONFIG:Debug>,DEVELOPMENT,RELEASE>")
+source_group(TREE ${VST3_SDK} PREFIX "IPlug/VST3" FILES ${_src})
+iplug_target_add(${tgt} INTERFACE SOURCE ${_inf} DEFINE ${_def})
+
+
+function(iplug_configure_vst3 target)
+  iplug_target_add(${target} PUBLIC LINK iPlug2_VST3)
+
+  set(out_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst3")
+  set(install_dir "${VST3_INSTALL_PATH}/${PLUG_NAME}.vst3")
+  set(res_dir "${CMAKE_BINARY_DIR}/${PLUG_NAME}.vst3/Contents/Resources")
+
+  if (WIN32)
+    # Use .vst3 as the extension instead of .dll
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${IPLUG_APP_NAME}"
+      LIBRARY_OUTPUT_DIRECTORY "${out_dir}/Contents/${vst3_target_arch}/"
+      PREFIX ""
+      SUFFIX ".vst3"
+    )
+
+    # After building, we run the post-build script
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND "${CMAKE_BINARY_DIR}/postbuild-win.bat" 
+      ARGS "\"$<TARGET_FILE:${target}>\"" "\".vst3\""
+    )
+
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    # Set the Info.plist file we're using and add resources
+    set_target_properties(${target} PROPERTIES 
+      BUNDLE TRUE
+      MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/resources/${PLUG_NAME}-VST3-Info.plist
+      BUNDLE_EXTENSION "vst3"
+      PREFIX ""
+      SUFFIX ""
+    )
+
+    if (CMAKE_GENERATOR STREQUAL "Xcode")
+      set(out_dir "${CMAKE_BINARY_DIR}/$<CONFIG>/${PLUG_NAME}.vst3")
+      set(res_dir "")
+    endif()
+    
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy_directory" "${out_dir}" "${install_dir}")
+
+    iplug_target_add(${TARGET} PUBLIC LINK iPlug2_VST3 _base RESOURCE ${RESOURCES})
+    
+    set(PKGINFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.vst3/Contents/PkgInfo")
+    file(WRITE ${PKGINFO_FILE} "BNDL????")
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E touch ${PKGINFO_FILE})
+
+  elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${IPLUG_APP_NAME}"
+      LIBRARY_OUTPUT_DIRECTORY "${out_dir}/Contents/${vst3_target_arch}/"
+      PREFIX ""
+      SUFFIX ".so"
+    )
+
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS "-E" "copy_directory" "${out_dir}" "${install_dir}")
+
+  endif()
+
+  if (res_dir)
+    iplug_target_bundle_resources(${target} "${res_dir}")
+  endif()
+
+endfunction()

--- a/Scripts/cmake/WDL.cmake
+++ b/Scripts/cmake/WDL.cmake
@@ -1,0 +1,20 @@
+set(WDL_DIR ${IPLUG2_DIR}/WDL)
+
+#
+add_library(_wdl INTERFACE)
+set(WDL_SRC "${WDL_DIR}/")
+set(_wdl_src
+  besselfilter.cpp
+  besselfilter.h
+  fft.c
+  fft.h
+  resample.cpp
+  resample.h
+  convoengine.h
+  convoengine.cpp
+  )
+list(TRANSFORM _wdl_src PREPEND "${WDL_SRC}")
+iplug_target_add(_wdl INTERFACE
+  INCLUDE ${WDL_DIR}
+  SOURCE ${_wdl_src}
+)

--- a/Scripts/create_bundle.bat
+++ b/Scripts/create_bundle.bat
@@ -35,7 +35,11 @@ IF EXIST %BundleDir%\PlugIn.ico GOTO ICON_EXISTS
 copy /Y %IconSource% %BundleDir%\PlugIn.ico > NUL
 :ICON_EXISTS
 
-attrib -r %BundleDir%
+IF EXIST %BundleDir%\desktop.ini GOTO DESKTOP_INI_EXISTS
+echo "" >%BundleDir%\desktop.ini
+:DESKTOP_INI_EXISTS
+
+attrib /D -r %BundleDir%
 attrib -h -r -s %BundleDir%\desktop.ini
 echo [.ShellClassInfo] > %BundleDir%\desktop.ini 
 echo IconResource=PlugIn.ico,0 >> %BundleDir%\desktop.ini 
@@ -45,5 +49,3 @@ echo IconIndex=0 >> %BundleDir%\desktop.ini
 attrib +h +r +s %BundleDir%\PlugIn.ico
 attrib +h +r +s %BundleDir%\desktop.ini
 attrib +r %BundleDir%
-
-

--- a/Scripts/postbuild-win.bat.in
+++ b/Scripts/postbuild-win.bat.in
@@ -1,0 +1,131 @@
+@echo off
+setlocal EnableDelayedExpansion
+setlocal EnableExtensions
+
+set FORMAT=%2
+set NAME="@PLUG_NAME@"
+set PLATFORM="@PROCESSOR_ARCH@"
+set COPY_VST2="1"
+set BUILT_BINARY=%1
+set VST2_32_PATH="@VST2_32_PATH@"
+set VST2_64_PATH="@VST2_64_PATH@"
+set VST3_32_PATH="@VST3_32_PATH@"
+set VST3_64_PATH="@VST3_64_PATH@"
+set AAX_32_PATH="@AAX_32_PATH@"
+set AAX_64_PATH="@AAX_64_PATH@"
+set BUILD_DIR="@plugin_build_dir@"
+set VST_ICON="@IPLUG2_VST_ICON@"
+set AAX_ICON="@IPLUG2_AAX_ICON@"
+set CREATE_BUNDLE_SCRIPT="@create_bundle_script@"
+
+REM copy and xcopy break with forward-slashes, and it's easier to do this here than in CMake
+set BUILT_BINARY=%BUILT_BINARY:/=\%
+set VST2_32_PATH=%VST2_32_PATH:/=\%
+set VST2_64_PATH=%VST2_64_PATH:/=\%
+set VST3_32_PATH=%VST3_32_PATH:/=\%
+set VST3_64_PATH=%VST3_64_PATH:/=\%
+set AAX_32_PATH=%AAX_32_PATH:/=\%
+set AAX_64_PATH=%AAX_64_PATH:/=\%
+set BUILD_DIR=%BUILD_DIR:/=\%
+set VST_ICON=%VST_ICON:/=\%
+set AAX_ICON=%AAX_ICON:/=\%
+set CREATE_BUNDLE_SCRIPT=%CREATE_BUNDLE_SCRIPT:/=\%
+
+echo POSTBUILD SCRIPT VARIABLES -----------------------------------------------------
+echo FORMAT %FORMAT% 
+echo NAME %NAME% 
+echo PLATFORM %PLATFORM% 
+echo COPY_VST2 %COPY_VST2% 
+echo BUILT_BINARY %BUILT_BINARY% 
+echo VST2_32_PATH %VST2_32_PATH% 
+echo VST2_64_PATH %VST2_64_PATH% 
+echo VST3_32_PATH %VST3_32_PATH% 
+echo VST3_64_PATH %VST3_64_PATH% 
+echo BUILD_DIR %BUILD_DIR%
+echo VST_ICON %VST_ICON% 
+echo AAX_ICON %AAX_ICON% 
+echo CREATE_BUNDLE_SCRIPT %CREATE_BUNDLE_SCRIPT%
+echo END POSTBUILD SCRIPT VARIABLES -----------------------------------------------------
+
+if %PLATFORM% == "Win32" (
+
+  if %FORMAT% == ".exe" (
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%_%PLATFORM%.exe
+  )
+
+  if %FORMAT% == ".dll" (
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%_%PLATFORM%.dll
+  )
+  
+  if %FORMAT% == ".dll" (
+    if %COPY_VST2% == "1" (
+      echo copying 32bit binary to 32bit VST2 Plugins folder ... 
+      copy /y %BUILT_BINARY% %VST2_32_PATH%
+    ) else (
+      echo not copying 32bit VST2 binary
+    )
+  )
+  
+  if %FORMAT% == ".vst3" (
+    echo copying 32bit binary to VST3 BUNDLE ..
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.vst3 %VST_ICON% %FORMAT%
+    copy /y %BUILT_BINARY% "%BUILD_DIR%\%NAME%.vst3\Contents\x86-win"
+    if exist %VST3_32_PATH% ( 
+      echo copying VST3 bundle to 32bit VST3 Plugins folder ...
+      call %CREATE_BUNDLE_SCRIPT% %VST3_32_PATH%\%NAME%.vst3 %VST_ICON% %FORMAT%
+      xcopy /E /H /Y %BUILD_DIR%\%NAME%.vst3\Contents\*  %VST3_32_PATH%\%NAME%.vst3\Contents\
+    )
+  )
+  
+  if %FORMAT% == ".aaxplugin" (
+    echo copying 32bit binary to AAX BUNDLE ..
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.aaxplugin %AAX_ICON% %FORMAT%
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%.aaxplugin\Contents\Win32
+    echo copying 32bit bundle to 32bit AAX Plugins folder ... 
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.aaxplugin %AAX_ICON% %FORMAT%
+    xcopy /E /H /Y %BUILD_DIR%\%NAME%.aaxplugin\Contents\* %AAX_32_PATH%\%NAME%.aaxplugin\Contents\
+  )
+)
+
+if %PLATFORM% == "x64" (
+  if not exist "%ProgramFiles(x86)%" (
+    echo "This batch script fails on 32 bit windows... edit accordingly"
+  )
+
+  if %FORMAT% == ".exe" (
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%_%PLATFORM%.exe
+  )
+
+  if %FORMAT% == ".dll" (
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%_%PLATFORM%.dll
+  )
+  
+  if %FORMAT% == ".dll" (
+    if %COPY_VST2% == "1" (
+      echo copying 64bit binary to 64bit VST2 Plugins folder ... 
+      copy /y %BUILT_BINARY% %VST2_64_PATH%
+    ) else (
+      echo not copying 64bit VST2 binary
+    )
+  )
+  
+  if %FORMAT% == ".vst3" (
+    echo copying 64bit binary to VST3 BUNDLE ...
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.vst3 %VST_ICON% %FORMAT%
+    copy /y %BUILT_BINARY% "%BUILD_DIR%\%NAME%.vst3\Contents\x86_64-win"
+    if exist %VST3_64_PATH% (
+      echo copying VST3 bundle to 64bit VST3 Plugins folder ...
+      call %CREATE_BUNDLE_SCRIPT% %VST3_64_PATH%\%NAME%.vst3 %VST_ICON% %FORMAT%
+      xcopy /E /H /Y %BUILD_DIR%\%NAME%.vst3\Contents\*  %VST3_64_PATH%\%NAME%.vst3\Contents\
+    )
+  )
+  
+  if %FORMAT% == ".aaxplugin" (
+    echo copying 64bit binary to AAX BUNDLE ...
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.aaxplugin %AAX_ICON% %FORMAT%
+    copy /y %BUILT_BINARY% %BUILD_DIR%\%NAME%.aaxplugin\Contents\x64
+    echo copying 64bit bundle to 64bit AAX Plugins folder ... 
+    call %CREATE_BUNDLE_SCRIPT% %BUILD_DIR%\%NAME%.aaxplugin %AAX_ICON% %FORMAT%
+    xcopy /E /H /Y %BUILD_DIR%\%NAME%.aaxplugin\Contents\* %AAX_64_PATH%\%NAME%.aaxplugin\Contents\
+  )
+)

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -1,0 +1,22 @@
+#
+# This file should be included in your main CMakeLists.txt file. #
+#
+
+
+if (APPLE)
+  enable_language(OBJC)
+  enable_language(OBJCXX)
+endif()
+
+# We need this so we can find call FindFaust.cmake
+set(IPLUG2_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR}/Scripts/cmake)
+list(APPEND CMAKE_MODULE_PATH ${IPLUG2_CMAKE_DIR})
+
+# This is used in many places
+set(IPLUG2_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+# Make sure MSVC uses static linking for compatibility with Skia libraries and easier distribution.
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+# We generate folders for targets that support it (Visual Studio, Xcode, etc.)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
Enables compiling under clang (rather than clang-cl) on Windows - described in a bit more detail in [this](https://github.com/iPlug2/iPlug2/issues/1084) issue, and I threw some comments around the bits I added for clarity. As mentioned in the issue, I haven't tried it with g++ under mingw or anything like that, but yeah, works for clang!