### PR TITLE
Added warnings to OBJ-C code to make sure namespace is properly customized

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -132,6 +132,10 @@ static int MacKeyEventToVK(NSEvent* pEvent, int& flag)
   return code;
 }
 
+#ifndef IGRAPHICS_MENU_RCVR
+#warning The iPlug2 Obj-C namespace is not customized. Did you forget to include IPlugOBJCPrefix.pch?
+#endif
+
 @implementation IGRAPHICS_MENU_RCVR
 
 - (NSMenuItem*) menuItem

--- a/IPlug/IPlugOBJCPrefix.pch
+++ b/IPlug/IPlugOBJCPrefix.pch
@@ -19,6 +19,7 @@
   //objective-c has a flat namespace, we need to customise the class name for all of our objective-c classes
   //so that binaries using different versions don't conflict
   #ifndef OBJC_PREFIX
+    #warning OBJC_PREFIX not defined, setting it to "vIPLUG2". To avoid conflict, define it specifically for each product.
     #define OBJC_PREFIX vIPLUG2
   #endif
 


### PR DESCRIPTION
Added warnings to OBJ-C code to make sure namespace is properly customized, which can easily be missed when creating a cmake project or an xcode project from scratch.
