### PR TITLE
Added public API to get raw host name IPluginBase::GetRawHostStr

### DIFF
--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -101,7 +101,8 @@ bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsP
 void IPlugAPIBase::SetHost(const char* host, int version)
 {
   assert(mHost == kHostUninit);
-    
+
+  mHostName = WDL_String(host);
   mHost = LookUpHost(host);
   mHostVersion = version;
   

--- a/IPlug/IPlugPluginBase.h
+++ b/IPlug/IPlugPluginBase.h
@@ -66,6 +66,10 @@ public:
   /** Get the host name as a CString
    * @param str string into which to write the host name */
   void GetHostStr(WDL_String& str) const { GetHostNameStr(GetHost(), str); }
+
+  /** Get raw host name as a CString
+   * @param str string into which to write the host name */
+  void GetRawHostStr(WDL_String& str) const { str.Set(mHostName.Get()); }
   
   /** Get the host version number as an integer
    * @param decimal \c true indicates decimal format = VVVVRRMM, otherwise hexadecimal 0xVVVVRRMM.
@@ -412,6 +416,8 @@ private:
   int mHostVersion = 0;
   /** Host that has been identified, see EHost enum */
   EHost mHost = kHostUninit;
+  /** Host name raw WDl_String **/
+  WDL_String mHostName{""};
   /** API of this instance */
   EAPI mAPI;
   /** macOS/iOS bundle ID */


### PR DESCRIPTION
* Fixes [Unable to get raw name for Unknown host #1099](https://github.com/iPlug2/iPlug2/issues/1099)
* This PR adds new API to retrieve raw host name. 