### PR TITLE
Fix "File not Found" on first run / clean builds

### DIFF
--- a/Scripts/create_bundle.bat
+++ b/Scripts/create_bundle.bat
@@ -35,8 +35,9 @@ IF EXIST %BundleDir%\PlugIn.ico GOTO ICON_EXISTS
 copy /Y %IconSource% %BundleDir%\PlugIn.ico > NUL
 :ICON_EXISTS
 
+IF EXIST %BundleDir%\desktop.ini attrib -h -r -s %BundleDir%\desktop.ini
+
 attrib -r %BundleDir%
-attrib -h -r -s %BundleDir%\desktop.ini
 echo [.ShellClassInfo] > %BundleDir%\desktop.ini 
 echo IconResource=PlugIn.ico,0 >> %BundleDir%\desktop.ini 
 echo ;For compatibility with Windows XP >> %BundleDir%\desktop.ini 


### PR DESCRIPTION
This is a fix for build log noise only.

Attributes are set on a desktop.ini that may not exist. That error is not propagated to the return value of the batch file so it does not cause an overall build error, but it does create noise in the build log.

Once the file exists (the script will create it) the noise disappears, but it seems preferable to only set attributes if the file is present.