### PR TITLE
Fix issue with crashes during unpaired OpenWindow() / CloseWindow() calls to IGraphicsMac

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -74,6 +74,9 @@ public:
   float MeasureText(const IText& text, const char* str, IRECT& bounds) const override;
 
   EUIAppearance GetUIAppearance() const override;
+  
+  bool IsViewPreventedFromCallingCloseWindow() { return mPreventViewCallingCloseWindow; }
+  
 protected:
 
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT bounds, bool& isAsync) override;
@@ -95,6 +98,7 @@ private:
   void StoreCursorPosition();
   
   void* mView = nullptr;
+  bool mPreventViewCallingCloseWindow = false;
   CGPoint mCursorLockPosition;
   WDL_String mBundleID, mAppGroupID;
   friend int GetMouseOver(IGraphicsMac* pGraphics);

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -89,7 +89,12 @@ float IGraphicsMac::MeasureText(const IText& text, const char* str, IRECT& bound
 void* IGraphicsMac::OpenWindow(void* pParent)
 {
   TRACE
+  
+  // Prevent the call to CloseWindow() deleting this copy of IGraphics
+  
+  mPreventViewCallingCloseWindow = true;
   CloseWindow();
+  mPreventViewCallingCloseWindow = false;
   IGRAPHICS_VIEW* pView = [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
   mView = (void*) pView;
     

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -1061,8 +1061,10 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
   
   mGraphics->SetPlatformContext(nullptr);
     
-  //For some APIs (AUv2) this is where we know about the window being closed, close via delegate
-  mGraphics->GetDelegate()->CloseWindow();
+  // For some APIs (AUv2) this is where we know about the window being closed, close via delegate
+  // We must not call this if the window is opening (when IsViewPreventedFromCallingCloseWindow() will return true)
+  if (!mGraphics->IsViewPreventedFromCallingCloseWindow())
+    mGraphics->GetDelegate()->CloseWindow();
   [super removeFromSuperview];
 }
 


### PR DESCRIPTION
This PR relates to #964.

If IGraphicsMac has a call to OpenWindow() whilst the window is already open this will call CloseWindow() and that call will trigger the view to call back into the delegate deleting the copy of IGraphics that is currently opening a window. This leads to crashes for unpaired OpenWindow() / CloseWindow() calls.

We require this call back to the delegate from the view's implementation of removeFromSuperview as this is the only place for some APIs we know that the window has closed. In other circumstances multiple calls to CloseWindow() are harmless but here the re-entrancy is problematic. The fix is thus to prevent this call only in instances where we know that we are in a call to OpenWindow() and the fix is entirely located in the Mac/View code as this is only an issue on this platform. It's not the nicest fix in the world, but it's low risk as I believe it is well isolated from other design decisions and scenarios.