### PR TITLE
Make sure newly added parameters are not zeroed with UnserializeParams()

### DIFF
--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -131,7 +131,7 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
     IParam* pParam = mParams.Get(i);
     double v = 0.0;
     pos = chunk.Get(&v, pos);
-    if (pos >=0)
+    if (pos >= 0)
     {
       pParam->Set(v);
       Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -131,8 +131,11 @@ int IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
     IParam* pParam = mParams.Get(i);
     double v = 0.0;
     pos = chunk.Get(&v, pos);
-    pParam->Set(v);
-    Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());
+    if (pos >=0)
+    {
+      pParam->Set(v);
+      Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());
+    }
   }
 
   OnParamReset(kPresetRecall);


### PR DESCRIPTION
Although the loop here already exits early if the chunk has no more data it will still write one parameter with a zero (overwriting the default or current value) if the number of parameters has increased and an old plugin state is loaded.

This change just checks if something (hopefully) valid was read from the chunk before setting the parameter