### PR TITLE
Corner resizer redraw after resting is finished

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1988,6 +1988,8 @@ void IGraphics::EndDragResize()
     ForAllControls(&IControl::OnRescale);
     SetAllControlsDirty();
   }
+  else if (mCornerResizer)
+    mCornerResizer->SetDirty(false);
 }
 
 void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable)


### PR DESCRIPTION
In resize mode when drag resizing finishes the oorner resizer is not currently made dirty. This is not an issue for rescaling as all controls are made dirty in that scenario.

This PR fixes that as the corner resizer may need to draw differently when resizing is not taking place.