### PR TITLE
Make ISender member variable protected (not private)

### DIFF
--- a/IPlug/ISender.h
+++ b/IPlug/ISender.h
@@ -108,7 +108,7 @@ public:
     }
   }
 
-private:
+protected:
   IPlugQueue<ISenderData<MAXNC, T>> mQueue {QUEUE_SIZE};
 };
 


### PR DESCRIPTION
Simple addition to allow extensions to Sender through inheritance 