### PR TITLE
Add an option to allow items to be deleted from menus on IOS

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -175,6 +175,11 @@ public:
    * @param valIdx An index that indicates which of the control's vals the menu relates to */
   virtual void OnPopupMenuSelection(IPopupMenu* pSelectedMenu, int valIdx);
 
+  /** Implement this method to handle popup menu deletion interactions (on IOS) after IGraphics::CreatePopupMenu/IControl::PromptUserInput
+     * @param pMenu The menu in which an item was deleted
+     * @param itemIdx An index that indicates which of the items was deleted */
+  virtual void OnDeleteFromPopupMenu(IPopupMenu* pMenu, int itemIdx) {}
+    
   /** Implement this method to handle text input after IGraphics::CreateTextEntry/IControl::PromptUserInput
    * @param str A CString with the inputted text
    * @param valIdx An index that indicates which of the control's values the text completion relates to */

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -277,6 +277,14 @@ void IGraphics::SetControlValueAfterPopupMenu(IPopupMenu* pMenu)
   mInPopupMenu = nullptr;
 }
 
+void IGraphics::DeleteFromPopupMenu(IPopupMenu* pMenu, int itemIdx)
+{
+  if (!mInPopupMenu)
+    return;
+  
+  mInPopupMenu->OnDeleteFromPopupMenu(pMenu, itemIdx);
+}
+
 void IGraphics::AttachBackground(const char* fileName)
 {
   IControl* pBG = new IBitmapControl(0, 0, LoadBitmap(fileName, 1, false), kNoParameter, EBlend::Default);

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1056,6 +1056,11 @@ public:
    * @param pMenu The menu that was clicked */
   void SetControlValueAfterPopupMenu(IPopupMenu* pMenu);
     
+  /** Called by IOS platform (or other supported platforms) in order to update a control with a deletion interaction on a popup menu.
+   * @param pMenu The menu that an item was deleted in 
+   * @param itemIdx The index of the deleted item */
+  void DeleteFromPopupMenu(IPopupMenu* pMenu, int itemIdx);
+
   /** Sets the minimum and maximum (draw) scaling values
    * @param lo The minimum scalar that the IGraphics context can be scaled down to
    * @param hi The maxiumum scalar that the IGraphics context can be scaled up to */

--- a/IGraphics/IGraphicsPopupMenu.h
+++ b/IGraphics/IGraphicsPopupMenu.h
@@ -50,7 +50,8 @@ public:
       kDisabled = 1 << 0,     // item is gray and not selectable
       kTitle    = 1 << 1,     // item indicates a title and is not selectable
       kChecked  = 1 << 2,     // item has a checkmark
-      kSeparator  = 1 << 3    // item is a separator
+      kSeparator  = 1 << 3,   // item is a separator
+      kDeletable  = 1 << 4    // item is deletable on IOS
     };
     
     Item(const char* str, int flags = kNoFlags, int tag = -1)
@@ -81,6 +82,7 @@ public:
     bool GetChecked() const { return (mFlags & kChecked) != 0; }
     bool GetIsTitle() const { return (mFlags & kTitle) != 0; }
     bool GetIsSeparator() const { return (mFlags & kSeparator) != 0; }
+    bool GetIsDeletable() const { return (mFlags & kDeletable) != 0; }
     int GetTag() const { return mTag; }
     IPopupMenu* GetSubmenu() const { return mSubmenu.get(); }
     bool GetIsChoosable() const
@@ -95,6 +97,7 @@ public:
     
     void SetEnabled(bool state) { SetFlag(kDisabled, !state); }
     void SetChecked(bool state) { SetFlag(kChecked, state); }
+    void SetDeletable(bool state) { SetFlag(kDeletable, state); }
     void SetTitle(bool state) {SetFlag(kTitle, state); }
     void SetSubmenu(IPopupMenu* pSubmenu) { mSubmenu.reset(pSubmenu); }
 


### PR DESCRIPTION
Here are some instructions for a good PR

This is a new feature for IPopUpMEnu in which items can be marked deletable, and these can be deleted (only on IOS) by using the normal IOS swipe and confirm method.

The menu is automatically updated, but the calling IControl also gets called to perform any underlying deletion work (for instance deleting a preset).

