### PR TITLE
AUv2: allow negative ppq. Solves issue #1094

### DIFF
--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -1937,8 +1937,7 @@ void IPlugAU::PreProcess()
     if (tempo > 0.0)
       timeInfo.mTempo = tempo;
     
-    if (currentBeat >= 0.0)
-      timeInfo.mPPQPos = currentBeat;
+    timeInfo.mPPQPos = currentBeat;
   }
 
   if (mHostCallbacks.transportStateProc)


### PR DESCRIPTION
VST3 uses the reported value even if negative, so I don't see why AUv2 should work any different.