### PR TITLE
GetMouseIsDown() function in IGraphics

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -986,6 +986,7 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
   {
     mMouseDownX = points[0].x;
     mMouseDownY = points[0].y;
+    mMouseIsDown = true;
   }
 
   for (auto& point : points)
@@ -1065,6 +1066,7 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
 void IGraphics::OnMouseUp(const std::vector<IMouseInfo>& points)
 {
 //  Trace("IGraphics::OnMouseUp", __LINE__, "x:%0.2f, y:%0.2f, mod:LRSCA: %i%i%i%i%i", x, y, mod.L, mod.R, mod.S, mod.C, mod.A);
+  mMouseIsDown = false;
   
   if (ControlIsCaptured())
   {

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1597,6 +1597,9 @@ public:
    * @param y Where the Y position will be stored */
   void GetMouseDownPoint(float& x, float&y) const { x = mMouseDownX; y = mMouseDownY; }
   
+  /** Get the current mouse down state. */
+  bool GetMouseIsDown() const { return mMouseIsDown; }
+  
   /**  Set by the platform class if the mouse input is coming from a tablet/stylus
    * @param tablet \c true means input is from a tablet */
   void SetTabletInput(bool tablet) { mTabletInput = tablet; }
@@ -1830,6 +1833,7 @@ private:
   int mMouseOverIdx = -1;
   float mMouseDownX = -1.f;
   float mMouseDownY = -1.f;
+  bool mMouseIsDown = false;
   float mMinScale;
   float mMaxScale;
   int mLastClickedParam = kNoParameter;


### PR DESCRIPTION
IGraphics can report the mouse position and latest mouseDown position, but not whether mouse is actually currently down. This is a pretty small addition, but useful nonetheless. I imagine in the future one could add a more complete touch/mouse state interface, but this is a good start and very compatible with the existing functions.