### PR TITLE
Webview: Handle global keypress events and pass to delegate

### DIFF
--- a/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
+++ b/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
@@ -67,8 +67,11 @@ IPlugOSCEditor::IPlugOSCEditor(const InstanceInfo& info)
 
     pGraphics->AttachControl(new IWebViewControl(bottomRow, true, [](IWebViewControl* pControl){
       pControl->LoadHTML("...");
-      }, nullptr, showDevTools), kCtrlTagWebView)->Hide(true);
-    
+    }, [](IWebViewControl* pControl, const char* jsonMsg){
+      // You can handle key up/down events on the WebView here (or any other messages that you send from the UI)
+      DBGMSG("Received message %s\n", jsonMsg);
+    }, showDevTools), kCtrlTagWebView)->Hide(true);
+        
     pGraphics->AttachControl(new IVButtonControl(bottomRow.GetFromTop(20).GetFromLeft(200).GetVShifted(-20),
     [](IControl* pControl){
       SplashClickActionFunc(pControl);

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdint>
-#include <emscripten/key_codes.h>
 
 #include "IGraphicsWeb.h"
 
@@ -113,209 +112,21 @@ private:
 
 #pragma mark - Utilities and Callbacks
 
-// Key combos
-
-static int domVKToWinVK(int dom_vk_code)
-{
-  switch(dom_vk_code)
-  {
-//    case DOM_VK_CANCEL:               return 0;  // TODO
-    case DOM_VK_HELP:                 return kVK_HELP;
-    case DOM_VK_BACK_SPACE:           return kVK_BACK;
-    case DOM_VK_TAB:                  return kVK_TAB;
-    case DOM_VK_CLEAR:                return kVK_CLEAR;
-    case DOM_VK_RETURN:               return kVK_RETURN;
-    case DOM_VK_ENTER:                return kVK_RETURN;
-    case DOM_VK_SHIFT:                return kVK_SHIFT;
-    case DOM_VK_CONTROL:              return kVK_CONTROL;
-    case DOM_VK_ALT:                  return kVK_MENU;
-    case DOM_VK_PAUSE:                return kVK_PAUSE;
-    case DOM_VK_CAPS_LOCK:            return kVK_CAPITAL;
-    case DOM_VK_ESCAPE:               return kVK_ESCAPE;
-//    case DOM_VK_CONVERT:              return 0;  // TODO
-//    case DOM_VK_NONCONVERT:           return 0;  // TODO
-//    case DOM_VK_ACCEPT:               return 0;  // TODO
-//    case DOM_VK_MODECHANGE:           return 0;  // TODO
-    case DOM_VK_SPACE:                return kVK_SPACE;
-    case DOM_VK_PAGE_UP:              return kVK_PRIOR;
-    case DOM_VK_PAGE_DOWN:            return kVK_NEXT;
-    case DOM_VK_END:                  return kVK_END;
-    case DOM_VK_HOME:                 return kVK_HOME;
-    case DOM_VK_LEFT:                 return kVK_LEFT;
-    case DOM_VK_UP:                   return kVK_UP;
-    case DOM_VK_RIGHT:                return kVK_RIGHT;
-    case DOM_VK_DOWN:                 return kVK_DOWN;
-//    case DOM_VK_SELECT:               return 0;  // TODO
-//    case DOM_VK_PRINT:                return 0;  // TODO
-//    case DOM_VK_EXECUTE:              return 0;  // TODO
-//    case DOM_VK_PRINTSCREEN:          return 0;  // TODO
-    case DOM_VK_INSERT:               return kVK_INSERT;
-    case DOM_VK_DELETE:               return kVK_DELETE;
-    case DOM_VK_0:                    return kVK_0;
-    case DOM_VK_1:                    return kVK_1;
-    case DOM_VK_2:                    return kVK_2;
-    case DOM_VK_3:                    return kVK_3;
-    case DOM_VK_4:                    return kVK_4;
-    case DOM_VK_5:                    return kVK_5;
-    case DOM_VK_6:                    return kVK_6;
-    case DOM_VK_7:                    return kVK_7;
-    case DOM_VK_8:                    return kVK_8;
-    case DOM_VK_9:                    return kVK_9;
-//    case DOM_VK_COLON:                return 0;  // TODO
-//    case DOM_VK_SEMICOLON:            return 0;  // TODO
-//    case DOM_VK_LESS_THAN:            return 0;  // TODO
-//    case DOM_VK_EQUALS:               return 0;  // TODO
-//    case DOM_VK_GREATER_THAN:         return 0;  // TODO
-//    case DOM_VK_QUESTION_MARK:        return 0;  // TODO
-//    case DOM_VK_AT:                   return 0;  // TODO
-    case DOM_VK_A:                    return kVK_A;
-    case DOM_VK_B:                    return kVK_B;
-    case DOM_VK_C:                    return kVK_C;
-    case DOM_VK_D:                    return kVK_D;
-    case DOM_VK_E:                    return kVK_E;
-    case DOM_VK_F:                    return kVK_F;
-    case DOM_VK_G:                    return kVK_G;
-    case DOM_VK_H:                    return kVK_H;
-    case DOM_VK_I:                    return kVK_I;
-    case DOM_VK_J:                    return kVK_J;
-    case DOM_VK_K:                    return kVK_K;
-    case DOM_VK_L:                    return kVK_L;
-    case DOM_VK_M:                    return kVK_M;
-    case DOM_VK_N:                    return kVK_N;
-    case DOM_VK_O:                    return kVK_O;
-    case DOM_VK_P:                    return kVK_P;
-    case DOM_VK_Q:                    return kVK_Q;
-    case DOM_VK_R:                    return kVK_R;
-    case DOM_VK_S:                    return kVK_S;
-    case DOM_VK_T:                    return kVK_T;
-    case DOM_VK_U:                    return kVK_U;
-    case DOM_VK_V:                    return kVK_V;
-    case DOM_VK_W:                    return kVK_W;
-    case DOM_VK_X:                    return kVK_X;
-    case DOM_VK_Y:                    return kVK_Y;
-    case DOM_VK_Z:                    return kVK_Z;
-//    case DOM_VK_WIN:                  return 0;  // TODO
-//    case DOM_VK_CONTEXT_MENU:         return 0;  // TODO
-//    case DOM_VK_SLEEP:                return 0;  // TODO
-    case DOM_VK_NUMPAD0:              return kVK_NUMPAD0;
-    case DOM_VK_NUMPAD1:              return kVK_NUMPAD1;
-    case DOM_VK_NUMPAD2:              return kVK_NUMPAD2;
-    case DOM_VK_NUMPAD3:              return kVK_NUMPAD3;
-    case DOM_VK_NUMPAD4:              return kVK_NUMPAD4;
-    case DOM_VK_NUMPAD5:              return kVK_NUMPAD5;
-    case DOM_VK_NUMPAD6:              return kVK_NUMPAD6;
-    case DOM_VK_NUMPAD7:              return kVK_NUMPAD7;
-    case DOM_VK_NUMPAD8:              return kVK_NUMPAD8;
-    case DOM_VK_NUMPAD9:              return kVK_NUMPAD9;
-    case DOM_VK_MULTIPLY:             return kVK_MULTIPLY;
-    case DOM_VK_ADD:                  return kVK_ADD;
-    case DOM_VK_SEPARATOR:            return kVK_SEPARATOR;
-    case DOM_VK_SUBTRACT:             return kVK_SUBTRACT;
-    case DOM_VK_DECIMAL:              return kVK_DECIMAL;
-    case DOM_VK_DIVIDE:               return kVK_DIVIDE;
-    case DOM_VK_F1:                   return kVK_F1;
-    case DOM_VK_F2:                   return kVK_F2;
-    case DOM_VK_F3:                   return kVK_F3;
-    case DOM_VK_F4:                   return kVK_F4;
-    case DOM_VK_F5:                   return kVK_F5;
-    case DOM_VK_F6:                   return kVK_F6;
-    case DOM_VK_F7:                   return kVK_F7;
-    case DOM_VK_F8:                   return kVK_F8;
-    case DOM_VK_F9:                   return kVK_F9;
-    case DOM_VK_F10:                  return kVK_F10;
-    case DOM_VK_F11:                  return kVK_F11;
-    case DOM_VK_F12:                  return kVK_F12;
-    case DOM_VK_F13:                  return kVK_F13;
-    case DOM_VK_F14:                  return kVK_F14;
-    case DOM_VK_F15:                  return kVK_F15;
-    case DOM_VK_F16:                  return kVK_F16;
-    case DOM_VK_F17:                  return kVK_F17;
-    case DOM_VK_F18:                  return kVK_F18;
-    case DOM_VK_F19:                  return kVK_F19;
-    case DOM_VK_F20:                  return kVK_F20;
-    case DOM_VK_F21:                  return kVK_F21;
-    case DOM_VK_F22:                  return kVK_F22;
-    case DOM_VK_F23:                  return kVK_F23;
-    case DOM_VK_F24:                  return kVK_F24;
-    case DOM_VK_NUM_LOCK:             return kVK_NUMLOCK;
-    case DOM_VK_SCROLL_LOCK:          return kVK_SCROLL;
-//    case DOM_VK_WIN_OEM_FJ_JISHO:     return 0;  // TODO
-//    case DOM_VK_WIN_OEM_FJ_MASSHOU:   return 0;  // TODO
-//    case DOM_VK_WIN_OEM_FJ_TOUROKU:   return 0;  // TODO
-//    case DOM_VK_WIN_OEM_FJ_LOYA:      return 0;  // TODO
-//    case DOM_VK_WIN_OEM_FJ_ROYA:      return 0;  // TODO
-//    case DOM_VK_CIRCUMFLEX:           return 0;  // TODO
-//    case DOM_VK_EXCLAMATION:          return 0;  // TODO
-//    case DOM_VK_HASH:                 return 0;  // TODO
-//    case DOM_VK_DOLLAR:               return 0;  // TODO
-//    case DOM_VK_PERCENT:              return 0;  // TODO
-//    case DOM_VK_AMPERSAND:            return 0;  // TODO
-//    case DOM_VK_UNDERSCORE:           return 0;  // TODO
-//    case DOM_VK_OPEN_PAREN:           return 0;  // TODO
-//    case DOM_VK_CLOSE_PAREN:          return 0;  // TODO
-//    case DOM_VK_ASTERISK:             return 0;  // TODO
-//    case DOM_VK_PLUS:                 return 0;  // TODO
-//    case DOM_VK_PIPE:                 return 0;  // TODO
-//    case DOM_VK_HYPHEN_MINUS:         return 0;  // TODO
-//    case DOM_VK_OPEN_CURLY_BRACKET:   return 0;  // TODO
-//    case DOM_VK_CLOSE_CURLY_BRACKET:  return 0;  // TODO
-//    case DOM_VK_TILDE:                return 0;  // TODO
-//    case DOM_VK_VOLUME_MUTE:          return 0;  // TODO
-//    case DOM_VK_VOLUME_DOWN:          return 0;  // TODO
-//    case DOM_VK_VOLUME_UP:            return 0;  // TODO
-//    case DOM_VK_COMMA:                return 0;  // TODO
-//    case DOM_VK_PERIOD:               return 0;  // TODO
-//    case DOM_VK_SLASH:                return 0;  // TODO
-//    case DOM_VK_BACK_QUOTE:           return 0;  // TODO
-//    case DOM_VK_OPEN_BRACKET:         return 0;  // TODO
-//    case DOM_VK_BACK_SLASH:           return 0;  // TODO
-//    case DOM_VK_CLOSE_BRACKET:        return 0;  // TODO
-//    case DOM_VK_QUOTE:                return 0;  // TODO
-//    case DOM_VK_META:                 return 0;  // TODO
-//    case DOM_VK_ALTGR:                return 0;  // TODO
-//    case DOM_VK_WIN_ICO_HELP:         return 0;  // TODO
-//    case DOM_VK_WIN_ICO_00:           return 0;  // TODO
-//    case DOM_VK_WIN_ICO_CLEAR:        return 0;  // TODO
-//    case DOM_VK_WIN_OEM_RESET:        return 0;  // TODO
-//    case DOM_VK_WIN_OEM_JUMP:         return 0;  // TODO
-//    case DOM_VK_WIN_OEM_PA1:          return 0;  // TODO
-//    case DOM_VK_WIN_OEM_PA2:          return 0;  // TODO
-//    case DOM_VK_WIN_OEM_PA3:          return 0;  // TODO
-//    case DOM_VK_WIN_OEM_WSCTRL:       return 0;  // TODO
-//    case DOM_VK_WIN_OEM_CUSEL:        return 0;  // TODO
-//    case DOM_VK_WIN_OEM_ATTN:         return 0;  // TODO
-//    case DOM_VK_WIN_OEM_FINISH:       return 0;  // TODO
-//    case DOM_VK_WIN_OEM_COPY:         return 0;  // TODO
-//    case DOM_VK_WIN_OEM_AUTO:         return 0;  // TODO
-//    case DOM_VK_WIN_OEM_ENLW:         return 0;  // TODO
-//    case DOM_VK_WIN_OEM_BACKTAB:      return 0;  // TODO
-//    case DOM_VK_ATTN:                 return 0;  // TODO
-//    case DOM_VK_CRSEL:                return 0;  // TODO
-//    case DOM_VK_EXSEL:                return 0;  // TODO
-//    case DOM_VK_EREOF:                return 0;  // TODO
-//    case DOM_VK_PLAY:                 return 0;  // TODO
-//    case DOM_VK_ZOOM:                 return 0;  // TODO
-//    case DOM_VK_PA1:                  return 0;  // TODO
-//    case DOM_VK_WIN_OEM_CLEAR:        return 0;  // TODO
-    default:                          return kVK_NONE;
-  }
-}
-
 static EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent* pEvent, void* pUserData)
 {
   IGraphicsWeb* pGraphicsWeb = (IGraphicsWeb*) pUserData;
 
-  int VK = domVKToWinVK(pEvent->keyCode);
+  int VK = DOMKeyToVirtualKey(pEvent->keyCode);
   WDL_String keyUTF8;
 
   // filter utf8 for non ascii keys
-  if((VK >= kVK_0 && VK <= kVK_Z) || VK == kVK_NONE)
+  if ((VK >= kVK_0 && VK <= kVK_Z) || VK == kVK_NONE)
     keyUTF8.Set(pEvent->key);
   else
     keyUTF8.Set("");
 
   IKeyPress keyPress {keyUTF8.Get(),
-                      domVKToWinVK(pEvent->keyCode),
+                      DOMKeyToVirtualKey(pEvent->keyCode),
                       static_cast<bool>(pEvent->shiftKey),
                       static_cast<bool>(pEvent->ctrlKey || pEvent->metaKey),
                       static_cast<bool>(pEvent->altKey)};
@@ -545,7 +356,7 @@ static EM_BOOL text_entry_keydown(int eventType, const EmscriptenKeyboardEvent* 
 {
   IGraphicsWeb* pGraphicsWeb = (IGraphicsWeb*) pUserData;
   
-  IKeyPress keyPress {pEvent->key, domVKToWinVK(pEvent->keyCode),
+  IKeyPress keyPress {pEvent->key, DOMKeyToVirtualKey(pEvent->keyCode),
     static_cast<bool>(pEvent->shiftKey),
     static_cast<bool>(pEvent->ctrlKey),
     static_cast<bool>(pEvent->altKey)};

--- a/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.cpp
+++ b/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.cpp
@@ -46,7 +46,8 @@ WebViewEditorDelegate::~WebViewEditorDelegate()
 
 void* WebViewEditorDelegate::OpenWindow(void* pParent)
 {
-  return OpenWebView(pParent, 0.0f, 0.0f, static_cast<float>(GetEditorWidth()), static_cast<float>(GetEditorHeight()), 1.0f);
+  mView = OpenWebView(pParent, 0.0f, 0.0f, static_cast<float>(GetEditorWidth()), static_cast<float>(GetEditorHeight()), 1.0f);
+  return mView;
 }
 
 void WebViewEditorDelegate::Resize(int width, int height)
@@ -59,4 +60,22 @@ void WebViewEditorDelegate::OnParentWindowResize(int width, int height)
 {
   SetWebViewBounds(0, 0, static_cast<float>(width), static_cast<float>(height));
   EditorResizeFromUI(width, height, false);
+}
+
+bool WebViewEditorDelegate::OnKeyDown(const IKeyPress& key)
+{
+  #ifdef OS_WIN
+  if (key.VK == VK_SPACE)
+  {
+    PostMessage((HWND)mView, WM_KEYDOWN, VK_SPACE, 0);
+    return true;
+  }
+  #endif
+  return false;
+}
+
+bool WebViewEditorDelegate::OnKeyUp(const IKeyPress& key)
+{
+
+  return true;
 }

--- a/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.mm
+++ b/IPlug/Extras/WebView/IPlugWebViewEditorDelegate.mm
@@ -95,9 +95,9 @@ WebViewEditorDelegate::~WebViewEditorDelegate()
 {
   CloseWindow();
   
-  PLATFORM_VIEW* pHelperView = (PLATFORM_VIEW*) mHelperView;
+  PLATFORM_VIEW* pHelperView = (PLATFORM_VIEW*) mView;
   [pHelperView release];
-  mHelperView = nullptr;
+  mView = nullptr;
 }
 
 void* WebViewEditorDelegate::OpenWindow(void* pParent)
@@ -105,7 +105,7 @@ void* WebViewEditorDelegate::OpenWindow(void* pParent)
   PLATFORM_VIEW* pParentView = (PLATFORM_VIEW*) pParent;
     
   IPLUG_WKWEBVIEW_EDITOR_HELPER* pHelperView = [[IPLUG_WKWEBVIEW_EDITOR_HELPER alloc] initWithEditorDelegate: this];
-  mHelperView = (void*) pHelperView;
+  mView = (void*) pHelperView;
 
   if (pParentView)
   {
@@ -117,7 +117,7 @@ void* WebViewEditorDelegate::OpenWindow(void* pParent)
     mEditorInitFunc();
   }
   
-  return mHelperView;
+  return mView;
 }
 
 void WebViewEditorDelegate::Resize(int width, int height)
@@ -136,7 +136,17 @@ void WebViewEditorDelegate::ResizeWebViewAndHelper(float width, float height)
 {
   CGFloat w = static_cast<float>(width);
   CGFloat h = static_cast<float>(height);
-  IPLUG_WKWEBVIEW_EDITOR_HELPER* pHelperView = (IPLUG_WKWEBVIEW_EDITOR_HELPER*) mHelperView;
+  IPLUG_WKWEBVIEW_EDITOR_HELPER* pHelperView = (IPLUG_WKWEBVIEW_EDITOR_HELPER*) mView;
   [pHelperView setFrame:CGRectMake(0, 0, w, h)];
   SetWebViewBounds(0, 0, w, h);
+}
+
+bool WebViewEditorDelegate::OnKeyDown(const IKeyPress& key)
+{
+  return false;
+}
+
+bool WebViewEditorDelegate::OnKeyUp(const IKeyPress& key)
+{
+  return false;
 }

--- a/IPlug/Extras/WebView/IPlugWebView_mac.mm
+++ b/IPlug/Extras/WebView/IPlugWebView_mac.mm
@@ -132,21 +132,31 @@ void* IWebViewImpl::OpenWebView(void* pParent, float x, float y, float w, float 
   }
   
   // this script adds a function IPlugSendMsg that is used to call the platform webview messaging function in JS
-  WKUserScript* script1 = [[WKUserScript alloc] initWithSource:
-                           @"function IPlugSendMsg(m) { webkit.messageHandlers.callback.postMessage(m); }" 
-                           injectionTime:WKUserScriptInjectionTimeAtDocumentStart 
-                           forMainFrameOnly:YES];
-  [controller addUserScript:script1];
+  [controller addUserScript:[[WKUserScript alloc] initWithSource:
+                             @"function IPlugSendMsg(m) { webkit.messageHandlers.callback.postMessage(m); }"
+                             injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+                             forMainFrameOnly:YES]];
 
   // this script prevents view scaling on iOS
-  WKUserScript* script2 = [[WKUserScript alloc] initWithSource:
-                           @"var meta = document.createElement('meta'); meta.name = 'viewport'; \
-                             meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=YES'; \
-                             var head = document.getElementsByTagName('head')[0]; \
-                             head.appendChild(meta);"
-                           injectionTime:WKUserScriptInjectionTimeAtDocumentEnd 
-                           forMainFrameOnly:YES];
-  [controller addUserScript:script2];
+  [controller addUserScript:[[WKUserScript alloc] initWithSource:
+                             @"var meta = document.createElement('meta'); meta.name = 'viewport'; \
+                               meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=YES'; \
+                               var head = document.getElementsByTagName('head')[0]; \
+                               head.appendChild(meta);"
+                             injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
+                             forMainFrameOnly:YES]];
+  
+  // this script receives global key down events and forwards them to the C++ side
+  [controller addUserScript:[[WKUserScript alloc] initWithSource:
+                             @"document.addEventListener('keydown', function(e) { if(document.activeElement.type != \"text\") { IPlugSendMsg({'msg': 'SKPFUI', 'keyCode': e.keyCode, 'utf8': e.key, 'S': e.shiftKey, 'C': e.ctrlKey, 'A': e.altKey, 'isUp': false}); e.preventDefault(); }});"
+                             injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+                             forMainFrameOnly:YES]];
+  
+  // this script receives global key up events and forwards them to the C++ side
+  [controller addUserScript:[[WKUserScript alloc] initWithSource:
+                             @"document.addEventListener('keyup', function(e) { if(document.activeElement.type != \"text\") { IPlugSendMsg({'msg': 'SKPFUI', 'keyCode': e.keyCode, 'utf8': e.key, 'S': e.shiftKey, 'C': e.ctrlKey, 'A': e.altKey, 'isUp': true}); e.preventDefault(); }});"
+                             injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+                             forMainFrameOnly:YES]];
   
   IPLUG_WKWEBVIEW* wkWebView = [[IPLUG_WKWEBVIEW alloc] initWithFrame: CGRectMake(x, y, w, h) configuration:webConfig];
   

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -416,6 +416,147 @@ static FILE* fopenUTF8(const char* path, const char* mode)
 
 #endif
 
+/*
+ * DOM Virtual Key Code to iPlug2 Virtual Key Code converter
+ * 
+ * Virtual key code definitions adapted from Emscripten
+ * Copyright 2017 The Emscripten Authors. All rights reserved.
+ * Source: https://github.com/emscripten-core/emscripten/
+ * Licensed under MIT and University of Illinois/NCSA Open Source License
+ */
+
+// DOM Virtual Key codes (subset of most common keys)
+enum EDOMVirtualKey {
+  DOM_VK_BACK_SPACE = 0x08,
+  DOM_VK_TAB = 0x09,
+  DOM_VK_RETURN = 0x0D,
+  DOM_VK_SHIFT = 0x10,
+  DOM_VK_CONTROL = 0x11,
+  DOM_VK_ALT = 0x12,
+  DOM_VK_PAUSE = 0x13,
+  DOM_VK_CAPS_LOCK = 0x14,
+  DOM_VK_ESCAPE = 0x1B,
+  DOM_VK_SPACE = 0x20,
+  DOM_VK_PAGE_UP = 0x21,
+  DOM_VK_PAGE_DOWN = 0x22,
+  DOM_VK_END = 0x23,
+  DOM_VK_HOME = 0x24,
+  DOM_VK_LEFT = 0x25,
+  DOM_VK_UP = 0x26,
+  DOM_VK_RIGHT = 0x27,
+  DOM_VK_DOWN = 0x28,
+  DOM_VK_INSERT = 0x2D,
+  DOM_VK_DELETE = 0x2E,
+  DOM_VK_F1 = 0x70,
+  DOM_VK_F2 = 0x71,
+  DOM_VK_F3 = 0x72,
+  DOM_VK_F4 = 0x73,
+  DOM_VK_F5 = 0x74,
+  DOM_VK_F6 = 0x75,
+  DOM_VK_F7 = 0x76,
+  DOM_VK_F8 = 0x77,
+  DOM_VK_F9 = 0x78,
+  DOM_VK_F10 = 0x79,
+  DOM_VK_F11 = 0x7A,
+  DOM_VK_F12 = 0x7B,
+  DOM_VK_NUMPAD0 = 0x60,
+  DOM_VK_NUMPAD1 = 0x61,
+  DOM_VK_NUMPAD2 = 0x62,
+  DOM_VK_NUMPAD3 = 0x63,
+  DOM_VK_NUMPAD4 = 0x64,
+  DOM_VK_NUMPAD5 = 0x65,
+  DOM_VK_NUMPAD6 = 0x66,
+  DOM_VK_NUMPAD7 = 0x67,
+  DOM_VK_NUMPAD8 = 0x68,
+  DOM_VK_NUMPAD9 = 0x69
+};
+
+/**
+ * @brief Converts a DOM virtual key code to an iPlug2 virtual key code
+ * @param domKeyCode The DOM virtual key code to convert
+ * @return The corresponding iPlug2 virtual key code, or 0 if no mapping exists
+ */
+inline int DOMKeyToVirtualKey(uint32_t domKeyCode) {
+  switch(domKeyCode) {
+    case DOM_VK_BACK_SPACE:     return kVK_BACK;
+    case DOM_VK_TAB:            return kVK_TAB;
+    case DOM_VK_RETURN:         return kVK_RETURN;
+    case DOM_VK_SHIFT:          return kVK_SHIFT;
+    case DOM_VK_CONTROL:        return kVK_CONTROL;
+    case DOM_VK_ALT:            return kVK_MENU;
+    case DOM_VK_PAUSE:          return kVK_PAUSE;
+    case DOM_VK_CAPS_LOCK:      return kVK_CAPITAL;
+    case DOM_VK_ESCAPE:         return kVK_ESCAPE;
+    case DOM_VK_SPACE:          return kVK_SPACE;
+    case DOM_VK_PAGE_UP:        return kVK_PRIOR;
+    case DOM_VK_PAGE_DOWN:      return kVK_NEXT;
+    case DOM_VK_END:            return kVK_END;
+    case DOM_VK_HOME:           return kVK_HOME;
+    case DOM_VK_LEFT:           return kVK_LEFT;
+    case DOM_VK_UP:             return kVK_UP;
+    case DOM_VK_RIGHT:          return kVK_RIGHT;
+    case DOM_VK_DOWN:           return kVK_DOWN;
+    case DOM_VK_INSERT:         return kVK_INSERT;
+    case DOM_VK_DELETE:         return kVK_DELETE;
+    
+    // Numbers (both main keyboard and numpad)
+    case 0x30: case DOM_VK_NUMPAD0:  return kVK_0;
+    case 0x31: case DOM_VK_NUMPAD1:  return kVK_1;
+    case 0x32: case DOM_VK_NUMPAD2:  return kVK_2;
+    case 0x33: case DOM_VK_NUMPAD3:  return kVK_3;
+    case 0x34: case DOM_VK_NUMPAD4:  return kVK_4;
+    case 0x35: case DOM_VK_NUMPAD5:  return kVK_5;
+    case 0x36: case DOM_VK_NUMPAD6:  return kVK_6;
+    case 0x37: case DOM_VK_NUMPAD7:  return kVK_7;
+    case 0x38: case DOM_VK_NUMPAD8:  return kVK_8;
+    case 0x39: case DOM_VK_NUMPAD9:  return kVK_9;
+    
+    // Letters
+    case 0x41: return kVK_A;
+    case 0x42: return kVK_B;
+    case 0x43: return kVK_C;
+    case 0x44: return kVK_D;
+    case 0x45: return kVK_E;
+    case 0x46: return kVK_F;
+    case 0x47: return kVK_G;
+    case 0x48: return kVK_H;
+    case 0x49: return kVK_I;
+    case 0x4A: return kVK_J;
+    case 0x4B: return kVK_K;
+    case 0x4C: return kVK_L;
+    case 0x4D: return kVK_M;
+    case 0x4E: return kVK_N;
+    case 0x4F: return kVK_O;
+    case 0x50: return kVK_P;
+    case 0x51: return kVK_Q;
+    case 0x52: return kVK_R;
+    case 0x53: return kVK_S;
+    case 0x54: return kVK_T;
+    case 0x55: return kVK_U;
+    case 0x56: return kVK_V;
+    case 0x57: return kVK_W;
+    case 0x58: return kVK_X;
+    case 0x59: return kVK_Y;
+    case 0x5A: return kVK_Z;
+    
+    // Function keys
+    case DOM_VK_F1:  return kVK_F1;
+    case DOM_VK_F2:  return kVK_F2;
+    case DOM_VK_F3:  return kVK_F3;
+    case DOM_VK_F4:  return kVK_F4;
+    case DOM_VK_F5:  return kVK_F5;
+    case DOM_VK_F6:  return kVK_F6;
+    case DOM_VK_F7:  return kVK_F7;
+    case DOM_VK_F8:  return kVK_F8;
+    case DOM_VK_F9:  return kVK_F9;
+    case DOM_VK_F10: return kVK_F10;
+    case DOM_VK_F11: return kVK_F11;
+    case DOM_VK_F12: return kVK_F12;
+    
+    default: return 0; // No mapping available
+  }
+}
+
 END_IPLUG_NAMESPACE
 
 /**@}*/


### PR DESCRIPTION
This PR updates the IWebViewEditorDelegate class to implement OnKeyDown() and OnKeyUp(). These events are passed down from scripts that are attached to the document in the webview. On Windows the default implementation passes the spacebar to the parent window, fixing #1177 

Also fixes macOS webview beeping on keypress. The DOM key to iPlug2 VirtualKey mapping is pulled out into an iPlug2 utility function, which is now used by IGraphicsWeb and the IWebViewEditorDelegate class to convert the mappings.