### PR TITLE
Activate and Deactivate GL context

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -480,6 +480,8 @@ void IGraphicsNanoVG::OnViewDestroyed()
 
 void IGraphicsNanoVG::DrawResize()
 {
+  ActivateGLContext();
+  
   if (mMainFrameBuffer != nullptr)
     nvgDeleteFramebuffer(mMainFrameBuffer);
   
@@ -490,6 +492,8 @@ void IGraphicsNanoVG::DrawResize()
     if (mMainFrameBuffer == nullptr)
       DBGMSG("Could not init FBO.\n");
   }
+  
+  DeactivateGLContext();
 }
 
 void IGraphicsNanoVG::BeginFrame()

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -971,10 +971,10 @@ public:
   virtual const char* GetAppGroupID() const { return ""; }
 
 protected:
-  /* Implemented on Windows to store previously active GLContext and HDC for restoring, calls GetDC */
-  virtual void ActivateGLContext() {}; 
+  /* Activate the context for the view (GL only) */
+  virtual void ActivateGLContext() {};
 
-  /* Implemented on Windows to restore previous GL context calls ReleaseDC */
+  /* Deactivate the context for the view (GL only) */
   virtual void DeactivateGLContext() {};
 
   /** Creates a platform native text entry field.

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -78,6 +78,10 @@ protected:
 
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT bounds, bool& isAsync) override;
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
+  
+  void ActivateGLContext() override;
+  void DeactivateGLContext() override;
+
 private:
   void PointToScreen(float& x, float& y) const;
   void ScreenToPoint(float& x, float& y) const;

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -725,6 +725,21 @@ EUIAppearance IGraphicsMac::GetUIAppearance() const
   return EUIAppearance::Light;
 }
 
+void IGraphicsMac::ActivateGLContext()
+{
+#ifdef IGRAPHICS_GL
+  IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
+  [[pView openGLContext] makeCurrentContext];
+#endif
+}
+
+void IGraphicsMac::DeactivateGLContext()
+{
+#ifdef IGRAPHICS_GL
+  [NSOpenGLContext clearCurrentContext];
+#endif
+}
+
 #if defined IGRAPHICS_NANOVG
   #include "IGraphicsNanoVG.cpp"
 #elif defined IGRAPHICS_SKIA

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -580,6 +580,12 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
                                                  name:NSViewFrameDidChangeNotification
                                                object:self];
     #endif
+    #ifdef IGRAPHICS_GL
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(frameDidChange:)
+                                                 name:NSViewGlobalFrameDidChangeNotification
+                                               object:self];
+    #endif
     
 //    [[NSNotificationCenter defaultCenter] addObserver:self
 //                                             selector:@selector(windowResized:) name:NSWindowDidEndLiveResizeNotification
@@ -670,6 +676,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     #endif
     #ifdef IGRAPHICS_GL
     [[self openGLContext] flushBuffer];
+    [NSOpenGLContext clearCurrentContext];
     #endif
   }
 }
@@ -1297,6 +1304,12 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
 
   [(CAMetalLayer*)[self layer] setDrawableSize:CGSizeMake(self.frame.size.width * scale,
                                                           self.frame.size.height * scale)];
+}
+#endif
+#ifdef IGRAPHICS_GL
+- (void) frameDidChange:(NSNotification*) pNotification
+{
+  [[self openGLContext] makeCurrentContext];
 }
 #endif
 


### PR DESCRIPTION
Fixes #1080 and replaces #1081 

I noticed that there was also an issue when using the corner resizer with multiple iPlug2 windows open using IGRAPHICS_GL, this PR adapts #1081 to make sure that case is covered too.

@svantana would you be able to try it with the original bug and check if my modifications achieve the same fix as your original PR?