### PR TITLE
The IPlugWebView example was calling IPlugAPIBase::EditorResize() rather than IEditorDelegate::EditorResizeFromUI()

### DIFF
--- a/Examples/IPlugWebUI/IPlugWebUI.cpp
+++ b/Examples/IPlugWebUI/IPlugWebUI.cpp
@@ -46,15 +46,15 @@ bool IPlugWebUI::OnMessage(int msgTag, int ctrlTag, int dataSize, const void* pD
 {
   if (msgTag == kMsgTagButton1)
   {
-    EditorResize(300, 300);
+    Resize(300, 300);
   }
   else if (msgTag == kMsgTagButton2)
   {
-    EditorResize(600, 600);
+    Resize(600, 600);
   }
   else if (msgTag == kMsgTagButton3)
   {
-    EditorResize(1024, 768);
+    Resize(1024, 768);
   }
   else if (msgTag == kMsgTagBinaryTest)
   {

--- a/IPlug/AAX/IPlugAAX.h
+++ b/IPlug/AAX/IPlugAAX.h
@@ -88,9 +88,7 @@ public:
   void EndInformHostOfParamChange(int idx) override;
   
   void InformHostOfPresetChange() override { }; //NA
-  
-  bool EditorResize(int viewWidth, int viewHeight) override;
-  
+    
   /** Get the name of the track that the plug-in is inserted on */
   virtual void GetTrackName(WDL_String& str) override { str = mTrackName; };
   
@@ -119,6 +117,8 @@ public:
   void DirtyPTCompareState() { mNumPlugInChanges++; }
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   AAX_CParameter<bool>* mBypassParameter = nullptr;
   AAX_ITransport* mTransport = nullptr;
   WDL_PtrList<WDL_String> mParamIDs;

--- a/IPlug/APP/IPlugAPP.h
+++ b/IPlug/APP/IPlugAPP.h
@@ -43,7 +43,6 @@ public:
   void InformHostOfParamChange(int idx, double normalizedValue) override {};
   void EndInformHostOfParamChange(int idx) override {};
   void InformHostOfPresetChange() override {};
-  bool EditorResize(int viewWidth, int viewHeight) override;
 
   //IEditorDelegate
   void SendSysexMsgFromUI(const ISysEx& msg) override;
@@ -56,6 +55,8 @@ public:
   void AppProcess(double** inputs, double** outputs, int nFrames);
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   IPlugAPPHost* mAppHost = nullptr;
   IPlugQueue<IMidiMsg> mMidiMsgsFromCallback {MIDI_TRANSFER_SIZE};
   IPlugQueue<SysExData> mSysExMsgsFromCallback {SYSEX_TRANSFER_SIZE};

--- a/IPlug/CLAP/IPlugCLAP.h
+++ b/IPlug/CLAP/IPlugCLAP.h
@@ -89,7 +89,6 @@ public:
   void BeginInformHostOfParamChange(int idx) override;
   void InformHostOfParamChange(int idx, double normalizedValue) override;
   void EndInformHostOfParamChange(int idx) override;
-  bool EditorResize(int viewWidth, int viewHeight) override;
   
   // IPlugProcessor
   void SetTailSize(int tailSize) override;
@@ -98,6 +97,8 @@ public:
   bool SendSysEx(const ISysEx& msg) override;
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   // clap_plugin
   bool init() noexcept override;
   bool activate(double sampleRate, uint32_t minFrameCount, uint32_t maxFrameCount) noexcept override;

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -90,7 +90,7 @@ bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) con
 
 bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsPlatformResize)
 {
-  if (needsPlatformResize && !GetHostResizeEnabled())
+  if (needsPlatformResize)
     return EditorResize(viewWidth, viewHeight);
   else
     return true;

--- a/IPlug/VST2/IPlugVST2.h
+++ b/IPlug/VST2/IPlugVST2.h
@@ -43,7 +43,6 @@ public:
   void EndInformHostOfParamChange(int idx) override;
   void InformHostOfPresetChange() override;
   void HostSpecificInit() override;
-  bool EditorResize(int viewWidth, int viewHeight) override;
 
   //IPlugProcessor
   void SetLatency(int samples) override;
@@ -56,6 +55,8 @@ public:
   void OutputSysexFromEditor();
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   virtual VstIntPtr VSTVendorSpecific(VstInt32 idx, VstIntPtr value, void* ptr, float opt) { return 0; }
   virtual VstIntPtr VSTCanDo(const char* hostString) { return 0; }
     

--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -61,7 +61,6 @@ public:
   void EndInformHostOfParamChange(int idx) override;
   void InformHostOfPresetChange() override {}
   void InformHostOfParameterDetailsChange() override;
-  bool EditorResize(int viewWidth, int viewHeight) override;
 
   // IEditorDelegate
   void DirtyParametersFromUI() override;
@@ -167,6 +166,8 @@ public:
   REFCOUNT_METHODS(SingleComponentEffect)
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   ViewType* mView;
 };
 

--- a/IPlug/VST3/IPlugVST3_Controller.h
+++ b/IPlug/VST3/IPlugVST3_Controller.h
@@ -110,7 +110,6 @@ public:
   void InformHostOfParamChange(int idx, double normalizedValue) override  { performEdit(idx, normalizedValue); }
   void EndInformHostOfParamChange(int idx) override  { endEdit(idx); }
   void InformHostOfPresetChange() override  { /* TODO: */}
-  bool EditorResize(int viewWidth, int viewHeight) override;
   void DirtyParametersFromUI() override;
   
   // IEditorDelegate
@@ -123,6 +122,8 @@ public:
   ViewType* GetView() const { return mView; }
 
 private:
+  bool EditorResize(int viewWidth, int viewHeight) override;
+
   ViewType* mView = nullptr;
   bool mPlugIsInstrument;
   bool mDoesMidiIn;


### PR DESCRIPTION
This wouldn't compile for audiounits but shouldn't work anyway. Why are the overridden methods not private in the other API classes, like in IPlugAPIBase. Let's make them private and see what breaks...