### PR TITLE
Add ScopedGLContext

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -331,18 +331,16 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* fileNameOrResID, int scale
 
     if (pResData)
     {
-      ActivateGLContext(); // no-op on non WIN/GL
+      ScopedGLContext scopedGLCtx {this};
       idx = nvgCreateImageMem(mVG, nvgImageFlags, (unsigned char*) pResData, size);
-      DeactivateGLContext(); // no-op on non WIN/GL
     }
   }
   else
 #endif
   if (location == EResourceLocation::kAbsolutePath)
   {
-    ActivateGLContext(); // no-op on non WIN/GL
+    ScopedGLContext scopedGLCtx {this};
     idx = nvgCreateImage(mVG, fileNameOrResID, nvgImageFlags);
-    DeactivateGLContext(); // no-op on non WIN/GL
   }
 
   return new Bitmap(mVG, fileNameOrResID, scale, idx, location == EResourceLocation::kPreloadedTexture);
@@ -358,10 +356,11 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* name, const void* pData, i
     int idx = 0;
     int nvgImageFlags = 0;
 
-    ActivateGLContext();
-    idx = nvgCreateImageMem(mVG, nvgImageFlags, (unsigned char*)pData, dataSize);
-    DeactivateGLContext();
-
+    {
+      ScopedGLContext scopedGLCtx {this};
+      idx = nvgCreateImageMem(mVG, nvgImageFlags, (unsigned char*)pData, dataSize);
+    }
+    
     pBitmap = new Bitmap(mVG, name, scale, idx, false);
 
     storage.Add(pBitmap, name, scale);
@@ -480,8 +479,8 @@ void IGraphicsNanoVG::OnViewDestroyed()
 
 void IGraphicsNanoVG::DrawResize()
 {
-  ActivateGLContext();
-  
+  ScopedGLContext scopedGLCtx {this};
+
   if (mMainFrameBuffer != nullptr)
     nvgDeleteFramebuffer(mMainFrameBuffer);
   
@@ -492,8 +491,6 @@ void IGraphicsNanoVG::DrawResize()
     if (mMainFrameBuffer == nullptr)
       DBGMSG("Could not init FBO.\n");
   }
-  
-  DeactivateGLContext();
 }
 
 void IGraphicsNanoVG::BeginFrame()

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -455,6 +455,7 @@ void IGraphicsSkia::OnViewDestroyed()
 
 void IGraphicsSkia::DrawResize()
 {
+  ScopedGLContext scopedGLContext{this};
   auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
   auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
   

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -970,6 +970,17 @@ public:
   /** Get the app group ID on macOS and iOS, returns emtpy string on other OSs */
   virtual const char* GetAppGroupID() const { return ""; }
 
+  // An RAII helper to manage the IGraphics GL context
+  class ScopedGLContext
+  {
+  public:
+    ScopedGLContext(IGraphics* pGraphics)
+    : mIGraphics(*pGraphics) { mIGraphics.ActivateGLContext(); }
+    ~ScopedGLContext() { mIGraphics.DeactivateGLContext(); }
+  private:
+    IGraphics& mIGraphics;
+  };
+  
 protected:
   /* Activate the context for the view (GL only) */
   virtual void ActivateGLContext() {};

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -93,10 +93,7 @@ void* IGraphicsMac::OpenWindow(void* pParent)
   IGRAPHICS_VIEW* pView = [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
   mView = (void*) pView;
     
-#ifdef IGRAPHICS_GL
-  [[pView openGLContext] makeCurrentContext];
-#endif
-    
+  ActivateGLContext();
   OnViewInitialized([pView layer]);
   SetScreenScale([[NSScreen mainScreen] backingScaleFactor]);
   GetDelegate()->LayoutUI(this);
@@ -727,17 +724,14 @@ EUIAppearance IGraphicsMac::GetUIAppearance() const
 
 void IGraphicsMac::ActivateGLContext()
 {
-#ifdef IGRAPHICS_GL
   IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
-  [[pView openGLContext] makeCurrentContext];
-#endif
+  [pView activateGLContext];
 }
 
 void IGraphicsMac::DeactivateGLContext()
 {
-#ifdef IGRAPHICS_GL
-  [NSOpenGLContext clearCurrentContext];
-#endif
+  IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
+  [pView deactivateGLContext];
 }
 
 #if defined IGRAPHICS_NANOVG

--- a/IGraphics/Platforms/IGraphicsMac_view.h
+++ b/IGraphics/Platforms/IGraphicsMac_view.h
@@ -175,7 +175,12 @@ using namespace igraphics;
 - (NSDragOperation) draggingEntered: (id <NSDraggingInfo>) sender;
 - (BOOL) performDragOperation: (id<NSDraggingInfo>) sender;
 - (NSDragOperation)draggingSession:(NSDraggingSession*) session sourceOperationMaskForDraggingContext:(NSDraggingContext)context;
-//
+
 - (void) setMouseCursor: (ECursor) cursorType;
+
+- (void) swapBuffers;
+- (void) activateGLContext;
+- (void) deactivateGLContext;
+
 @end
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -654,16 +654,11 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
         BeginPaint(hWnd, &ps);
 #endif
 
-#ifdef IGRAPHICS_GL
-        pGraphics->ActivateGLContext();
-#endif
-
-        pGraphics->Draw(rects);
-
-        #ifdef IGRAPHICS_GL
-        SwapBuffers((HDC) pGraphics->GetPlatformContext());
-        pGraphics->DeactivateGLContext();
-        #endif
+        {
+          ScopedGLContext scopedGLCtx {pGraphics};
+          pGraphics->Draw(rects);
+          SwapBuffers((HDC) pGraphics->GetPlatformContext());
+        }
 
 #if defined IGRAPHICS_GL || IGRAPHICS_D2D
         EndPaint(hWnd, &ps);
@@ -937,15 +932,6 @@ void IGraphicsWin::PlatformResize(bool parentHasResized)
   }
 }
 
-#ifdef IGRAPHICS_GL
-void IGraphicsWin::DrawResize()
-{
-  ActivateGLContext();
-  IGRAPHICS_DRAW_CLASS::DrawResize();
-  DeactivateGLContext();
-}
-#endif
-
 void IGraphicsWin::HideMouseCursor(bool hide, bool lock)
 {
   if (mCursorHidden == hide)
@@ -1107,16 +1093,20 @@ void IGraphicsWin::DestroyGLContext()
 
 void IGraphicsWin::ActivateGLContext()
 {
+#ifdef IGRAPHICS_GL
   mStartHDC = wglGetCurrentDC();
   mStartHGLRC = wglGetCurrentContext();
   HDC dc = GetDC(mPlugWnd);
   wglMakeCurrent(dc, mHGLRC);
+#endif
 }
 
 void IGraphicsWin::DeactivateGLContext()
 {
+#ifdef IGRAPHICS_GL
   ReleaseDC(mPlugWnd, (HDC) GetPlatformContext());
   wglMakeCurrent(mStartHDC, mStartHGLRC); // return current ctxt to start
+#endif
 }
 #endif
 
@@ -1287,14 +1277,12 @@ void IGraphicsWin::CloseWindow()
     else
       KillTimer(mPlugWnd, IPLUG_TIMER_ID);
 
+    {
+      ScopedGLContext scopedGLCtx {this};
+      OnViewDestroyed();
+    }
+    
 #ifdef IGRAPHICS_GL
-    ActivateGLContext();
-#endif
-
-    OnViewDestroyed();
-
-#ifdef IGRAPHICS_GL
-    DeactivateGLContext();
     DestroyGLContext();
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -38,10 +38,6 @@ public:
 
   void PlatformResize(bool parentHasResized) override;
 
-#ifdef IGRAPHICS_GL
-  void DrawResize() override; // overriden here to deal with GL graphics context capture
-#endif
-
   void CheckTabletInput(UINT msg);
   void DestroyEditWindow();
     
@@ -121,11 +117,12 @@ private:
   inline IMouseInfo GetMouseInfo(LPARAM lParam, WPARAM wParam);
   bool MouseCursorIsLocked();
 
+  void ActivateGLContext() override;
+  void DeactivateGLContext() override;
+  
 #ifdef IGRAPHICS_GL
   void CreateGLContext(); // OpenGL context management - TODO: RAII instead ?
   void DestroyGLContext();
-  void ActivateGLContext() override;
-  void DeactivateGLContext() override;
   HGLRC mHGLRC = nullptr;
   HGLRC mStartHGLRC = nullptr;
   HDC mStartHDC = nullptr;


### PR DESCRIPTION
This is a highly risky PR that I would like to get merged before a subsequent PR that would merge GLES support via ANGLE.

Rationale, for ANGLE: Apple have deprecated OpenGL and we never supported it on iOS in iPlug2. I notice some strange artefacts with IGRAPHICS_GL3 / IGRAPHICS_NANOVG on my Apple Silicon mac when I run IGraphicsTest. I am not sure if this is due to the way we create the GL Context (there are different ways) or if something is just broken with GL on macOS.

Anyhow, I would like to add GLES support via ANGLE, which is the library that allows WebGL to work consistently across many browsers. That means someone can use IGraphics with GLES on all platforms.

This PR is the first part of that work to clean up the Activate/Deactivate/SwapBuffers calls. It's a bit fiddly so I could do with some more 👀 