### PR TITLE
ICaptionControl triangle dynamic sizing

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -648,7 +648,11 @@ void ICaptionControl::OnResize()
   const IParam* pParam = GetParam();
   if(pParam && pParam->Type() == IParam::kTypeEnum)
   {
-    mTri = mRECT.FracRectHorizontal(0.2f, true).GetCentredInside(IRECT(0, 0, 8, 5)); //TODO: This seems rubbish
+    const float boundsHeight = mRECT.H();
+    const float rectW = boundsHeight * 0.8f;
+    const float triSizeX = rectW * 0.5f;
+    const float triSizeY = rectW * 0.33f;
+    mTri = mRECT.GetFromRight(rectW).GetCentredInside(IRECT(0.f, 0.f, triSizeX, triSizeY));
   }
 }
 

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -648,10 +648,11 @@ void ICaptionControl::OnResize()
   const IParam* pParam = GetParam();
   if(pParam && pParam->Type() == IParam::kTypeEnum)
   {
-    const float boundsHeight = mRECT.H();
-    const float rectW = boundsHeight * 0.8f;
+    const float textHeight = mText.mSize;
+    const float rectW = textHeight;
     const float triSizeX = rectW * 0.5f;
     const float triSizeY = rectW * 0.33f;
+
     mTri = mRECT.GetFromRight(rectW).GetCentredInside(IRECT(0.f, 0.f, triSizeX, triSizeY));
   }
 }


### PR DESCRIPTION
issue for this PR - https://github.com/iPlug2/iPlug2/issues/1107

`ICaptionControl::OnResize()` calculates triangle size and position relative to IText size.
![image](https://github.com/iPlug2/iPlug2/assets/26794315/0b9ead63-1a85-4f9b-9fe4-84fcf047ad82)

