### PR TITLE
Revert "VST3: IPlugVST3View reports screen-scaled dimensions"

### DIFF
--- a/Examples/IPlugWebUI/IPlugWebUI.cpp
+++ b/Examples/IPlugWebUI/IPlugWebUI.cpp
@@ -45,17 +45,11 @@ void IPlugWebUI::OnReset()
 bool IPlugWebUI::OnMessage(int msgTag, int ctrlTag, int dataSize, const void* pData)
 {
   if (msgTag == kMsgTagButton1)
-  {
-    EditorResize(300, 300);
-  }
-  else if (msgTag == kMsgTagButton2)
-  {
-    EditorResize(600, 600);
-  }
-  else if (msgTag == kMsgTagButton3)
-  {
-    EditorResize(1024, 768);
-  }
+    Resize(512, 335);
+  else if(msgTag == kMsgTagButton2)
+    Resize(1024, 335);
+  else if(msgTag == kMsgTagButton3)
+    Resize(1024, 768);
   else if (msgTag == kMsgTagBinaryTest)
   {
     auto uint8Data = reinterpret_cast<const uint8_t*>(pData);

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -89,8 +89,8 @@ bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) con
 }
 
 bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsPlatformResize)
-{
-  if (needsPlatformResize && !GetHostResizeEnabled())
+{  
+  if (needsPlatformResize)
     return EditorResize(viewWidth, viewHeight);
   else
     return true;

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -59,8 +59,7 @@ public:
     if (pSize)
     {
       rect = *pSize;
-      mOwner.OnParentWindowResize(rect.getWidth() / mScaleFactor, 
-                                  rect.getHeight() / mScaleFactor);
+      mOwner.OnParentWindowResize(rect.getWidth(), rect.getHeight());
     }
     
     return Steinberg::kResultTrue;
@@ -72,7 +71,7 @@ public:
     
     if (mOwner.HasUI())
     {
-      *pSize = Steinberg::ViewRect(0, 0, mOwner.GetEditorWidth() * mScaleFactor, mOwner.GetEditorHeight() * mScaleFactor);
+      *pSize = Steinberg::ViewRect(0, 0, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
       
       return Steinberg::kResultTrue;
     }
@@ -94,13 +93,13 @@ public:
   
   Steinberg::tresult PLUGIN_API checkSizeConstraint(Steinberg::ViewRect* pRect) override
   {
-    int w = pRect->getWidth() / mScaleFactor;
-    int h = pRect->getHeight() / mScaleFactor;
+    int w = pRect->getWidth();
+    int h = pRect->getHeight();
     
-    if (!mOwner.ConstrainEditorResize(w, h))
+    if(!mOwner.ConstrainEditorResize(w, h))
     {
-      pRect->right = pRect->left + (w * mScaleFactor);
-      pRect->bottom = pRect->top + (h * mScaleFactor);
+      pRect->right = pRect->left + w;
+      pRect->bottom = pRect->top + h;
     }
     
     return Steinberg::kResultTrue;
@@ -137,7 +136,7 @@ public:
   Steinberg::tresult PLUGIN_API setContentScaleFactor(ScaleFactor factor) override
   {
     mOwner.SetScreenScale(factor);
-    mScaleFactor = factor;
+
     return Steinberg::kResultOk;
   }
 
@@ -336,10 +335,9 @@ public:
   {
     TRACE
     
-    Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w * mScaleFactor, h * mScaleFactor);
+    Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w, h);
     plugFrame->resizeView(this, &newSize);
   }
 
   T& mOwner;
-  float mScaleFactor = 1.f;
 };


### PR DESCRIPTION
Reverts iPlug2/iPlug2#1158 which caused a regression with VST3 editor sizing on windows.

WebView UI plugins will not get the correct dimensions without this. If you need that functionality, use the work on branch VST3/screen-scaled . Hopefully soon i can find a solution that works everywhere