### PR TITLE
Add new InitFrequencyAutoRange initialization function

### DIFF
--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -175,6 +175,21 @@ void IParam::InitFrequency(const char *name, double defaultVal, double minVal, d
   InitDouble(name, defaultVal, minVal, maxVal, step, "Hz", flags, group, ShapeExp(), kUnitFrequency);
 }
 
+void IParam::InitFrequencyAutoRange(const char* name, double defaultVal, double minVal, double maxVal, double step, int flags, const char* group)
+{
+  InitDouble(name, defaultVal, minVal, maxVal, step, "", flags, group, ShapeExp(), kUnitCustom);
+  auto freqFormatter = [](double val, WDL_String& str, IParam* parent)
+  {
+    const double onethousand = parent->FromNormalized(parent->ToNormalized(1000.));
+    const bool gte1k = val >= onethousand || val >= 1000.;
+    const char* units = gte1k? "kHz" : "Hz";
+    if (gte1k) val *= 0.001;
+    const int displayPrecision = parent->GetDisplayPrecision();
+    str.SetFormatted(MAX_PARAM_DISPLAY_LEN, "%.*f %s", displayPrecision, val, units);
+  };
+  SetDisplayFunc(std::bind(freqFormatter, std::placeholders::_1, std::placeholders::_2, this));
+}
+
 void IParam::InitSeconds(const char *name, double defaultVal, double minVal, double maxVal, double step, int flags, const char *group)
 {
   InitDouble(name, defaultVal, minVal, maxVal, step, "Seconds", flags, group, ShapeLinear(), kUnitSeconds);

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -214,7 +214,18 @@ public:
    * @param flags The parameter's flags \see IParam::EFlags
    * @param group The parameter's group */
   void InitFrequency(const char* name, double defaultVal = 1000., double minVal = 0.1, double maxVal = 10000., double step = 0.1, int flags = 0, const char* group = "");
-  
+
+  /** Initialize the parameter as frequency
+   * Where the units switch between Hz for value < 1000. or kHz for value >= 1000.
+   * @param name The parameter's name
+   * @param defaultVal The default value of the parameter
+   * @param minVal The minimum value of the parameter
+   * @param maxVal The maximum value of the parameter
+   * @param step The step size of the parameter
+   * @param flags The parameter's flags \see IParam::EFlags
+   * @param group The parameter's group */
+  void InitFrequencyAutoRange(const char* name, double defaultVal = 1000., double minVal = 0.1, double maxVal = 10000., double step = 0.1, int flags = 0, const char* group = "");
+
   /** Initialize the parameter as pitch
    * @param name The parameter's name
    * @param defaultVal The default value of the parameter


### PR DESCRIPTION
With reference to: https://iplug2.discourse.group/t/automatic-hz-khz-change-during-frequency-parameter-changes/984/3 add a new function called: InitFrequencyAutoRange that provides a frequency parameter that automatically changes formatting between Hz and kHz.

Uses the function:
```c++
  auto freqFormatter = [](double val, WDL_String& str, IParam* parent)
  {
    const double onethousand = parent->FromNormalized(parent->ToNormalized(1000.));
    const bool gte1k = val >= onethousand || val >= 1000.;
    const char* units = gte1k? "kHz" : "Hz";
    if (gte1k) val *= 0.001;
    const int displayPrecision = parent->GetDisplayPrecision();
    str.SetFormatted(MAX_PARAM_DISPLAY_LEN, "%.*f %s", displayPrecision, val, units);
  };
```

In order to both provide formatting, and also respect either the precomputed precision, or a call to:
`SetDisplayPrecision`

All feedback welcome.