### PR TITLE
Separate some of the windows font code from IGraphicsWin (.h/,cpp) 

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -15,6 +15,7 @@
 #include <winuser.h>
 
 #include "IGraphics_select.h"
+#include "IGraphicsWinFonts.h"
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
@@ -23,9 +24,9 @@ BEGIN_IGRAPHICS_NAMESPACE
 * @ingroup PlatformClasses */
 class IGraphicsWin final : public IGRAPHICS_DRAW_CLASS
 {
-  class Font;
-  class InstalledFont;
-  struct HFontHolder;
+  using InstalledFont = InstalledWinFont;
+  using Font = WinFont;
+  
 public:
   IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale);
   ~IGraphicsWin();

--- a/IGraphics/Platforms/IGraphicsWinFonts.h
+++ b/IGraphics/Platforms/IGraphicsWinFonts.h
@@ -1,0 +1,110 @@
+/*
+ ==============================================================================
+
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+
+ See LICENSE.txt for  more info.
+
+ ==============================================================================
+*/
+
+#pragma once
+
+#include <windows.h>
+
+#include "IGraphicsPrivate.h"
+
+BEGIN_IPLUG_NAMESPACE
+BEGIN_IGRAPHICS_NAMESPACE
+
+// Fonts
+
+class InstalledWinFont
+{
+public:
+  InstalledWinFont(void* data, int resSize)
+  : mFontHandle(nullptr)
+  {
+    if (data)
+    {
+      DWORD numFonts = 0;
+      mFontHandle = AddFontMemResourceEx(data, resSize, NULL, &numFonts);
+    }
+  }
+  
+  ~InstalledWinFont()
+  {
+    if (IsValid())
+      RemoveFontMemResourceEx(mFontHandle);
+  }
+  
+  InstalledWinFont(const InstalledWinFont&) = delete;
+  InstalledWinFont& operator=(const InstalledWinFont&) = delete;
+    
+  bool IsValid() const { return mFontHandle; }
+  
+private:
+  HANDLE mFontHandle;
+};
+
+struct HFontHolder
+{
+  HFontHolder(HFONT hfont) : mHFont(nullptr)
+  {
+    LOGFONTW lFont = { 0 };
+    GetObjectW(hfont, sizeof(LOGFONTW), &lFont);
+    mHFont = CreateFontIndirectW(&lFont);
+  }
+  
+  HFONT mHFont;
+};
+
+class WinFont : public PlatformFont
+{
+public:
+  WinFont(HFONT font, const char* styleName, bool system)
+  : PlatformFont(system), mFont(font), mStyleName(styleName) {}
+  ~WinFont()
+  {
+    DeleteObject(mFont);
+  }
+  
+  FontDescriptor GetDescriptor() override { return mFont; }
+  
+  IFontDataPtr GetFontData() override
+  {
+    HDC hdc = CreateCompatibleDC(NULL);
+    IFontDataPtr fontData(new IFontData());
+      
+    if (hdc != NULL)
+    {
+      SelectObject(hdc, mFont);
+      const size_t size = ::GetFontData(hdc, 0, 0, NULL, 0);
+
+      if (size != GDI_ERROR)
+      {
+        fontData = std::make_unique<IFontData>(size);
+
+        if (fontData->GetSize() == size)
+        {
+          size_t result = ::GetFontData(hdc, 0x66637474, 0, fontData->Get(), size);
+          if (result == GDI_ERROR)
+            result = ::GetFontData(hdc, 0, 0, fontData->Get(), size);
+          if (result == size)
+            fontData->SetFaceIdx(GetFaceIdx(fontData->Get(), fontData->GetSize(), mStyleName.Get()));
+        }
+      }
+        
+      DeleteDC(hdc);
+    }
+
+    return fontData;
+  }
+    
+private:
+  HFONT mFont;
+  WDL_String mStyleName;
+};
+
+END_IGRAPHICS_NAMESPACE
+END_IPLUG_NAMESPACE


### PR DESCRIPTION
This code means that font code in IGraphicsWin that is currently private can be reused for different platform implementations on windows, rather than creating a need to duplicate (the Mac fonts code is already separated). There should be no change to functionality.

It does create a new header, so whilst projects (Examples etc.) do not require changes to compile, it would be good to update them in order to include this file in projects in the future.

@olilarkin - do you have a nice way to update examples etc. in cases like this, rather than working fully manually? I'm also aware this should potentially go back to OOS.