### PR TITLE
Enable SKIA Graphite for Metal

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -36,14 +36,30 @@
   #if defined IGRAPHICS_GL2
     #error SKIA doesn't work correctly with IGRAPHICS_GL2
   #elif defined IGRAPHICS_GL3
+    #if defined SKIA_GRAPHITE
+      #error SKIA Graphite is not valide with IGRAPHICS_GL3
+    #endif
     #include <OpenGL/gl3.h>
   #elif defined IGRAPHICS_METAL
     // even though this is a .cpp we are in an objc(pp) compilation unit
     #import <Metal/Metal.h>
     #import <QuartzCore/CAMetalLayer.h>
+  #ifdef SKIA_GRAPHITE
+      #include "include/gpu/graphite/Context.h"
+      #include "include/gpu/graphite/ContextOptions.h"
+      #include "include/gpu/graphite/GraphiteTypes.h"
+      #include "include/gpu/graphite/Recorder.h"
+      #include "include/gpu/graphite/Surface.h"
+      #include "include/gpu/graphite/Image.h"
+      #include "include/gpu/graphite/ImageProvider.h"
+      #include "include/gpu/graphite/mtl/MtlBackendContext.h"
+      #include "include/gpu/graphite/mtl/MtlGraphiteUtils.h"
+      #include "include/gpu/graphite/mtl/MtlGraphiteTypes.h"
+  #else // GANESH
     #include "include/gpu/ganesh/mtl/GrMtlBackendContext.h"
     #include "include/gpu/ganesh/mtl/GrMtlDirectContext.h"
     #include "include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+  #endif
   #elif !defined IGRAPHICS_CPU
     #error Define either IGRAPHICS_GL2, IGRAPHICS_GL3, IGRAPHICS_METAL, or IGRAPHICS_CPU for IGRAPHICS_SKIA with OS_MAC
   #endif
@@ -93,7 +109,7 @@ public:
   Bitmap(const char* path, double sourceScale);
   Bitmap(const void* pData, int size, double sourceScale);
   Bitmap(sk_sp<SkImage>, double sourceScale);
-
+  
 private:
   SkiaDrawable mDrawable;
 };
@@ -114,10 +130,10 @@ IGraphicsSkia::Bitmap::Bitmap(const char* path, double sourceScale)
   
   auto image = SkImages::DeferredFromEncodedData(data);
   
-#ifdef IGRAPHICS_CPU
+#if defined IGRAPHICS_CPU
   image = image->makeRasterImage();
 #endif
-  
+
   mDrawable.mImage = image;
   
   mDrawable.mIsSurface = false;
@@ -404,7 +420,8 @@ APIBitmap* IGraphicsSkia::LoadAPIBitmap(const char* fileNameOrResID, int scale, 
   }
   else
 #endif
-  return new Bitmap(fileNameOrResID, scale);
+  auto* pAPIBitmap = new Bitmap(fileNameOrResID, scale);
+  return pAPIBitmap;
 }
 
 APIBitmap* IGraphicsSkia::LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale)
@@ -425,10 +442,22 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   CAMetalLayer* pMTLLayer = (CAMetalLayer*) pContext;
   id<MTLDevice> device = pMTLLayer.device;
   id<MTLCommandQueue> commandQueue = [device newCommandQueue];
+  
+#ifdef SKIA_GRAPHITE
+  skgpu::graphite::MtlBackendContext backendContext = {};
+  backendContext.fDevice.retain((__bridge CFTypeRef) device);
+  backendContext.fQueue.retain((__bridge CFTypeRef) commandQueue);
+  skgpu::graphite::ContextOptions options;
+  mGraphiteContext = skgpu::graphite::ContextFactory::MakeMetal(backendContext, options);
+  if (!mGraphiteContext) {
+    DBGMSG("Could not make Graphite Native Metal context\n");
+  }
+#else // GANESH
   GrMtlBackendContext backendContext = {};
   backendContext.fDevice.retain((__bridge GrMTLHandle) device);
   backendContext.fQueue.retain((__bridge GrMTLHandle) commandQueue);
   mGrContext = GrDirectContexts::MakeMetal(backendContext);
+#endif
   mMTLDevice = (void*) device;
   mMTLCommandQueue = (void*) commandQueue;
   mMTLLayer = pContext;
@@ -453,17 +482,64 @@ void IGraphicsSkia::OnViewDestroyed()
 #endif
 }
 
+#if defined IGRAPHICS_METAL && defined SKIA_GRAPHITE
+class ImageProvider : public skgpu::graphite::ImageProvider
+{
+public:
+  ImageProvider(IGraphicsSkia* pGraphics)
+  : mpGraphics(pGraphics)
+  {
+  }
+  
+private:
+  virtual sk_sp<SkImage> findOrCreate(skgpu::graphite::Recorder* recorder, const SkImage* image, SkImage::RequiredProperties) override
+  {
+    uint32_t id = image->uniqueID();
+    
+    auto it = mCache.find(id);
+    if (it != mCache.end())
+    {
+      return it->second;
+    }
+    
+    SkImage::RequiredProperties props{.fMipmapped = false};
+    auto graphiteImage = SkImages::TextureFromImage(recorder, image, props);
+    mCache[id] = graphiteImage;
+    return graphiteImage;
+  }
+  
+  std::unordered_map<uint32_t, sk_sp<SkImage>> mCache;
+  IGraphicsSkia* mpGraphics = nullptr;
+};
+#endif
+
 void IGraphicsSkia::DrawResize()
 {
   auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
   auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
   
 #if defined IGRAPHICS_GL || defined IGRAPHICS_METAL
+#if defined SKIA_GRAPHITE
+  SkImageInfo info = SkImageInfo::MakeN32Premul(w, h);
+  skgpu::graphite::RecorderOptions options;
+  options.fImageProvider = sk_sp<ImageProvider>(new ImageProvider(this));
+  mRecorder = mGraphiteContext->makeRecorder(options);
+  if (!mRecorder)
+  {
+    DBGMSG("Could not make recorder\n");
+  }
+  mSurface = SkSurfaces::RenderTarget(mRecorder.get(), info);
+  if (!mSurface)
+  {
+    DBGMSG("Could not make surface from Metal Recorder\n");
+  }
+#else // GANESH
   if (mGrContext.get())
   {
     SkImageInfo info = SkImageInfo::MakeN32Premul(w, h);
     mSurface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
   }
+#endif
 #else
   #ifdef OS_WIN
     mSurface.reset();
@@ -522,6 +598,18 @@ void IGraphicsSkia::BeginFrame()
     assert(mScreenSurface);
   }
 #elif defined IGRAPHICS_METAL
+#if defined SKIA_GRAPHITE
+  int width = WindowWidth() * GetScreenScale();
+  int height = WindowHeight() * GetScreenScale();
+  
+  id<CAMetalDrawable> drawable = [(CAMetalLayer*) mMTLLayer nextDrawable];
+  
+  auto backendTex = skgpu::graphite::BackendTextures::MakeMetal(
+          {width, height}, (CFTypeRef)drawable.texture);
+
+  mScreenSurface = SkSurfaces::WrapBackendTexture(mRecorder.get(), backendTex, kBGRA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr);
+  mMTLDrawable = (void*) drawable;
+#else // GANESH
   if (mGrContext.get())
   {
     int width = WindowWidth() * GetScreenScale();
@@ -537,6 +625,7 @@ void IGraphicsSkia::BeginFrame()
     mMTLDrawable = (void*) drawable;
     assert(mScreenSurface);
   }
+#endif
 #endif
 
   IGraphics::BeginFrame();
@@ -570,11 +659,22 @@ void IGraphicsSkia::EndFrame()
   #endif
 #else // GPU
   mSurface->draw(mScreenSurface->getCanvas(), 0.0, 0.0, nullptr);
-
-  if (auto dContext = GrAsDirectContext(mScreenSurface->getCanvas()->recordingContext())) {
+  
+#ifdef SKIA_GRAPHITE
+  if (auto recording = mRecorder->snap())
+  {
+    skgpu::graphite::InsertRecordingInfo info;
+    info.fRecording = recording.get();
+    mGraphiteContext->insertRecording(info);
+    mGraphiteContext->submit(skgpu::graphite::SyncToCpu::kNo);
+  }
+#else
+  if (auto dContext = GrAsDirectContext(mScreenSurface->getCanvas()->recordingContext()))
+  {
     dContext->flushAndSubmit();
   }
-
+#endif
+  
   #ifdef IGRAPHICS_METAL
     id<MTLCommandBuffer> commandBuffer = [(id<MTLCommandQueue>) mMTLCommandQueue commandBuffer];
     commandBuffer.label = @"Present";
@@ -592,7 +692,9 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
   p.setAntiAlias(true);
   p.setBlendMode(SkiaBlendMode(pBlend));
   if (pBlend)
+  {
     p.setAlpha(Clip(static_cast<int>(pBlend->mWeight * 255), 0, 255));
+  }
     
   SkiaDrawable* image = bitmap.GetAPIBitmap()->GetBitmap();
 
@@ -612,9 +714,13 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
 #endif
     
   if (image->mIsSurface)
+  {
     image->mSurface->draw(mCanvas, 0.0, 0.0, samplingOptions, &p);
+  }
   else
+  {
     mCanvas->drawImage(image->mImage, 0.0, 0.0, samplingOptions, &p);
+  }
     
   mCanvas->restore();
 }
@@ -956,7 +1062,11 @@ APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, do
   }
   else
   {
+    #ifdef SKIA_GRAPHITE
+    surface = SkSurfaces::RenderTarget(mRecorder.get(), info, skgpu::Mipmapped::kNo);
+    #else
     surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
+    #endif
   }
   #else
   surface = SkSurfaces::Raster(info);
@@ -1126,6 +1236,10 @@ const char* IGraphicsSkia::GetDrawingAPIStr()
 #elif defined IGRAPHICS_GL3
   return "SKIA | GL3";
 #elif defined IGRAPHICS_METAL
-  return "SKIA | Metal";
+  #if defined SKIA_GRAPHITE
+  return "SKIA | Metal | Graphite";
+  #else
+  return "SKIA | Metal | Ganesh";
+  #endif
 #endif
 }

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -19,6 +19,7 @@
 #include "include/core/SkCanvas.h"
 #include "include/core/SkImage.h"
 #include "include/gpu/GrDirectContext.h"
+#include "include/gpu/graphite/Context.h"
 #pragma warning( pop )
 
 namespace skia::textlayout {
@@ -158,7 +159,12 @@ private:
 #endif
   
 #ifndef IGRAPHICS_CPU
+#ifdef SKIA_GRAPHITE
+  std::unique_ptr<skgpu::graphite::Context> mGraphiteContext;
+  std::unique_ptr<skgpu::graphite::Recorder> mRecorder;
+#else // GANESH
   sk_sp<GrDirectContext> mGrContext;
+#endif
   sk_sp<SkSurface> mScreenSurface;
 #endif
   


### PR DESCRIPTION
Skia's new Graphite backend is designed for modern graphics APIs like Metal. It should be faster and we should see less jank, e.g. brief pause on first render while shaders are compiled

To enable it, defined IGRAPHICS_SKIA and SKIA_GRAPHITE