### PR TITLE
Fix VST2 casting so that the compiler gives no warnings

### DIFF
--- a/IPlug/IPlug_include_in_plug_src.h
+++ b/IPlug/IPlug_include_in_plug_src.h
@@ -88,11 +88,8 @@
     
     EXPORT int main(int hostCallback)
     {
-    #if defined OS_MAC
-      return (VstIntPtr) VSTPluginMain((audioMasterCallback)hostCallback);
-    #else
-      return (int) VSTPluginMain((audioMasterCallback)hostCallback);
-    #endif
+      audioMasterCallback callback = reinterpret_cast<audioMasterCallback>(static_cast<VstIntPtr>(hostCallback));
+      return static_cast<int>(reinterpret_cast<std::uintptr_t>(VSTPluginMain(callback)));
     }
   };
 #pragma mark - VST3 (All)


### PR DESCRIPTION
There have been some warnings in the VST2 main function due that can be fixed by casting in an appropriate C++ style to let the compiler know that the casts are fully intentional. This PR does that.