### PR TITLE
Add GitHub Actions CI workflows

### DIFF
--- a/.github/actions/ios-build/action.yml
+++ b/.github/actions/ios-build/action.yml
@@ -1,0 +1,57 @@
+name: 'Build iOS Project'
+description: 'Build an iPlug2 project for iOS using Xcode'
+
+inputs:
+  project:
+    description: 'Project name (e.g., IPlugEffect)'
+    required: true
+  path:
+    description: 'Path to project folder (e.g., Examples or Tests)'
+    required: true
+  graphics:
+    description: 'Graphics backend (NANOVG or SKIA)'
+    required: true
+    default: 'NANOVG'
+  configuration:
+    description: 'Build configuration (Release or Debug)'
+    required: false
+    default: 'Release'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure graphics backend
+      shell: bash
+      run: |
+        if [ "${{ inputs.graphics }}" = "SKIA" ]; then
+          cd ./${{ inputs.path }}/${{ inputs.project }}/config
+          sed -i.bu 's/IGRAPHICS_NANOVG/IGRAPHICS_SKIA/' ${{ inputs.project }}-ios.xcconfig
+          sed -i.bu 's/\/\/$(IGRAPHICS_LNK_FLAGS)/$(IGRAPHICS_LNK_FLAGS)/' ${{ inputs.project }}-ios.xcconfig
+        fi
+
+    - name: Build iOS App with AUv3
+      shell: bash
+      run: |
+        xcodebuild -project "${{ inputs.path }}/${{ inputs.project }}/projects/${{ inputs.project }}-ios.xcodeproj" \
+          -scheme "iOS-APP with AUv3" \
+          -configuration ${{ inputs.configuration }} \
+          -xcconfig "${{ inputs.path }}/${{ inputs.project }}/config/${{ inputs.project }}-ios.xcconfig" \
+          -destination 'generic/platform=iOS' \
+          CODE_SIGNING_ALLOWED=NO \
+          | xcpretty || true
+
+    - name: Organize artifacts
+      shell: bash
+      run: |
+        mkdir -p artifacts/IOS/${{ inputs.project }}_${{ inputs.graphics }}
+
+        cd ${{ inputs.path }}/${{ inputs.project }}/build-ios/ 2>/dev/null || exit 0
+
+        # Find and package any built iOS artifacts
+        if [ -d "${{ inputs.project }}.app" ]; then
+          zip -r ${{ inputs.project }}_iOS.zip "${{ inputs.project }}.app"
+          mv ${{ inputs.project }}_iOS.zip ../../../artifacts/IOS/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi
+
+        # Package any .ipa if present
+        find . -name "*.ipa" -exec cp {} ../../../artifacts/IOS/${{ inputs.project }}_${{ inputs.graphics }}/ \; 2>/dev/null || true

--- a/.github/actions/mac-build/action.yml
+++ b/.github/actions/mac-build/action.yml
@@ -1,0 +1,102 @@
+name: 'Build macOS Project'
+description: 'Build an iPlug2 project for macOS using Xcode'
+
+inputs:
+  project:
+    description: 'Project name (e.g., IPlugEffect)'
+    required: true
+  path:
+    description: 'Path to project folder (e.g., Examples or Tests)'
+    required: true
+  graphics:
+    description: 'Graphics backend (NANOVG or SKIA)'
+    required: true
+    default: 'NANOVG'
+  build_vst3:
+    description: 'Build VST3 format'
+    required: false
+    default: 'true'
+  build_auv2:
+    description: 'Build AUv2 format'
+    required: false
+    default: 'true'
+  build_app:
+    description: 'Build standalone app'
+    required: false
+    default: 'true'
+  configuration:
+    description: 'Build configuration (Release or Debug)'
+    required: false
+    default: 'Release'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure graphics backend
+      shell: bash
+      run: |
+        if [ "${{ inputs.graphics }}" = "SKIA" ]; then
+          cd ./${{ inputs.path }}/${{ inputs.project }}/config
+          sed -i.bu 's/IGRAPHICS_NANOVG/IGRAPHICS_SKIA/' ${{ inputs.project }}-mac.xcconfig
+          sed -i.bu 's/\/\/$(IGRAPHICS_LNK_FLAGS)/$(IGRAPHICS_LNK_FLAGS)/' ${{ inputs.project }}-mac.xcconfig
+        fi
+
+    - name: Build VST3
+      if: ${{ inputs.build_vst3 == 'true' }}
+      shell: bash
+      run: |
+        xcodebuild -project "${{ inputs.path }}/${{ inputs.project }}/projects/${{ inputs.project }}-macOS.xcodeproj" \
+          -target VST3 \
+          -configuration ${{ inputs.configuration }} \
+          -xcconfig "${{ inputs.path }}/${{ inputs.project }}/config/${{ inputs.project }}-mac.xcconfig" \
+          -UseModernBuildSystem=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          | xcpretty || true
+
+    - name: Build AUv2
+      if: ${{ inputs.build_auv2 == 'true' }}
+      shell: bash
+      run: |
+        xcodebuild -project "${{ inputs.path }}/${{ inputs.project }}/projects/${{ inputs.project }}-macOS.xcodeproj" \
+          -target AU \
+          -configuration ${{ inputs.configuration }} \
+          -xcconfig "${{ inputs.path }}/${{ inputs.project }}/config/${{ inputs.project }}-mac.xcconfig" \
+          -UseModernBuildSystem=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          | xcpretty || true
+
+    - name: Build APP
+      if: ${{ inputs.build_app == 'true' }}
+      shell: bash
+      run: |
+        xcodebuild -project "${{ inputs.path }}/${{ inputs.project }}/projects/${{ inputs.project }}-macOS.xcodeproj" \
+          -target APP \
+          -configuration ${{ inputs.configuration }} \
+          -xcconfig "${{ inputs.path }}/${{ inputs.project }}/config/${{ inputs.project }}-mac.xcconfig" \
+          -UseModernBuildSystem=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          | xcpretty || true
+
+    - name: Organize artifacts
+      shell: bash
+      run: |
+        mkdir -p artifacts/VST3/${{ inputs.project }}_${{ inputs.graphics }}
+        mkdir -p artifacts/AU/${{ inputs.project }}_${{ inputs.graphics }}
+        mkdir -p artifacts/APP/${{ inputs.project }}_${{ inputs.graphics }}
+
+        cd ${{ inputs.path }}/${{ inputs.project }}/build-mac/
+
+        if [ -d "${{ inputs.project }}.vst3" ]; then
+          zip -r ${{ inputs.project }}_VST3.zip "${{ inputs.project }}.vst3"
+          mv ${{ inputs.project }}_VST3.zip ../../../artifacts/VST3/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi
+
+        if [ -d "${{ inputs.project }}.component" ]; then
+          zip -r ${{ inputs.project }}_AU.zip "${{ inputs.project }}.component"
+          mv ${{ inputs.project }}_AU.zip ../../../artifacts/AU/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi
+
+        if [ -d "${{ inputs.project }}.app" ]; then
+          zip -r ${{ inputs.project }}_APP.zip "${{ inputs.project }}.app"
+          mv ${{ inputs.project }}_APP.zip ../../../artifacts/APP/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi

--- a/.github/actions/web-build/action.yml
+++ b/.github/actions/web-build/action.yml
@@ -1,0 +1,33 @@
+name: 'Build Web Project'
+description: 'Build an iPlug2 project as a Web Audio Module using Emscripten'
+
+inputs:
+  project:
+    description: 'Project name (e.g., IPlugEffect)'
+    required: true
+  path:
+    description: 'Path to project folder (e.g., Examples or Tests)'
+    required: true
+  graphics:
+    description: 'Graphics backend (NANOVG or CANVAS)'
+    required: true
+    default: 'NANOVG'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build WAM
+      shell: bash
+      run: |
+        cd ./${{ inputs.path }}/${{ inputs.project }}/scripts
+        chmod +x *.sh
+        ./makedist-web.sh off
+
+    - name: Organize artifacts
+      shell: bash
+      run: |
+        mkdir -p artifacts/WEB/${{ inputs.project }}_${{ inputs.graphics }}
+
+        if [ -d "${{ inputs.path }}/${{ inputs.project }}/build-web" ]; then
+          cp -r "${{ inputs.path }}/${{ inputs.project }}/build-web/"* artifacts/WEB/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi

--- a/.github/actions/win-build/action.yml
+++ b/.github/actions/win-build/action.yml
@@ -1,0 +1,79 @@
+name: 'Build Windows Project'
+description: 'Build an iPlug2 project for Windows using MSBuild'
+
+inputs:
+  project:
+    description: 'Project name (e.g., IPlugEffect)'
+    required: true
+  path:
+    description: 'Path to project folder (e.g., Examples or Tests)'
+    required: true
+  graphics:
+    description: 'Graphics backend (NANOVG or SKIA)'
+    required: true
+    default: 'NANOVG'
+  build_vst3:
+    description: 'Build VST3 format'
+    required: false
+    default: 'true'
+  build_app:
+    description: 'Build standalone app'
+    required: false
+    default: 'true'
+  configuration:
+    description: 'Build configuration (Release or Debug)'
+    required: false
+    default: 'Release'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure graphics backend
+      shell: bash
+      run: |
+        if [ "${{ inputs.graphics }}" = "SKIA" ]; then
+          cd ./${{ inputs.path }}/${{ inputs.project }}/config
+          sed -i 's/IGRAPHICS_NANOVG;IGRAPHICS_GL2/IGRAPHICS_SKIA;IGRAPHICS_GL2/' ${{ inputs.project }}-win.props
+        fi
+
+    - name: Build VST3
+      if: ${{ inputs.build_vst3 == 'true' }}
+      shell: pwsh
+      run: |
+        msbuild "${{ inputs.path }}/${{ inputs.project }}/${{ inputs.project }}.sln" `
+          /t:${{ inputs.project }}-vst3 `
+          /p:Configuration=${{ inputs.configuration }} `
+          /p:Platform=x64 `
+          /m
+
+    - name: Build APP
+      if: ${{ inputs.build_app == 'true' }}
+      shell: pwsh
+      run: |
+        msbuild "${{ inputs.path }}/${{ inputs.project }}/${{ inputs.project }}.sln" `
+          /t:${{ inputs.project }}-app `
+          /p:Configuration=${{ inputs.configuration }} `
+          /p:Platform=x64 `
+          /m
+
+    - name: Organize artifacts
+      shell: bash
+      run: |
+        mkdir -p artifacts/VST3/${{ inputs.project }}_${{ inputs.graphics }}
+        mkdir -p artifacts/APP/${{ inputs.project }}_${{ inputs.graphics }}
+
+        cd ${{ inputs.path }}/${{ inputs.project }}/build-win/
+
+        if [ -d "${{ inputs.project }}.vst3" ]; then
+          cp -r "${{ inputs.project }}.vst3" ../../../artifacts/VST3/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi
+
+        if [ -f "${{ inputs.project }}_x64.exe" ]; then
+          cp "${{ inputs.project }}_x64.exe" ../../../artifacts/APP/${{ inputs.project }}_${{ inputs.graphics }}/
+        fi
+
+        # Copy PDB files for debugging
+        if [ -d "pdbs" ]; then
+          cp pdbs/*.pdb ../../../artifacts/VST3/${{ inputs.project }}_${{ inputs.graphics }}/ 2>/dev/null || true
+          cp pdbs/*.pdb ../../../artifacts/APP/${{ inputs.project }}_${{ inputs.graphics }}/ 2>/dev/null || true
+        fi

--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -1,0 +1,271 @@
+name: CI (CMake)
+
+on:
+  push:
+    branches: [master, main, cmake-2]
+  pull_request:
+    branches: [master, main, cmake-2]
+  workflow_dispatch:
+    inputs:
+      build_mac:
+        description: 'Build macOS'
+        type: boolean
+        default: true
+      build_win:
+        description: 'Build Windows'
+        type: boolean
+        default: true
+      build_ios:
+        description: 'Build iOS'
+        type: boolean
+        default: true
+      build_web:
+        description: 'Build Web (Emscripten)'
+        type: boolean
+        default: false
+      graphics:
+        description: 'Graphics backend'
+        type: choice
+        options:
+          - NANOVG
+          - SKIA
+        default: NANOVG
+      configuration:
+        description: 'Build configuration'
+        type: choice
+        options:
+          - Release
+          - Debug
+        default: Release
+
+env:
+  BUILD_MAC: ${{ github.event_name == 'workflow_dispatch' && inputs.build_mac || true }}
+  BUILD_WIN: ${{ github.event_name == 'workflow_dispatch' && inputs.build_win || true }}
+  BUILD_IOS: ${{ github.event_name == 'workflow_dispatch' && inputs.build_ios || true }}
+  BUILD_WEB: ${{ github.event_name == 'workflow_dispatch' && inputs.build_web || false }}
+  GRAPHICS: ${{ github.event_name == 'workflow_dispatch' && inputs.graphics || 'NANOVG' }}
+  CONFIGURATION: ${{ github.event_name == 'workflow_dispatch' && inputs.configuration || 'Release' }}
+
+jobs:
+  # =============================================================================
+  # Build macOS with CMake
+  # =============================================================================
+  build-mac-cmake:
+    name: macOS CMake (${{ matrix.graphics }})
+    runs-on: macos-latest
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.build_mac }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG]
+        # Add SKIA once dependencies are available
+        # graphics: [NANOVG, SKIA]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download IPlug SDKs
+        run: |
+          cd ./Dependencies/IPlug
+          chmod +x download-iplug-sdks.sh
+          ./download-iplug-sdks.sh
+
+      - name: Download prebuilt IGraphics dependencies
+        run: |
+          cd ./Dependencies/
+          chmod +x download-prebuilt-libs.sh
+          ./download-prebuilt-libs.sh mac
+
+      - name: Configure CMake
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=${{ env.CONFIGURATION }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+            -DIGRAPHICS_BACKEND=${{ matrix.graphics }}
+
+      - name: Build with CMake
+        run: cmake --build build --config ${{ env.CONFIGURATION }} --parallel
+
+      - name: List build outputs
+        run: |
+          find build -name "*.vst3" -o -name "*.component" -o -name "*.app" -o -name "*.clap" 2>/dev/null | head -50
+
+      - name: Upload macOS CMake artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MAC-CMAKE-${{ matrix.graphics }}
+          path: |
+            build/**/*.vst3
+            build/**/*.component
+            build/**/*.app
+            build/**/*.clap
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # =============================================================================
+  # Build Windows with CMake
+  # =============================================================================
+  build-win-cmake:
+    name: Windows CMake (${{ matrix.graphics }})
+    runs-on: windows-2022
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.build_win }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG]
+        # Add SKIA once dependencies are available
+        # graphics: [NANOVG, SKIA]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download IPlug SDKs
+        shell: bash
+        run: |
+          cd ./Dependencies/IPlug
+          chmod +x download-iplug-sdks.sh
+          ./download-iplug-sdks.sh
+
+      - name: Download prebuilt IGraphics dependencies
+        shell: bash
+        run: |
+          cd ./Dependencies/
+          chmod +x download-prebuilt-libs.sh
+          ./download-prebuilt-libs.sh win
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -G "Visual Studio 17 2022" -A x64 `
+            -DIGRAPHICS_BACKEND=${{ matrix.graphics }}
+
+      - name: Build with CMake
+        run: cmake --build build --config ${{ env.CONFIGURATION }} --parallel
+
+      - name: List build outputs
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path build -Recurse -Include *.vst3,*.exe,*.clap -ErrorAction SilentlyContinue | Select-Object -First 50
+
+      - name: Upload Windows CMake artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: WIN-CMAKE-${{ matrix.graphics }}
+          path: |
+            build/**/*.vst3
+            build/**/*.exe
+            build/**/*.clap
+            build/**/*.pdb
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # =============================================================================
+  # Build iOS with CMake
+  # =============================================================================
+  build-ios-cmake:
+    name: iOS CMake (${{ matrix.graphics }})
+    runs-on: macos-latest
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.build_ios }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download IPlug SDKs
+        run: |
+          cd ./Dependencies/IPlug
+          chmod +x download-iplug-sdks.sh
+          ./download-iplug-sdks.sh
+
+      - name: Download prebuilt IGraphics dependencies
+        run: |
+          cd ./Dependencies/
+          chmod +x download-prebuilt-libs.sh
+          ./download-prebuilt-libs.sh ios
+
+      - name: Configure CMake for iOS
+        run: |
+          cmake -B build-ios \
+            -G Xcode \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DIGRAPHICS_BACKEND=${{ matrix.graphics }}
+
+      - name: Build with CMake
+        run: |
+          cmake --build build-ios \
+            --config ${{ env.CONFIGURATION }} \
+            -- -sdk iphoneos \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload iOS CMake artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: IOS-CMAKE-${{ matrix.graphics }}
+          path: |
+            build-ios/**/*.app
+            build-ios/**/*.appex
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # =============================================================================
+  # Build Web (Emscripten) with CMake
+  # =============================================================================
+  build-web-cmake:
+    name: Web CMake (${{ matrix.graphics }})
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_web }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, CANVAS]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+          actions-cache-folder: 'emsdk-cache'
+
+      - name: Download IPlug SDKs
+        run: |
+          cd ./Dependencies/IPlug
+          chmod +x download-iplug-sdks.sh
+          ./download-iplug-sdks.sh
+
+      - name: Configure CMake for Emscripten
+        run: |
+          emcmake cmake -B build-web \
+            -DCMAKE_BUILD_TYPE=${{ env.CONFIGURATION }} \
+            -DIGRAPHICS_BACKEND=${{ matrix.graphics }}
+
+      - name: Build with CMake
+        run: cmake --build build-web --config ${{ env.CONFIGURATION }} --parallel
+
+      - name: Upload Web CMake artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: WEB-CMAKE-${{ matrix.graphics }}
+          path: |
+            build-web/**/*.js
+            build-web/**/*.wasm
+            build-web/**/*.html
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,542 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      build_mac:
+        description: 'Build macOS binaries'
+        type: boolean
+        default: true
+      build_win:
+        description: 'Build Windows binaries'
+        type: boolean
+        default: true
+      build_ios:
+        description: 'Build iOS binaries'
+        type: boolean
+        default: true
+      build_web:
+        description: 'Build Web Audio Modules'
+        type: boolean
+        default: false
+      build_vst3:
+        description: 'Build VST3 format'
+        type: boolean
+        default: true
+      build_auv2:
+        description: 'Build AUv2 format (macOS only)'
+        type: boolean
+        default: true
+      build_app:
+        description: 'Build standalone app'
+        type: boolean
+        default: true
+      test_projects:
+        description: 'Run plugin validation tests'
+        type: boolean
+        default: false
+      configuration:
+        description: 'Build configuration'
+        type: choice
+        options:
+          - Release
+          - Debug
+        default: Release
+
+env:
+  # Default values for non-dispatch triggers
+  BUILD_MAC: ${{ github.event_name == 'workflow_dispatch' && inputs.build_mac || true }}
+  BUILD_WIN: ${{ github.event_name == 'workflow_dispatch' && inputs.build_win || true }}
+  BUILD_IOS: ${{ github.event_name == 'workflow_dispatch' && inputs.build_ios || true }}
+  BUILD_WEB: ${{ github.event_name == 'workflow_dispatch' && inputs.build_web || false }}
+  BUILD_VST3: ${{ github.event_name == 'workflow_dispatch' && inputs.build_vst3 || true }}
+  BUILD_AUV2: ${{ github.event_name == 'workflow_dispatch' && inputs.build_auv2 || true }}
+  BUILD_APP: ${{ github.event_name == 'workflow_dispatch' && inputs.build_app || true }}
+  TEST_PROJECTS: ${{ github.event_name == 'workflow_dispatch' && inputs.test_projects || false }}
+  CONFIGURATION: ${{ github.event_name == 'workflow_dispatch' && inputs.configuration || 'Release' }}
+
+jobs:
+  # =============================================================================
+  # Setup: Download dependencies and create source artifact
+  # =============================================================================
+  setup:
+    name: Setup Source Tree
+    runs-on: ubuntu-latest
+    outputs:
+      build_mac: ${{ env.BUILD_MAC }}
+      build_win: ${{ env.BUILD_WIN }}
+      build_ios: ${{ env.BUILD_IOS }}
+      build_web: ${{ env.BUILD_WEB }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download prebuilt IGraphics dependencies
+        run: |
+          cd ./Dependencies/
+          ./download-prebuilt-libs.sh mac
+          ./download-prebuilt-libs.sh ios
+          ./download-prebuilt-libs.sh win
+
+      - name: Download IPlug SDKs
+        run: |
+          cd ./Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Clean up unnecessary files
+        run: |
+          rm -rf .git
+          cd ./Dependencies/Build/
+          find . -type f -iname "*.png" -delete
+
+      - name: Upload source artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SRC
+          path: .
+          retention-days: 1
+
+  # =============================================================================
+  # Build macOS Projects
+  # =============================================================================
+  build-mac:
+    name: Build macOS (${{ matrix.graphics }})
+    needs: setup
+    if: ${{ needs.setup.outputs.build_mac == 'true' }}
+    runs-on: macos-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, SKIA]
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: SRC
+
+      - name: Make scripts executable
+        run: |
+          find . -name "*.sh" -exec chmod +x {} \;
+          find . -name "*.command" -exec chmod +x {} \;
+
+      - name: Build IPlugEffect
+        uses: ./.github/actions/mac-build
+        with:
+          project: IPlugEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugInstrument
+        uses: ./.github/actions/mac-build
+        with:
+          project: IPlugInstrument
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugMidiEffect
+        uses: ./.github/actions/mac-build
+        with:
+          project: IPlugMidiEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugControls
+        uses: ./.github/actions/mac-build
+        with:
+          project: IPlugControls
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugResponsiveUI
+        uses: ./.github/actions/mac-build
+        with:
+          project: IPlugResponsiveUI
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IGraphicsStressTest
+        uses: ./.github/actions/mac-build
+        with:
+          project: IGraphicsStressTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IGraphicsTest
+        uses: ./.github/actions/mac-build
+        with:
+          project: IGraphicsTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build MetaParamTest
+        uses: ./.github/actions/mac-build
+        with:
+          project: MetaParamTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_auv2: ${{ env.BUILD_AUV2 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MAC-${{ matrix.graphics }}
+          path: artifacts/
+          retention-days: 7
+
+  # =============================================================================
+  # Build Windows Projects
+  # =============================================================================
+  build-win:
+    name: Build Windows (${{ matrix.graphics }})
+    needs: setup
+    if: ${{ needs.setup.outputs.build_win == 'true' }}
+    runs-on: windows-2022
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, SKIA]
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: SRC
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build IPlugEffect
+        uses: ./.github/actions/win-build
+        with:
+          project: IPlugEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugInstrument
+        uses: ./.github/actions/win-build
+        with:
+          project: IPlugInstrument
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugMidiEffect
+        uses: ./.github/actions/win-build
+        with:
+          project: IPlugMidiEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugControls
+        uses: ./.github/actions/win-build
+        with:
+          project: IPlugControls
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugResponsiveUI
+        uses: ./.github/actions/win-build
+        with:
+          project: IPlugResponsiveUI
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IGraphicsStressTest
+        uses: ./.github/actions/win-build
+        with:
+          project: IGraphicsStressTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IGraphicsTest
+        uses: ./.github/actions/win-build
+        with:
+          project: IGraphicsTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build MetaParamTest
+        uses: ./.github/actions/win-build
+        with:
+          project: MetaParamTest
+          path: Tests
+          graphics: ${{ matrix.graphics }}
+          build_vst3: ${{ env.BUILD_VST3 }}
+          build_app: ${{ env.BUILD_APP }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: WIN-${{ matrix.graphics }}
+          path: artifacts/
+          retention-days: 7
+
+  # =============================================================================
+  # Build iOS Projects
+  # =============================================================================
+  build-ios:
+    name: Build iOS (${{ matrix.graphics }})
+    needs: setup
+    if: ${{ needs.setup.outputs.build_ios == 'true' }}
+    runs-on: macos-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, SKIA]
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: SRC
+
+      - name: Make scripts executable
+        run: |
+          find . -name "*.sh" -exec chmod +x {} \;
+          find . -name "*.command" -exec chmod +x {} \;
+
+      - name: Build IPlugEffect
+        uses: ./.github/actions/ios-build
+        with:
+          project: IPlugEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugInstrument
+        uses: ./.github/actions/ios-build
+        with:
+          project: IPlugInstrument
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Build IPlugControls
+        uses: ./.github/actions/ios-build
+        with:
+          project: IPlugControls
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+          configuration: ${{ env.CONFIGURATION }}
+
+      - name: Upload iOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: IOS-${{ matrix.graphics }}
+          path: artifacts/
+          retention-days: 7
+
+  # =============================================================================
+  # Build Web Audio Modules
+  # =============================================================================
+  build-web:
+    name: Build Web (${{ matrix.graphics }})
+    needs: setup
+    if: ${{ needs.setup.outputs.build_web == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, CANVAS]
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: SRC
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+          actions-cache-folder: 'emsdk-cache'
+
+      - name: Make scripts executable
+        run: |
+          find . -name "*.sh" -exec chmod +x {} \;
+
+      - name: Build IPlugEffect
+        uses: ./.github/actions/web-build
+        with:
+          project: IPlugEffect
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+
+      - name: Build IPlugInstrument
+        uses: ./.github/actions/web-build
+        with:
+          project: IPlugInstrument
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+
+      - name: Build IPlugControls
+        uses: ./.github/actions/web-build
+        with:
+          project: IPlugControls
+          path: Examples
+          graphics: ${{ matrix.graphics }}
+
+      - name: Upload Web artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: WEB-${{ matrix.graphics }}
+          path: artifacts/
+          retention-days: 7
+
+  # =============================================================================
+  # Test macOS Plugins
+  # =============================================================================
+  test-mac:
+    name: Test macOS (${{ matrix.graphics }})
+    needs: build-mac
+    if: ${{ needs.setup.outputs.build_mac == 'true' && (github.event_name == 'workflow_dispatch' && inputs.test_projects || false) }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, SKIA]
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: MAC-${{ matrix.graphics }}
+          path: artifacts
+
+      - name: Download pluginval
+        run: |
+          curl -L -o pluginval.zip https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_macOS.zip
+          unzip pluginval.zip
+          chmod +x pluginval.app/Contents/MacOS/pluginval
+
+      - name: Download VST3 SDK for validator
+        run: |
+          git clone --depth 1 https://github.com/steinbergmedia/vst3sdk.git
+          cd vst3sdk
+          git submodule update --init --recursive
+          mkdir build && cd build
+          cmake .. -DSMTG_ADD_VSTGUI=OFF
+          cmake --build . --target validator --config Release
+
+      - name: Validate VST3 plugins
+        continue-on-error: true
+        run: |
+          for plugin in artifacts/VST3/*/*.vst3; do
+            if [ -d "$plugin" ]; then
+              echo "Validating $plugin with pluginval..."
+              ./pluginval.app/Contents/MacOS/pluginval --validate-in-process --skip-gui-tests "$plugin" || true
+              echo "Validating $plugin with VST3 validator..."
+              ./vst3sdk/build/bin/Release/validator "$plugin" || true
+            fi
+          done
+
+      - name: Validate AUv2 plugins
+        continue-on-error: true
+        run: |
+          # Install AUs to user plugin directory
+          mkdir -p ~/Library/Audio/Plug-Ins/Components
+          for plugin in artifacts/AU/*/*.component; do
+            if [ -d "$plugin" ]; then
+              cp -R "$plugin" ~/Library/Audio/Plug-Ins/Components/
+            fi
+          done
+          # Run auval on installed plugins
+          for plugin in ~/Library/Audio/Plug-Ins/Components/*.component; do
+            if [ -d "$plugin" ]; then
+              name=$(basename "$plugin" .component)
+              echo "Validating $name with auval..."
+              auval -a || true
+            fi
+          done
+
+  # =============================================================================
+  # Test Windows Plugins
+  # =============================================================================
+  test-win:
+    name: Test Windows (${{ matrix.graphics }})
+    needs: build-win
+    if: ${{ needs.setup.outputs.build_win == 'true' && (github.event_name == 'workflow_dispatch' && inputs.test_projects || false) }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        graphics: [NANOVG, SKIA]
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: WIN-${{ matrix.graphics }}
+          path: artifacts
+
+      - name: Download pluginval
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_Windows.zip" -OutFile "pluginval.zip"
+          Expand-Archive -Path "pluginval.zip" -DestinationPath "."
+
+      - name: Validate VST3 plugins
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path "artifacts/VST3" -Recurse -Filter "*.vst3" -Directory | ForEach-Object {
+            Write-Host "Validating $($_.FullName) with pluginval..."
+            & "./pluginval.exe" --validate-in-process --skip-gui-tests $_.FullName
+          }


### PR DESCRIPTION
Migrate CI from Azure Pipelines to GitHub Actions:

- ci.yml: Main workflow for Xcode/Visual Studio builds
  - Builds macOS, Windows, iOS, and Web targets
  - Matrix for NANOVG and SKIA graphics backends
  - Plugin formats: VST3, AUv2, standalone APP
  - Optional plugin validation tests with pluginval/auval

- ci-cmake.yml: CMake-based build workflow
  - Prepares for cmake-2 branch integration
  - Builds on macOS, Windows, iOS, and Web (Emscripten)
  - Uses modern CMake configure/build flow

- Composite actions for building projects per platform:
  - mac-build: xcodebuild for macOS
  - win-build: MSBuild for Windows
  - ios-build: xcodebuild for iOS
  - web-build: Emscripten for WAM