### PR TITLE
IGraphicsIOS: Add HoverGestureRecognizer for mouse-overs

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -230,6 +230,10 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForegroundNotification:) name:UIApplicationWillEnterForegroundNotification object:nil];
   mColorPickerHandlerFunc = nullptr;
   
+  UIHoverGestureRecognizer* hoverGestureRecognizer =
+      [[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(onHoverGesture:)];
+  [self addGestureRecognizer: hoverGestureRecognizer];
+  
   return self;
 }
 
@@ -830,6 +834,20 @@ extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
   info.type = EGestureType::Rotate;
 
   mGraphics->OnGestureRecognized(info);
+}
+
+- (void) onHoverGesture: (UIHoverGestureRecognizer*) recognizer
+{
+  CGPoint pos = [recognizer locationInView:self];
+
+  IMouseInfo info;
+  
+  auto ds = mGraphics->GetDrawScale();  
+  info.x = pos.x / ds;
+  info.y = pos.y / ds;
+  
+  if (mGraphics)
+    mGraphics->OnMouseOver(info.x, info.y, info.ms);
 }
 
 -(BOOL) gestureRecognizer:(UIGestureRecognizer*) gestureRecognizer shouldReceiveTouch:(UITouch*) touch


### PR DESCRIPTION
Adds a [uihovergesturerecognizer](https://developer.apple.com/documentation/uikit/uihovergesturerecognizer)

When an iPad / mac Catalyst app / visionOS app receives pointer info we currently don't issue any mouse overs. This fixes that. I believe that the gesture recogniser is freed via ARC, and that on e.g. iPhone where there are not pointer events it shouldn't have any negative impact on performance