### PR TITLE
VST3: IPlugVST3View reports screen-scaled dimensions

### DIFF
--- a/Examples/IPlugWebUI/IPlugWebUI.cpp
+++ b/Examples/IPlugWebUI/IPlugWebUI.cpp
@@ -51,11 +51,17 @@ void IPlugWebUI::OnReset()
 bool IPlugWebUI::OnMessage(int msgTag, int ctrlTag, int dataSize, const void* pData)
 {
   if (msgTag == kMsgTagButton1)
-    Resize(512, 335);
-  else if(msgTag == kMsgTagButton2)
-    Resize(1024, 335);
-  else if(msgTag == kMsgTagButton3)
-    Resize(1024, 768);
+  {
+    EditorResize(300, 300);
+  }
+  else if (msgTag == kMsgTagButton2)
+  {
+    EditorResize(600, 600);
+  }
+  else if (msgTag == kMsgTagButton3)
+  {
+    EditorResize(1024, 768);
+  }
   else if (msgTag == kMsgTagBinaryTest)
   {
     auto uint8Data = reinterpret_cast<const uint8_t*>(pData);

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -89,8 +89,8 @@ bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) con
 }
 
 bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsPlatformResize)
-{  
-  if (needsPlatformResize)
+{
+  if (needsPlatformResize && !GetHostResizeEnabled())
     return EditorResize(viewWidth, viewHeight);
   else
     return true;

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -59,7 +59,8 @@ public:
     if (pSize)
     {
       rect = *pSize;
-      mOwner.OnParentWindowResize(rect.getWidth(), rect.getHeight());
+      mOwner.OnParentWindowResize(rect.getWidth() / mScaleFactor, 
+                                  rect.getHeight() / mScaleFactor);
     }
     
     return Steinberg::kResultTrue;
@@ -71,7 +72,7 @@ public:
     
     if (mOwner.HasUI())
     {
-      *pSize = Steinberg::ViewRect(0, 0, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
+      *pSize = Steinberg::ViewRect(0, 0, mOwner.GetEditorWidth() * mScaleFactor, mOwner.GetEditorHeight() * mScaleFactor);
       
       return Steinberg::kResultTrue;
     }
@@ -93,13 +94,13 @@ public:
   
   Steinberg::tresult PLUGIN_API checkSizeConstraint(Steinberg::ViewRect* pRect) override
   {
-    int w = pRect->getWidth();
-    int h = pRect->getHeight();
+    int w = pRect->getWidth() / mScaleFactor;
+    int h = pRect->getHeight() / mScaleFactor;
     
-    if(!mOwner.ConstrainEditorResize(w, h))
+    if (!mOwner.ConstrainEditorResize(w, h))
     {
-      pRect->right = pRect->left + w;
-      pRect->bottom = pRect->top + h;
+      pRect->right = pRect->left + (w * mScaleFactor);
+      pRect->bottom = pRect->top + (h * mScaleFactor);
     }
     
     return Steinberg::kResultTrue;
@@ -136,7 +137,7 @@ public:
   Steinberg::tresult PLUGIN_API setContentScaleFactor(ScaleFactor factor) override
   {
     mOwner.SetScreenScale(factor);
-
+    mScaleFactor = factor;
     return Steinberg::kResultOk;
   }
 
@@ -335,9 +336,10 @@ public:
   {
     TRACE
     
-    Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w, h);
+    Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w * mScaleFactor, h * mScaleFactor);
     plugFrame->resizeView(this, &newSize);
   }
 
   T& mOwner;
+  float mScaleFactor = 1.f;
 };


### PR DESCRIPTION
This is only relevant on Windows, where the IPlugViewContentScaleSupport is used to obtain the screen scaling factor. Without this the IPlugResponsiveUI example, and the NO_IGRAPHICS examples will have incorrect dimensions and only show a portion of the UI. #define PLUG_HOST_RESIZE 1 / IPluginBase::GetHostResizeEnabled() will not work correctly.

Affected examples

IPlugResponsiveUI
IPlugWebUI
IPlugSvelteUI
IPlugP5js