### PR TITLE
AUv3: Add Message Channel Support

### DIFF
--- a/IPlug/AUv3/IPlugAUAudioUnit.h
+++ b/IPlug/AUv3/IPlugAUAudioUnit.h
@@ -34,4 +34,6 @@
 - (PLATFORM_VIEW*) openWindow: (PLATFORM_VIEW*) pParent;
 - (void) closeWindow;
 - (bool) sendMidiData:(int64_t) sampleTime : (NSInteger) length : (const uint8_t*) midiBytes;
+- (id<AUMessageChannel>)messageChannelFor:(NSString *)channelName;
+
 @end

--- a/IPlug/AUv3/IPlugAUAudioUnit.mm
+++ b/IPlug/AUv3/IPlugAUAudioUnit.mm
@@ -797,6 +797,11 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
   });
 }
 
+- (id<AUMessageChannel>)messageChannelFor:(NSString *)channelName
+{
+  return (__bridge id<AUMessageChannel>) self->mPlug->GetNamedMessageChannel([channelName UTF8String]);
+}
+
 #pragma mark - IPlugAUAudioUnit
 
 - (void) beginInformHostOfParamChange: (uint64_t) address;

--- a/IPlug/AUv3/IPlugAUv3.h
+++ b/IPlug/AUv3/IPlugAUv3.h
@@ -80,6 +80,9 @@ public:
 
   void SetOffline(bool renderingOffline) { IPlugProcessor::SetRenderingOffline(renderingOffline); }
 
+#pragma mark - Specialist Use
+public:
+  virtual void* GetNamedMessageChannel(const char* name) { return nullptr; }
 private:
   // void HandleOneEvent(AURenderEvent const* event, int64_t startTime);
   // void PerformAllSimultaneousEvents(int64_t now, AURenderEvent const*& event);


### PR DESCRIPTION
This allows hosts to query for a special data connection from the Audio Unit. 

https://developer.apple.com/documentation/audiotoolbox/aumessagechannel

https://developer.apple.com/documentation/audiotoolbox/auaudiounit/messagechannel(for:)

Since the contents of such a message channel are highly specific to the plugin, so add IPlugAUv3::GetNamedMessageChannel() to pass it in from your plugin implementation (ifdef out for other formats)

in plugin header:
```c++
#ifdef AUv3_API
  void* GetNamedMessageChannel(const char* name) override;
  void* mAUMessageChannel = nullptr;
#endif
```

in an objc .mm implementation wth ARC enabled

```objc
#ifdef AUv3_API
void* MyPlugin::GetNamedMessageChannel(const char* name)
{
  if (std::string_view(name) == "meters")
  {
    if (!mAUMessageChannel) {
      mAUMessageChannel = (__bridge_retained void*) [[VisualizationMessageChannel alloc] initWithIPlug:this];
    }
    return mAUMessageChannel;
  }
}
#endif
```