### PR TITLE
Skia image filter dropshadow

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -122,6 +122,7 @@ public:
 
   APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) override;
 
+  void ApplyLayerDropShadow(ILayerPtr& layer, const IShadow& shadow) override;
   void GetLayerBitmapData(const ILayerPtr& layer, RawBitmapData& data) override;
   void ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, const IShadow& shadow) override;
 

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -559,7 +559,7 @@ public:
   /** Applies a drop shadow directly onto a layer
   * @param layer - the layer to add the shadow to 
   * @param shadow - the shadow to add */
-  void ApplyLayerDropShadow(ILayerPtr& layer, const IShadow& shadow);
+  virtual void ApplyLayerDropShadow(ILayerPtr& layer, const IShadow& shadow);
 
   /** Get the contents of a layer as Raw RGBA bitmap data
    * NOTE: you should only call this within IControl::Draw()


### PR DESCRIPTION
This is an optimisation/enhancement.

This provides a way that Skia GPU backends can use an image filter to do shadows that have a single color, leading to currently very similar results visually as the convolution drop shadow in IGraphics with much improved performance. This also allows drop shadows to run on IOS where grabbing the pixels fails (or crashes I can't quite remember) for security reasons.

Notes:
- **I would like to tweak the approximation of E** to see if we can get even more similar outputs for the same input **before we merge**.
- The IGraphics code is used for gradient pattern shadows to ensure there is no change in functionality (this is not supported by skia image filters and it's not obvious that we could do this in skia with a hand-rolled filter
- On the CPU there is not evidence that using an image filter is faster, and some cases where it is slower, as the code in IGraphics tries to determine a smaller area for the shadow which will sometimes be the case.
- We can squash this to a single merge without needing to keep any of the history.