### PR TITLE
Clearer wording for UnserializeEditorSize()

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -84,7 +84,7 @@ public:
   
   /** Unserializes the size and scale of the IGraphics.
    * @param chunk The incoming chunk where data is stored to unserialize
-   * @param startPos The start position in the chunk where parameter values are stored
+   * @param startPos The start position in the chunk where editor size data is stored
    * @return The new chunk position (endPos) */
   int UnserializeEditorSize(const IByteChunk& chunk, int startPos);
     


### PR DESCRIPTION
Mention editor size data instead of referencing parameter values in the doc comment, since the function is not meant to account for or work with parameter values