### PR TITLE
Allow FPS display to be able to be positioned by user

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -434,13 +434,13 @@ void IGraphics::ShowBubbleControl(IControl* pCaller, float x, float y, const cha
     mBubbleControls.Get(0)->ShowBubble(pCaller, x, y, str, dir, minimumContentBounds);
 }
 
-void IGraphics::ShowFPSDisplay(bool enable)
+void IGraphics::ShowFPSDisplay(bool enable, const IRECT& bounds)
 {
   if (enable)
   {
     if (!mPerfDisplay)
     {
-      mPerfDisplay = std::make_unique<IFPSDisplayControl>(GetBounds().GetPadded(-10).GetFromTLHC(200, 50));
+      mPerfDisplay = std::make_unique<IFPSDisplayControl>(bounds.Empty()? GetBounds().GetPadded(-10).GetFromTLHC(200, 50) : bounds);
       mPerfDisplay->SetDelegate(*GetDelegate());
     }
   }

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1341,7 +1341,7 @@ public:
 
   /** Shows a control to display the frame rate of drawing
    * @param enable \c true to show */
-  void ShowFPSDisplay(bool enable);
+  void ShowFPSDisplay(bool enable, const IRECT& bounds = IRECT());
   
   /** @return \c true if performance display is shown */
   bool ShowingFPSDisplay() { return mPerfDisplay != nullptr; }


### PR DESCRIPTION
Adds the ability to specify the position of the IFPSDisplayControl.
It's useful to move this control around to place it in a location where it's not in the way of the rest of the interface.