### PR TITLE
Fix incomplete IPlug doxygen documentation

### DIFF
--- a/IPlug/Extras/Synth/SynthVoice.h
+++ b/IPlug/Extras/Synth/SynthVoice.h
@@ -61,7 +61,7 @@ public:
   virtual bool GetBusy() const = 0;
 
   /** Trigger is called by the VoiceAllocator when a new voice should start, or if the voice limit has been hit and an existing voice needs to re-trigger. While the VoiceInputs are sufficient to control a voice from the VoiceAllocator, this method can be used to do additional tasks like resetting oscillators.
-   * @param level Normalised starting level for this voice, derived from the velocity of the keypress, or in the case of a re-trigger the existing level \todo check
+   * @param level Normalised starting level for this voice, derived from the velocity of the keypress (range 0.0-1.0), or in the case of a re-trigger the existing level
    * @param isRetrigger If this is \c true it means the voice is being re-triggered, and you should accommodate for this in your algorithm */
   virtual void Trigger(double level, bool isRetrigger) {};
 

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -203,10 +203,12 @@ private:
   virtual void InformHostOfParamChange(int paramIdx, double normalizedValue) {}
   
   //DISTRIBUTED ONLY (Currently only VST3)
-  /** \todo */
+  /** Transmits a MIDI message from processor to controller in distributed architectures
+   * @param msg The MIDI message to transmit */
   virtual void TransmitMidiMsgFromProcessor(const IMidiMsg& msg) {}
-  
-  /** \todo */
+
+  /** Transmits SysEx data from processor to controller in distributed architectures
+   * @param data The SysEx data to transmit */
   virtual void TransmitSysExDataFromProcessor(const SysExData& data) {}
 
   void OnTimer(Timer& t);

--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -267,10 +267,9 @@ public:
    * @param msg The MIDI message to send. */
   virtual void SendMidiMsgFromUI(const IMidiMsg& msg) {};
 
-  /** SendMidiMsgFromUI (Abbreviation: SSMFUI)
+  /** SendSysexMsgFromUI (Abbreviation: SSMFUI)
    * If a plug-in can send Sysex data as a result of actions in the user interface, this method can be used.
    * Unlike SendMidiMsgFromUI, Sysex messages will not be received in IPlugProcessor::ProcessSysex()
-   * Since it is extremely unlikely that you would want to use Sysex to communicate between editor and processor \todo is this correct?
    * @param msg The Sysex message to send. */
   virtual void SendSysexMsgFromUI(const ISysEx& msg) {};
   
@@ -291,11 +290,11 @@ public:
 #pragma mark - Editor resizing
   void SetEditorSize(int width, int height) { mEditorWidth = width; mEditorHeight = height; }
   
-  /** \todo
-   * @param widthLo \todo
-   * @param widthHi \todo
-   * @param heightLo \todo
-   * @param heightHi \todo */
+  /** Sets the minimum and maximum size constraints for the editor window
+   * @param widthLo Minimum width
+   * @param widthHi Maximum width
+   * @param heightLo Minimum height
+   * @param heightHi Maximum height */
   void SetSizeConstraints(int widthLo, int widthHi, int heightLo, int heightHi)
   {
     mMinWidth = std::min(widthLo, widthHi);

--- a/IPlug/IPlugProcessor.h
+++ b/IPlug/IPlugProcessor.h
@@ -49,8 +49,8 @@ public:
   };
     
   /** IPlugProcessor constructor
-   * @param config \todo
-   * @param plugAPI \todo */
+   * @param config The plugin configuration struct containing compile-time options
+   * @param plugAPI The plugin API type (VST2, VST3, AU, etc.) */
   IPlugProcessor(const Config& config, EAPI plugAPI);
   virtual ~IPlugProcessor();
 

--- a/IPlug/IPlugQueue.h
+++ b/IPlug/IPlugQueue.h
@@ -31,8 +31,8 @@ template<typename T>
 class IPlugQueue final
 {
 public:
-  /** IPlugQueue constructor 
-   * @param size \todo */
+  /** IPlugQueue constructor
+   * @param size The queue capacity (number of elements) */
   IPlugQueue(int size)
   {
     Resize(size);
@@ -43,17 +43,17 @@ public:
   IPlugQueue(const IPlugQueue&) = delete;
   IPlugQueue& operator=(const IPlugQueue&) = delete;
     
-  /** \todo 
-   * @param size \todo */
+  /** Changes the queue capacity
+   * @param size The new queue capacity (number of elements) */
   void Resize(int size)
   {
     mData.Resize(size + 1);
   }
 
-  /** \todo 
-   * @param item \todo
-   * @return true \todo
-   * @return false \todo */
+  /** Adds an item to the queue
+   * @param item The item to add to the queue
+   * @return true if the item was successfully added
+   * @return false if the queue is full */
   bool Push(const T& item)
   {
     const auto currentWriteIndex = mWriteIndex.load(std::memory_order_relaxed);
@@ -67,10 +67,10 @@ public:
     return false;
   }
 
-  /** \todo 
-   * @param item \todo
-   * @return true \todo
-   * @return false \todo */
+  /** Removes and retrieves an item from the queue
+   * @param item Reference to store the retrieved item
+   * @return true if an item was successfully retrieved
+   * @return false if the queue is empty */
   bool Pop(T& item)
   {
     const auto currentReadIndex = mReadIndex.load(std::memory_order_relaxed);
@@ -83,10 +83,10 @@ public:
     return true;
   }
 
-  /** \todo
-   * @param args... \todo
-   * @return true \todo
-   * @return false \todo */
+  /** Constructs and adds an item to the queue in-place from arguments
+   * @param args... Arguments to forward to the item's constructor
+   * @return true if the item was successfully added
+   * @return false if the queue is full */
   template <typename... Args>
   bool PushFromArgs(Args ...args)
   {
@@ -101,8 +101,8 @@ public:
     return false;
   }
   
-  /** \todo 
-   * @return size_t \todo */
+  /** Returns the number of elements currently in the queue
+   * @return The number of elements available to pop */
   size_t ElementsAvailable() const
   {
     size_t write = mWriteIndex.load(std::memory_order_acquire);
@@ -111,27 +111,27 @@ public:
     return (read > write) ? mData.GetSize() - (read - write) : write - read;
   }
 
-  /** \todo
-   * useful for reading elements while a criterion is met. Can be used like
-   * while IPlugQueue.ElementsAvailable() && q.peek().mTime < 100 { elem = q.pop() ... }
-   * @return const T& \todo */
+  /** Returns a const reference to the next item without removing it
+   * Useful for reading elements while a criterion is met. Can be used like:
+   * `while (q.ElementsAvailable() && q.Peek().mTime < 100) { T elem; q.Pop(elem); ... }`
+   * @return const reference to the next item in the queue */
   const T& Peek()
   {
     const auto currentReadIndex = mReadIndex.load(std::memory_order_relaxed);
     return mData.Get()[currentReadIndex];
   }
 
-  /** \todo 
-   * @return true \todo
-   * @return false \todo */
+  /** Checks if the queue is currently empty
+   * @return true if the queue is empty
+   * @return false if the queue contains elements */
   bool WasEmpty() const
   {
     return (mWriteIndex.load() == mReadIndex.load());
   }
 
-  /** \todo 
-   * @return true \todo
-   * @return false \todo */
+  /** Checks if the queue is currently full
+   * @return true if the queue is full
+   * @return false if the queue has space for more elements */
   bool WasFull() const
   {
     const auto nextWriteIndex = Increment(mWriteIndex.load());
@@ -139,9 +139,9 @@ public:
   }
 
 private:
-  /** \todo 
-   * @param idx \todo
-   * @return size_t \todo */
+  /** Increments an index in the circular buffer, wrapping around when necessary
+   * @param idx The index to increment
+   * @return The incremented index, wrapped to stay within bounds */
   size_t Increment(size_t idx) const
   {
     return (idx + 1) % (mData.GetSize());

--- a/IPlug/IPlugStructs.h
+++ b/IPlug/IPlugStructs.h
@@ -510,29 +510,28 @@ struct IOConfig
     mBusInfo[1].Empty(true);
   }
   
-  /** \todo 
-   * @param direction \todo
-   * @param NChans \todo
-   * @param label \todo */
+  /** Adds bus information for this IOConfig
+   * @param direction The signal direction (kInput or kOutput)
+   * @param NChans The number of channels on this bus */
   void AddBusInfo(ERoute direction, int NChans)
   {
     mBusInfo[direction].Add(new IBusInfo(direction, NChans));
   }
   
-  /** \todo
-   * @param direction \todo
-   * @param index \todo
-   * @return IBusInfo* \todo */
+  /** Gets bus information for a specific bus
+   * @param direction The signal direction (kInput or kOutput)
+   * @param index The bus index
+   * @return Pointer to the bus information */
   const IBusInfo* GetBusInfo(ERoute direction, int index) const
   {
     assert(index >= 0 && index < mBusInfo[direction].GetSize());
     return mBusInfo[direction].Get(index);
   }
   
-  /** \todo 
-   * @param direction \todo
-   * @param index \todo
-   * @return int \todo */
+  /** Gets the number of channels on a bus with bounds checking
+   * @param direction The signal direction (kInput or kOutput)
+   * @param index The bus index
+   * @return The number of channels on the bus, or 0 if index is out of bounds */
   int NChansOnBusSAFE(ERoute direction, int index) const
   {
     int NChans = 0;
@@ -543,17 +542,17 @@ struct IOConfig
     return NChans;
   }
   
-  /** \todo  
-   * @param direction \todo
-   * @return int \todo */
+  /** Gets the number of buses for a given direction
+   * @param direction The signal direction (kInput or kOutput)
+   * @return The number of buses */
   int NBuses(ERoute direction) const
   {
     return mBusInfo[direction].GetSize();
   }
   
-  /** Get the total number of channels across all direction buses for this IOConfig
-   * @param direction \todo
-   * @return int \todo */
+  /** Get the total number of channels across all buses for this IOConfig
+   * @param direction The signal direction (kInput or kOutput)
+   * @return The total number of channels across all buses in the given direction */
   int GetTotalNChannels(ERoute direction) const
   {
     int total = 0;
@@ -564,10 +563,10 @@ struct IOConfig
     return total;
   }
   
-  /** \todo  
-   * @param direction \todo
-   * @return true \todo
-   * @return false \todo */
+  /** Checks if any bus in the given direction has a wildcard channel count
+   * @param direction The signal direction (kInput or kOutput)
+   * @return true if any bus has a wildcard (negative) channel count
+   * @return false if all buses have explicit channel counts */
   bool ContainsWildcard(ERoute direction) const
   {
     for(auto i = 0; i < mBusInfo[direction].GetSize(); i++)

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -154,9 +154,9 @@ void CastCopy(DEST* pDest, SRC* pSrc, int n)
   }
 }
 
-/** \todo  
- * @param cDest \todo
- * @param cSrc \todo */
+/** Converts a C string to lowercase
+ * @param cDest Destination buffer for the lowercase string (must be pre-allocated)
+ * @param cSrc Source string to convert */
 static void ToLower(char* cDest, const char* cSrc)
 {
   int i, n = (int) strlen(cSrc);
@@ -290,11 +290,11 @@ static void GetHostNameStr(EHost host, WDL_String& str)
   }
 }
 
-/** \todo 
- * @param midiPitch \todo
- * @param noteName \todo
- * @param cents \todo
- * @param middleCisC4 \todo */
+/** Converts a MIDI pitch number to a human-readable note name
+ * @param midiPitch The MIDI pitch (0-127, fractional values supported)
+ * @param noteName Output string to store the note name
+ * @param cents If true, includes cent deviation from the nearest pitch
+ * @param middleCisC4 If true, uses C4 as middle C; if false, uses C3 as middle C */
 static void MidiNoteName(double midiPitch, WDL_String& noteName, bool cents = false, bool middleCisC4 = false)
 {
   static const char noteNames[12][3] = {"C ","C#","D ","D#","E ","F ","F#","G ","G#","A ","A#","B "};

--- a/IPlug/ReaperExt/ReaperExtBase.h
+++ b/IPlug/ReaperExt/ReaperExtBase.h
@@ -38,15 +38,17 @@ public:
   
   bool EditorResizeFromUI(int viewWidth, int viewHeight, bool needsPlatformResize) override;
 
-  /** \todo */
+  /** Called during idle processing - override to perform periodic tasks */
   virtual void OnIdle() {}; // NO-OP
-  
-  /** \todo
-   * @param actionName \todo
-   * @param func \todo */
+
+  /** Registers an action with the REAPER extension system
+   * @param actionName The name of the action to register
+   * @param func The function to call when the action is executed
+   * @param addMenuItem If true, adds a menu item for this action
+   * @param pToggle Optional pointer to an int for toggle state */
   void RegisterAction(const char* actionName, std::function<void()> func, bool addMenuItem = false, int* pToggle = nullptr/*, IKeyPress keyCmd*/);
-  
-  /** \todo */
+
+  /** Toggles the visibility of the main extension window */
   void ShowHideMainWindow();
   
   void ToggleDocking();


### PR DESCRIPTION
Fixed documentation in the following files:
- IPlugQueue.h: Document queue methods (Push, Pop, Peek, etc.)
- IPlugStructs.h: Document IOConfig bus methods
- IPlugProcessor.h: Document constructor parameters
- IPlugUtilities.h: Document ToLower and MidiNoteName utility functions
- IPlugAPIBase.h: Document distributed MIDI/SysEx transmission methods
- SynthVoice.h: Complete Trigger method parameter documentation
- ReaperExtBase.h: Document OnIdle, RegisterAction, and ShowHideMainWindow
- IPlugEditorDelegate.h: Complete SetSizeConstraints documentation and remove TODO note

All changes focus on completing incomplete Doxygen documentation marked with \todo, without adding excessive documentation or modifying functionality.