### PR TITLE
IPlugAPP/WIN: Fix App window size for NO_IGRAPHICS and PLUG_HOST_RESIZE = 1

### DIFF
--- a/IPlug/APP/IPlugAPP_dialog.cpp
+++ b/IPlug/APP/IPlugAPP_dialog.cpp
@@ -14,6 +14,7 @@
 
 #ifdef OS_WIN
 #include "asio.h"
+extern float GetScaleForHWND(HWND hWnd);
 #define GET_MENU() GetMenu(gHWND)
 #elif defined OS_MAC
 #define GET_MENU() SWELL_GetCurrentMenu()
@@ -514,8 +515,16 @@ WDL_DLGRET IPlugAPPHost::PreferencesDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPar
   return TRUE;
 }
 
-static void ClientResize(HWND hWnd, int nWidth, int nHeight)
+static void ClientResize(HWND hWnd, int width, int height)
 {
+  #if defined OS_WIN
+  #if defined NO_IGRAPHICS || PLUG_HOST_RESIZE 
+  float ss = GetScaleForHWND(hWnd);
+  width = int(float(width) * ss);
+  height = int(float(height) * ss);
+  #endif
+  #endif
+
   RECT rcClient, rcWindow;
   POINT ptDiff;
   int screenwidth, screenheight;
@@ -523,8 +532,8 @@ static void ClientResize(HWND hWnd, int nWidth, int nHeight)
   
   screenwidth  = GetSystemMetrics(SM_CXSCREEN);
   screenheight = GetSystemMetrics(SM_CYSCREEN);
-  x = (screenwidth / 2) - (nWidth / 2);
-  y = (screenheight / 2) - (nHeight / 2);
+  x = (screenwidth / 2) - (width / 2);
+  y = (screenheight / 2) - (height / 2);
   
   GetClientRect(hWnd, &rcClient);
   GetWindowRect(hWnd, &rcWindow);
@@ -532,20 +541,13 @@ static void ClientResize(HWND hWnd, int nWidth, int nHeight)
   ptDiff.x = (rcWindow.right - rcWindow.left) - rcClient.right;
   ptDiff.y = (rcWindow.bottom - rcWindow.top) - rcClient.bottom;
   
-  SetWindowPos(hWnd, 0, x, y, nWidth + ptDiff.x, nHeight + ptDiff.y, 0);
+  SetWindowPos(hWnd, 0, x, y, width + ptDiff.x, height + ptDiff.y, 0);
 }
-
-#ifdef OS_WIN 
-extern float GetScaleForHWND(HWND hWnd);
-#endif
 
 //static
 WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   IPlugAPPHost* pAppHost = IPlugAPPHost::sInstance.get();
-
-  int width = 0;
-  int height = 0;
 
   switch (uMsg)
   {
@@ -555,12 +557,11 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
       IPlugAPP* pPlug = pAppHost->GetPlug();
 
       if (!pAppHost->OpenWindow(gHWND))
+      {
         DBGMSG("couldn't attach gui\n");
+      }
 
-      width = pPlug->GetEditorWidth();
-      height = pPlug->GetEditorHeight();
-
-      ClientResize(hwndDlg, width, height);
+      ClientResize(hwndDlg, pPlug->GetEditorWidth(), pPlug->GetEditorHeight());
 
       ShowWindow(hwndDlg, SW_SHOW);
       return 1;


### PR DESCRIPTION
This is not an ideal solution but it seems to result in the correct size window on a variety of screen scaling settings for a variety of examples.