### PR TITLE
CI: Update macOS SDK

### DIFF
--- a/Scripts/ci/build_project-mac.yml
+++ b/Scripts/ci/build_project-mac.yml
@@ -49,7 +49,7 @@ steps:
 
   - task: Xcode@5
     inputs:
-      sdk: 'macosx14.5'
+      sdk: 'macosx'
       xcWorkspacePath: '${{parameters.path}}/${{parameters.name}}/projects/${{parameters.name}}-macOS.xcodeproj'
       args: '-target VST2 -xcconfig ${{parameters.path}}/${{parameters.name}}/config/${{parameters.name}}-mac.xcconfig'
       configuration: 'Release'
@@ -59,7 +59,7 @@ steps:
 
   - task: Xcode@5
     inputs:
-      sdk: 'macosx14.5'
+      sdk: 'macosx'
       xcWorkspacePath: '${{parameters.path}}/${{parameters.name}}/projects/${{parameters.name}}-macOS.xcodeproj'
       args: '-UseModernBuildSystem=NO -target VST3 -xcconfig ${{parameters.path}}/${{parameters.name}}/config/${{parameters.name}}-mac.xcconfig'
       configuration: 'Release'
@@ -69,7 +69,7 @@ steps:
 
   - task: Xcode@5
     inputs:
-      sdk: 'macosx14.5'
+      sdk: 'macosx'
       xcWorkspacePath: '${{parameters.path}}/${{parameters.name}}/projects/${{parameters.name}}-macOS.xcodeproj'
       args: '-UseModernBuildSystem=NO -target AAX -xcconfig ${{parameters.path}}/${{parameters.name}}/config/${{parameters.name}}-mac.xcconfig'
       configuration: '${{parameters.configuration}}'
@@ -79,7 +79,7 @@ steps:
 
   - task: Xcode@5
     inputs:
-      sdk: 'macosx14.5'
+      sdk: 'macosx'
       xcWorkspacePath: '${{parameters.path}}/${{parameters.name}}/projects/${{parameters.name}}-macOS.xcodeproj'
       args: '-UseModernBuildSystem=NO -target AU -xcconfig ${{parameters.path}}/${{parameters.name}}/config/${{parameters.name}}-mac.xcconfig'
       configuration: 'Release'
@@ -89,7 +89,7 @@ steps:
 
   - task: Xcode@5
     inputs:
-      sdk: 'macosx14.5'
+      sdk: 'macosx'
       xcWorkspacePath: '${{parameters.path}}/${{parameters.name}}/projects/${{parameters.name}}-macOS.xcodeproj'
       args: '-UseModernBuildSystem=NO -target APP -xcconfig ${{parameters.path}}/${{parameters.name}}/config/${{parameters.name}}-mac.xcconfig'
       configuration: 'Release'


### PR DESCRIPTION
Update pipeline sdk, since ci nodes have been updated and macosx14.5 has been removed