### PR TITLE
Update ITextEntryControl.cpp to support label entry

### DIFF
--- a/IGraphics/Controls/ITextEntryControl.cpp
+++ b/IGraphics/Controls/ITextEntryControl.cpp
@@ -308,6 +308,8 @@ bool ITextEntryControl::OnKeyDown(float x, float y, const IKeyPress& key)
               break;
             if (stbKey == '+' || stbKey == '-' || stbKey == '.')
               break;
+            if (strchr(pParam->GetLabel(), stbKey) != NULL)
+              break;
             stbKey = 0;
             break;
           }


### PR DESCRIPTION
This is an initial suggestion of how you could go about entering the label as a part of the text entry. For simple examples this already works, but there are some outstanding issues:

1.) It's case sensitive, and probably shouldn't be 2.) You cannot use this with advanced entry, like entries where the label changes type depending on the value 3.) It's limited to a double, it could be extended for all

Just throwing this out there to show that it's both possible, and probably not THAT hard.

What do people want to see to consider this complete?