### PR TITLE
Add CMake build system

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -1,0 +1,787 @@
+name: CMake CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'CMakeLists.txt'
+      - 'iPlug2.cmake'
+      - 'CMakePresets.json'
+      - 'Scripts/cmake/**'
+      - 'IPlug/**'
+      - 'IGraphics/**'
+      - 'Examples/**/CMakeLists.txt'
+      - 'Tests/**/CMakeLists.txt'
+      - '.github/workflows/cmake-ci.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'CMakeLists.txt'
+      - 'iPlug2.cmake'
+      - 'CMakePresets.json'
+      - 'Scripts/cmake/**'
+      - 'IPlug/**'
+      - 'IGraphics/**'
+      - 'Examples/**/CMakeLists.txt'
+      - 'Tests/**/CMakeLists.txt'
+      - '.github/workflows/cmake-ci.yml'
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      examples:
+        description: 'Examples to build (comma-separated, empty = IPlugEffect only, "all" = everything)'
+        type: string
+        default: 'IPlugEffect'
+      all_generators:
+        description: 'Test all generators (Ninja, Make, Xcode, VS2022)'
+        type: boolean
+        default: false
+      ios:
+        description: 'Include iOS build'
+        type: boolean
+        default: false
+      visionos:
+        description: 'Include visionOS build'
+        type: boolean
+        default: false
+      wam:
+        description: 'Include WAM/Emscripten build'
+        type: boolean
+        default: false
+      universal:
+        description: 'Include macOS Universal build (arm64+x86_64)'
+        type: boolean
+        default: false
+      arm64ec:
+        description: 'Include Windows ARM64EC build'
+        type: boolean
+        default: false
+
+# Cancel in-progress runs for the same PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ============================================================================
+  # Parse PR commands from comments
+  # ============================================================================
+  parse-commands:
+    name: Parse Commands
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/ci'))
+    outputs:
+      examples: ${{ steps.parse.outputs.examples }}
+      all_generators: ${{ steps.parse.outputs.all_generators }}
+      ios: ${{ steps.parse.outputs.ios }}
+      visionos: ${{ steps.parse.outputs.visionos }}
+      wam: ${{ steps.parse.outputs.wam }}
+      universal: ${{ steps.parse.outputs.universal }}
+      arm64ec: ${{ steps.parse.outputs.arm64ec }}
+      should_run: ${{ steps.parse.outputs.should_run }}
+      pr_ref: ${{ steps.get-pr.outputs.ref }}
+      pr_sha: ${{ steps.get-pr.outputs.sha }}
+    steps:
+      - name: Parse CI commands from comment
+        id: parse
+        env:
+          # Use environment variable to avoid shell injection from direct interpolation
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          INPUT_EXAMPLES: ${{ inputs.examples }}
+        run: |
+          # Default examples to build (IPlugEffect only for faster CI)
+          DEFAULT_EXAMPLES="IPlugEffect"
+
+          # Function to validate examples input (alphanumeric, commas, underscores only)
+          validate_examples() {
+            local input="$1"
+            if [[ "$input" =~ ^[a-zA-Z0-9,_]+$ ]]; then
+              echo "$input"
+            else
+              echo "Invalid examples input, using default" >&2
+              echo "$DEFAULT_EXAMPLES"
+            fi
+          }
+
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            # Sanitize comment for safe pattern matching (remove potentially dangerous chars)
+            COMMENT=$(echo "$COMMENT_BODY" | tr -cd '[:alnum:][:space:]/=,_-')
+            echo "Parsing comment: $COMMENT"
+
+            # Parse examples=... parameter with validation
+            if [[ "$COMMENT" =~ examples=([^[:space:]]+) ]]; then
+              EXAMPLES_VALUE=$(validate_examples "${BASH_REMATCH[1]}")
+              echo "examples=$EXAMPLES_VALUE" >> $GITHUB_OUTPUT
+            elif [[ "$COMMENT" == *"/ci all"* ]]; then
+              echo "examples=all" >> $GITHUB_OUTPUT
+            else
+              echo "examples=$DEFAULT_EXAMPLES" >> $GITHUB_OUTPUT
+            fi
+
+            # Check for various commands
+            if [[ "$COMMENT" == *"/ci all"* ]]; then
+              echo "all_generators=true" >> $GITHUB_OUTPUT
+              echo "ios=true" >> $GITHUB_OUTPUT
+              echo "visionos=true" >> $GITHUB_OUTPUT
+              echo "wam=true" >> $GITHUB_OUTPUT
+              echo "universal=true" >> $GITHUB_OUTPUT
+              echo "arm64ec=true" >> $GITHUB_OUTPUT
+            else
+              [[ "$COMMENT" == *"/ci all-generators"* || "$COMMENT" == *"/ci generators"* ]] && echo "all_generators=true" >> $GITHUB_OUTPUT || echo "all_generators=false" >> $GITHUB_OUTPUT
+              [[ "$COMMENT" == *"/ci ios"* ]] && echo "ios=true" >> $GITHUB_OUTPUT || echo "ios=false" >> $GITHUB_OUTPUT
+              [[ "$COMMENT" == *"/ci visionos"* ]] && echo "visionos=true" >> $GITHUB_OUTPUT || echo "visionos=false" >> $GITHUB_OUTPUT
+              [[ "$COMMENT" == *"/ci wam"* ]] && echo "wam=true" >> $GITHUB_OUTPUT || echo "wam=false" >> $GITHUB_OUTPUT
+              [[ "$COMMENT" == *"/ci universal"* ]] && echo "universal=true" >> $GITHUB_OUTPUT || echo "universal=false" >> $GITHUB_OUTPUT
+              [[ "$COMMENT" == *"/ci arm64ec"* ]] && echo "arm64ec=true" >> $GITHUB_OUTPUT || echo "arm64ec=false" >> $GITHUB_OUTPUT
+            fi
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Validate workflow_dispatch input as well
+            EXAMPLES_INPUT="${INPUT_EXAMPLES:-IPlugEffect}"
+            EXAMPLES_VALUE=$(validate_examples "$EXAMPLES_INPUT")
+            echo "examples=$EXAMPLES_VALUE" >> $GITHUB_OUTPUT
+            echo "all_generators=${{ inputs.all_generators }}" >> $GITHUB_OUTPUT
+            echo "ios=${{ inputs.ios }}" >> $GITHUB_OUTPUT
+            echo "visionos=${{ inputs.visionos }}" >> $GITHUB_OUTPUT
+            echo "wam=${{ inputs.wam }}" >> $GITHUB_OUTPUT
+            echo "universal=${{ inputs.universal }}" >> $GITHUB_OUTPUT
+            echo "arm64ec=${{ inputs.arm64ec }}" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            # push or pull_request - use defaults (IPlugEffect only)
+            echo "examples=$DEFAULT_EXAMPLES" >> $GITHUB_OUTPUT
+            echo "all_generators=false" >> $GITHUB_OUTPUT
+            echo "ios=false" >> $GITHUB_OUTPUT
+            echo "visionos=false" >> $GITHUB_OUTPUT
+            echo "wam=false" >> $GITHUB_OUTPUT
+            echo "universal=false" >> $GITHUB_OUTPUT
+            echo "arm64ec=false" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get PR ref for comment trigger
+        id: get-pr
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "ref=$(echo $PR_DATA | jq -r .head.ref)" >> $GITHUB_OUTPUT
+          echo "sha=$(echo $PR_DATA | jq -r .head.sha)" >> $GITHUB_OUTPUT
+
+  # ============================================================================
+  # macOS - Xcode Generator (Default)
+  # ============================================================================
+  macos-xcode:
+    name: macOS (Xcode)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.should_run == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset macos-xcode -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset macos-xcode
+          else
+            # Build each example's targets
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)  # trim whitespace
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap --target ${example}-au"
+            done
+            cmake --build --preset macos-xcode $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-xcode-artifacts
+          path: build/macos-xcode/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # Windows - Visual Studio 2022 (Default)
+  # ============================================================================
+  windows-vs2022:
+    name: Windows (VS2022)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.should_run == 'true'
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        shell: bash
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset windows-vs2022 -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        shell: bash
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset windows-vs2022
+          else
+            # Build each example's targets
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)  # trim whitespace
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap"
+            done
+            cmake --build --preset windows-vs2022 $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts
+          path: build/windows-vs2022/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # macOS - Ninja Generator (Optional - /ci all-generators)
+  # ============================================================================
+  macos-ninja:
+    name: macOS (Ninja)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.all_generators == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset macos-ninja -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset macos-ninja
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap --target ${example}-au"
+            done
+            cmake --build --preset macos-ninja $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-ninja-artifacts
+          path: build/macos-ninja/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # macOS - Unix Makefiles Generator (Optional - /ci all-generators)
+  # ============================================================================
+  macos-make:
+    name: macOS (Make)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.all_generators == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset macos-make -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset macos-make -- -j$(sysctl -n hw.ncpu)
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap --target ${example}-au"
+            done
+            cmake --build --preset macos-make $TARGETS -- -j$(sysctl -n hw.ncpu)
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-make-artifacts
+          path: build/macos-make/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # iOS - Xcode Generator (Optional - /ci ios)
+  # ============================================================================
+  ios-xcode:
+    name: iOS (Xcode)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.ios == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake --preset ios-xcode -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset ios-xcode
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-ios-app"
+            done
+            cmake --build --preset ios-xcode $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-artifacts
+          path: build/ios-xcode/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # visionOS - Xcode Generator (Optional - /ci visionos)
+  # ============================================================================
+  visionos-xcode:
+    name: visionOS (Xcode)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.visionos == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake --preset visionos-xcode -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset visionos-xcode
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-ios-app"
+            done
+            cmake --build --preset visionos-xcode $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: visionos-artifacts
+          path: build/visionos-xcode/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # macOS Universal - arm64 + x86_64 (Optional - /ci universal)
+  # ============================================================================
+  macos-universal:
+    name: macOS (Universal)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.universal == 'true'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset macos-xcode-universal -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset macos-xcode-universal
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap --target ${example}-au"
+            done
+            cmake --build --preset macos-xcode-universal $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-universal-artifacts
+          path: build/macos-xcode-universal/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # Windows ARM64EC (Optional - /ci arm64ec)
+  # ============================================================================
+  windows-arm64ec:
+    name: Windows (ARM64EC)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.arm64ec == 'true'
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Setup Proprietary SDKs
+        shell: bash
+        env:
+          VST2_SDK_B64: ${{ secrets.VST2_SDK_B64 }}
+          AAX_SDK_B64_1: ${{ secrets.AAX_SDK_B64_1 }}
+          AAX_SDK_B64_2: ${{ secrets.AAX_SDK_B64_2 }}
+          AAX_SDK_B64_3: ${{ secrets.AAX_SDK_B64_3 }}
+          AAX_SDK_B64_4: ${{ secrets.AAX_SDK_B64_4 }}
+          AAX_SDK_B64_5: ${{ secrets.AAX_SDK_B64_5 }}
+          AAX_SDK_B64_6: ${{ secrets.AAX_SDK_B64_6 }}
+          AAX_SDK_B64_7: ${{ secrets.AAX_SDK_B64_7 }}
+        run: |
+          if [ -n "$VST2_SDK_B64" ]; then
+            echo "$VST2_SDK_B64" | base64 -d | tar -xz -C Dependencies/IPlug/
+          fi
+          if [ -n "$AAX_SDK_B64_1" ]; then
+            echo "${AAX_SDK_B64_1}${AAX_SDK_B64_2}${AAX_SDK_B64_3}${AAX_SDK_B64_4}${AAX_SDK_B64_5}${AAX_SDK_B64_6}${AAX_SDK_B64_7}" | base64 -d | tar -xJ -C Dependencies/IPlug/
+          fi
+
+      - name: Configure CMake
+        run: cmake --preset windows-vs2022-arm64ec -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON -DIPLUG_DEPLOY_PLUGINS=OFF
+
+      - name: Build
+        shell: bash
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset windows-vs2022-arm64ec
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-app --target ${example}-vst3 --target ${example}-clap"
+            done
+            cmake --build --preset windows-vs2022-arm64ec $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64ec-artifacts
+          path: build/windows-vs2022-arm64ec/out/
+          if-no-files-found: warn
+
+  # ============================================================================
+  # WAM - Emscripten/WebAssembly (Optional - /ci wam)
+  # ============================================================================
+  wam:
+    name: WAM (Emscripten)
+    needs: parse-commands
+    if: needs.parse-commands.outputs.wam == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse-commands.outputs.pr_sha || github.sha }}
+          submodules: recursive
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: '3.1.51'
+
+      - name: Install Ninja
+        run: sudo apt-get install -y ninja-build
+
+      - name: Cache SDKs
+        id: cache-sdks
+        uses: actions/cache@v4
+        with:
+          path: |
+            Dependencies/IPlug/VST3_SDK
+            Dependencies/IPlug/CLAP_SDK
+            Dependencies/IPlug/CLAP_HELPERS
+            Dependencies/IPlug/WAM_SDK
+            Dependencies/IPlug/WAM_AWP
+          key: sdks-${{ runner.os }}-${{ hashFiles('Dependencies/IPlug/download-*.sh') }}
+
+      - name: Download Public SDKs
+        if: steps.cache-sdks.outputs.cache-hit != 'true'
+        run: |
+          cd Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Configure CMake
+        run: cmake --preset wam -DIPLUG2_DISABLE_DEPRECATION_WARNINGS=ON
+
+      - name: Build
+        run: |
+          EXAMPLES="${{ needs.parse-commands.outputs.examples }}"
+          if [[ "$EXAMPLES" == "all" || -z "$EXAMPLES" ]]; then
+            cmake --build --preset wam
+          else
+            TARGETS=""
+            IFS=',' read -ra EXAMPLE_LIST <<< "$EXAMPLES"
+            for example in "${EXAMPLE_LIST[@]}"; do
+              example=$(echo "$example" | xargs)
+              TARGETS="$TARGETS --target ${example}-wam --target ${example}-web"
+            done
+            cmake --build --preset wam $TARGETS
+          fi
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wam-artifacts
+          path: build/wam/out/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,12 @@ Documentation/html
 Documentation/doxygen_warnings.txt
 Examples/build_errors.log
 Projects/*
-Examples/IPlugSwift/Pods
 PodFile.lock
 */*/.vscode/ipch
 Examples/*/EBWebView
 Examples/*/packages
 Examples/IPlugConvoEngine/r8brain
 **/node_modules
+Examples/*/build*
+Tests/*/build*
+build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.14)
+project(iPlug2 VERSION 2.0.0)
+
+# Set IPLUG2_DIR to this directory
+set(IPLUG2_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "iPlug2 root directory")
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Add examples
+add_subdirectory(Examples)
+
+# Add tests
+add_subdirectory(Tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,249 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "IGRAPHICS_BACKEND": "NANOVG"
+      }
+    },
+    {
+      "name": "base-macos",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "10.15",
+        "IGRAPHICS_RENDERER": "METAL"
+      }
+    },
+    {
+      "name": "base-windows",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "IGRAPHICS_RENDERER": "GL2"
+      }
+    },
+    {
+      "name": "macos-ninja",
+      "displayName": "macOS Ninja",
+      "description": "macOS build with Ninja generator (NanoVG/Metal)",
+      "inherits": "base-macos",
+      "generator": "Ninja"
+    },
+    {
+      "name": "macos-make",
+      "displayName": "macOS Unix Makefiles",
+      "description": "macOS build with Unix Makefiles generator (NanoVG/Metal)",
+      "inherits": "base-macos",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "macos-xcode",
+      "displayName": "macOS Xcode",
+      "description": "macOS build with Xcode generator (NanoVG/Metal)",
+      "inherits": "base-macos",
+      "generator": "Xcode"
+    },
+    {
+      "name": "macos-xcode-universal",
+      "displayName": "macOS Xcode (Universal)",
+      "description": "macOS Universal (arm64+x86_64) build with Xcode generator",
+      "inherits": "base-macos",
+      "generator": "Xcode",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64"
+      }
+    },
+    {
+      "name": "ios-xcode",
+      "displayName": "iOS Xcode (Device)",
+      "description": "iOS device build with Xcode generator (NanoVG/Metal)",
+      "inherits": "base",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "iOS",
+        "IGRAPHICS_RENDERER": "METAL"
+      }
+    },
+    {
+      "name": "ios-sim-xcode",
+      "displayName": "iOS Xcode (Simulator)",
+      "description": "iOS simulator build with Xcode generator (NanoVG/Metal)",
+      "inherits": "base",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "iOS",
+        "CMAKE_OSX_SYSROOT": "iphonesimulator",
+        "IGRAPHICS_RENDERER": "METAL"
+      }
+    },
+    {
+      "name": "visionos-xcode",
+      "displayName": "visionOS Xcode (Device)",
+      "description": "visionOS device build with Xcode generator (NanoVG/Metal)",
+      "inherits": "base",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "visionOS",
+        "CMAKE_OSX_SYSROOT": "xros",
+        "IGRAPHICS_RENDERER": "METAL"
+      }
+    },
+    {
+      "name": "visionos-sim-xcode",
+      "displayName": "visionOS Xcode (Simulator)",
+      "description": "visionOS simulator build with Xcode generator (NanoVG/Metal)",
+      "inherits": "base",
+      "generator": "Xcode",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "visionOS",
+        "CMAKE_OSX_SYSROOT": "xrsimulator",
+        "IGRAPHICS_RENDERER": "METAL"
+      }
+    },
+    {
+      "name": "windows-vs2022",
+      "displayName": "Windows Visual Studio 2022",
+      "description": "Windows x64 build with Visual Studio 2022 (NanoVG/GL2)",
+      "inherits": "base-windows",
+      "generator": "Visual Studio 17 2022",
+      "architecture": {
+        "value": "x64",
+        "strategy": "set"
+      }
+    },
+    {
+      "name": "windows-vs2022-arm64ec",
+      "displayName": "Windows Visual Studio 2022 (ARM64EC)",
+      "description": "Windows ARM64EC build with Visual Studio 2022 (NanoVG/GL2)",
+      "inherits": "base-windows",
+      "generator": "Visual Studio 17 2022",
+      "architecture": {
+        "value": "ARM64EC",
+        "strategy": "set"
+      }
+    },
+    {
+      "name": "wam",
+      "displayName": "WAM (Emscripten)",
+      "description": "Web Audio Module build with Emscripten/WebAssembly",
+      "inherits": "base",
+      "generator": "Ninja",
+      "toolchainFile": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
+      "cacheVariables": {
+        "CMAKE_CROSSCOMPILING_EMULATOR": "$env{EMSDK_NODE}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "macos-ninja",
+      "configurePreset": "macos-ninja",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-make",
+      "configurePreset": "macos-make"
+    },
+    {
+      "name": "macos-xcode",
+      "configurePreset": "macos-xcode",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-xcode-universal",
+      "configurePreset": "macos-xcode-universal",
+      "configuration": "Release"
+    },
+    {
+      "name": "ios-xcode",
+      "configurePreset": "ios-xcode",
+      "configuration": "Release",
+      "nativeToolOptions": [
+        "-destination", "generic/platform=iOS",
+        "CODE_SIGNING_ALLOWED=NO"
+      ]
+    },
+    {
+      "name": "ios-sim-xcode",
+      "configurePreset": "ios-sim-xcode",
+      "configuration": "Release",
+      "nativeToolOptions": [
+        "-destination", "generic/platform=iOS Simulator",
+        "CODE_SIGNING_ALLOWED=NO"
+      ]
+    },
+    {
+      "name": "visionos-xcode",
+      "configurePreset": "visionos-xcode",
+      "configuration": "Release",
+      "nativeToolOptions": [
+        "-destination", "generic/platform=visionOS",
+        "CODE_SIGNING_ALLOWED=NO"
+      ]
+    },
+    {
+      "name": "visionos-sim-xcode",
+      "configurePreset": "visionos-sim-xcode",
+      "configuration": "Release",
+      "nativeToolOptions": [
+        "-destination", "generic/platform=visionOS Simulator",
+        "CODE_SIGNING_ALLOWED=NO"
+      ]
+    },
+    {
+      "name": "windows-vs2022",
+      "configurePreset": "windows-vs2022",
+      "configuration": "Release"
+    },
+    {
+      "name": "windows-vs2022-arm64ec",
+      "configurePreset": "windows-vs2022-arm64ec",
+      "configuration": "Release"
+    },
+    {
+      "name": "wam",
+      "configurePreset": "wam",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/Documentation/cmake.md
+++ b/Documentation/cmake.md
@@ -1,0 +1,677 @@
+# Building iPlug2 Projects with CMake
+
+This document covers building iPlug2 plugin projects using CMake on all supported platforms.
+
+## Prerequisites
+
+### macOS
+
+- **CMake** 3.14 or later
+- **Ninja** (recommended) or Xcode
+- **Xcode Command Line Tools**
+
+```bash
+# Install via Homebrew
+brew install cmake ninja
+```
+
+### Windows
+
+- **CMake** 3.14 or later
+- **Visual Studio 2019 or 2022** with "Desktop development with C++" workload
+- **Ninja** (optional, recommended for faster builds)
+
+CMake and Ninja can be installed via:
+- Visual Studio Installer (includes CMake)
+- [cmake.org](https://cmake.org/download/)
+- `winget install Kitware.CMake` / `winget install Ninja-build.Ninja`
+
+### Web (Emscripten)
+
+- **Emscripten SDK** for WebAssembly builds
+- **WAM SDK** (downloaded via `Dependencies/download-iplug-sdks.sh`)
+
+```bash
+# Install Emscripten
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install latest
+./emsdk activate latest
+source ./emsdk_env.sh
+```
+
+## Generators
+
+CMake supports multiple build system generators:
+
+### Ninja (Recommended)
+
+Fast, cross-platform. Works on macOS and Windows.
+
+```bash
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
+ninja
+```
+
+### Visual Studio (Windows)
+
+Multi-configuration generator. Supports x64 and ARM64EC architectures.
+
+```bash
+# x64 (default)
+cmake -G "Visual Studio 17 2022" -A x64 ..
+
+# ARM64EC (ARM64 with x64 emulation compatibility)
+cmake -G "Visual Studio 17 2022" -A ARM64EC ..
+
+# Build from command line
+cmake --build . --config Release
+```
+
+### Xcode (macOS/iOS/visionOS)
+
+Multi-configuration generator for Apple platforms.
+
+```bash
+cmake -G Xcode ..
+cmake --build . --config Release
+# Or open the .xcodeproj in Xcode
+```
+
+## Quick Start
+
+```bash
+# From your plugin project directory
+mkdir build && cd build
+
+# Configure (choose one)
+cmake -G Ninja ..                              # Ninja (macOS/Windows)
+cmake -G "Visual Studio 17 2022" -A x64 ..     # Visual Studio
+cmake -G Xcode ..                              # Xcode
+
+# Build
+cmake --build . --config Release
+```
+
+## Supported Platforms & Targets
+
+| Format | Target Suffix | macOS | Windows | iOS | visionOS | Web |
+|--------|---------------|-------|---------|-----|----------|-----|
+| Standalone App | `-app` | ✓ | ✓ | ✓ | ✓ | - |
+| VST2 | `-vst2` | ✓ | ✓ | - | - | - |
+| VST3 | `-vst3` | ✓ | ✓ | - | - | - |
+| CLAP | `-clap` | ✓ | ✓ | - | - | - |
+| AAX | `-aax` | ✓ | ✓ | - | - | - |
+| AUv2 | `-au` | ✓ | - | - | - | - |
+| AUv3 | `AU-framework`, `AUv3-appex` | ✓ | - | ✓ | ✓ | - |
+| WAM | `-wam`, `-web` | - | - | - | - | ✓ |
+
+**Notes:**
+- VST2 requires the VST2 SDK (deprecated, no longer distributed by Steinberg)
+- VST3 requires the VST3 SDK
+- CLAP requires the CLAP SDK
+- AAX requires the AAX SDK from Avid
+- AUv3 is embedded in the standalone APP on macOS
+- Linux is not yet supported
+
+## Build Commands
+
+### Build All Targets
+
+```bash
+# Ninja
+ninja
+
+# Visual Studio / Xcode
+cmake --build . --config Release
+```
+
+### Build Specific Targets
+
+```bash
+# Ninja
+ninja MyPlugin-app       # Standalone app
+ninja MyPlugin-vst2      # VST2
+ninja MyPlugin-vst3      # VST3
+ninja MyPlugin-clap      # CLAP
+ninja MyPlugin-aax       # AAX
+ninja MyPlugin-au        # AUv2 (macOS)
+
+# Visual Studio / Xcode
+cmake --build . --config Release --target MyPlugin-vst3
+```
+
+## Build Options
+
+### Common Options
+
+```bash
+# Debug build (default)
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
+
+# Release build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
+
+# Enable tracer/profiling
+cmake -G Ninja -DIPLUG2_TRACER=ON ..
+```
+
+### macOS Options
+
+```bash
+# Universal binaries (Intel + Apple Silicon)
+cmake -G Ninja -DIPLUG2_UNIVERSAL=ON ..
+
+# Or set architectures directly
+cmake -G Ninja -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..
+
+# Deployment target (default: 10.13)
+cmake -G Ninja -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ..
+```
+
+### Windows Options
+
+Architecture is set via the `-A` flag with Visual Studio generator:
+
+```bash
+cmake -G "Visual Studio 17 2022" -A x64 ..      # 64-bit Intel/AMD
+cmake -G "Visual Studio 17 2022" -A ARM64EC ..  # ARM64 with x64 emulation compatibility
+```
+
+### Debugging Options
+
+Set a host application for debugging plugins:
+
+```bash
+# Windows (Visual Studio)
+cmake -G "Visual Studio 17 2022" -A x64 -DIPLUG2_DEBUG_HOST="C:/Program Files/REAPER (x64)/reaper.exe" ..
+
+# macOS (Xcode)
+cmake -G Xcode -DIPLUG2_DEBUG_HOST="/Applications/REAPER.app" ..
+```
+
+| Variable | Description |
+|----------|-------------|
+| `IPLUG2_DEBUG_HOST` | Path to host application (REAPER, Ableton, etc.) |
+| `IPLUG2_DEBUG_HOST_ARGS` | Command line arguments for the host |
+
+**Windows:** Sets `VS_DEBUGGER_COMMAND` for plugin targets, allowing F5 to launch host and attach debugger. If REAPER is installed at `C:/Program Files/REAPER (x64)/reaper.exe`, it is automatically used as the default.
+
+**macOS:** Generates Xcode schemes for plugin targets. If `IPLUG2_DEBUG_HOST` is set, schemes use that executable. Otherwise, schemes are generated with no executable set, allowing you to choose "Ask on Launch" or configure manually in Xcode.
+
+### iOS Options
+
+```bash
+# iOS Device
+cmake -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DIPLUG2_IOS_PLATFORM=OS ..
+
+# iOS Simulator
+cmake -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DIPLUG2_IOS_PLATFORM=SIMULATOR ..
+
+# Deployment target (default: 14)
+cmake -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DIPLUG2_IOS_DEPLOYMENT_TARGET=15 ..
+```
+
+### visionOS Options
+
+Requires Xcode 15+ with visionOS SDK.
+
+```bash
+# visionOS Device
+cmake -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DIPLUG2_IOS_PLATFORM=VISIONOS ..
+
+# visionOS Simulator
+cmake -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DIPLUG2_IOS_PLATFORM=VISIONOS_SIMULATOR ..
+```
+
+| `IPLUG2_IOS_PLATFORM` | SDK | Description |
+|-----------------------|-----|-------------|
+| `OS` | iphoneos | iOS device (default) |
+| `SIMULATOR` | iphonesimulator | iOS Simulator |
+| `VISIONOS` | xros | visionOS device |
+| `VISIONOS_SIMULATOR` | xrsimulator | visionOS Simulator |
+
+### Web/Emscripten Options
+
+```bash
+# Configure with Emscripten toolchain
+emcmake cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
+
+# Build WAM and Web targets
+ninja MyPlugin-wam       # Audio processor (WASM)
+ninja MyPlugin-web       # UI controller (WASM)
+ninja MyPlugin-wam-dist  # Complete distribution package
+```
+
+## IGraphics Backends
+
+iPlug2 provides `${IGRAPHICS_LIB}` which is set based on cache variables, allowing backend switching at configure time.
+
+### Cache Variables
+
+| Variable | Options | Default |
+|----------|---------|---------|
+| `IGRAPHICS_BACKEND` | `NANOVG`, `SKIA` | `NANOVG` |
+| `IGRAPHICS_RENDERER` | `GL2`, `GL3`, `METAL`, `CPU` | `GL2` (Windows), `METAL` (macOS/iOS) |
+
+### Configure at Build Time
+
+```bash
+# Default: NanoVG with GL2 (Windows) or Metal (macOS)
+cmake -G Ninja ..
+
+# Skia with OpenGL 3
+cmake -G Ninja -DIGRAPHICS_BACKEND=SKIA -DIGRAPHICS_RENDERER=GL3 ..
+
+# NanoVG with Metal (macOS)
+cmake -G Ninja -DIGRAPHICS_BACKEND=NANOVG -DIGRAPHICS_RENDERER=METAL ..
+```
+
+### Available Targets
+
+```cmake
+# NanoVG (lightweight, included in iPlug2)
+iPlug2::IGraphics::NanoVG        # GL2 (default)
+iPlug2::IGraphics::NanoVG::GL3   # OpenGL 3
+iPlug2::IGraphics::NanoVG::Metal # Metal (macOS/iOS)
+
+# Skia (feature-rich, requires downloading dependencies)
+iPlug2::IGraphics::Skia::GL3     # OpenGL 3
+iPlug2::IGraphics::Skia::Metal   # Metal (macOS/iOS)
+iPlug2::IGraphics::Skia::CPU     # Software rendering
+```
+
+## Project Structure
+
+A minimal CMake-enabled iPlug2 project:
+
+```
+MyPlugin/
+├── CMakeLists.txt
+├── MyPlugin.cpp
+├── MyPlugin.h
+├── config.h
+└── resources/
+    ├── MyPlugin-macOS-Info.plist
+    ├── MyPlugin-VST3-Info.plist
+    ├── MyPlugin-CLAP-Info.plist
+    ├── fonts/
+    └── ...
+```
+
+## The `iplug_add_plugin` Macro
+
+The `iplug_add_plugin()` macro simplifies plugin project configuration, reducing ~190 lines of boilerplate to ~15 lines.
+
+### Basic Usage
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(MyPlugin VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)
+```
+
+### Syntax
+
+```cmake
+iplug_add_plugin(<name>
+  SOURCES <file1> [file2 ...]
+  [RESOURCES <file1> [file2 ...]]
+  [WEB_RESOURCES <file1> [file2 ...]]
+  [FORMATS <format1> [format2 ...]]
+  [EXCLUDE_FORMATS <format1> [format2 ...]]
+  [LINK <library1> [library2 ...]]
+  [DEFINES <def1> [def2 ...]]
+  [UI <IGRAPHICS|WEBVIEW|NONE>]
+  [WAM_SITE_ORIGIN <origin>]
+)
+```
+
+### Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `SOURCES` | Source files (.cpp, .h, .mm) | Required |
+| `RESOURCES` | Bundle resources (fonts, images) - goes into `Resources/` | None |
+| `WEB_RESOURCES` | Web UI files (HTML, JS, CSS) - goes into `Resources/web/` | None |
+| `FORMATS` | Target formats to build | `ALL` |
+| `EXCLUDE_FORMATS` | Formats to exclude | None |
+| `LINK` | Additional libraries to link | None |
+| `DEFINES` | Additional compile definitions | None |
+| `UI` | UI framework: `IGRAPHICS`, `WEBVIEW`, or `NONE` | `IGRAPHICS` |
+| `WAM_SITE_ORIGIN` | WAM site origin for CORS | `"/"` |
+
+### Format Names
+
+| Format | Description | Platforms |
+|--------|-------------|-----------|
+| `APP` | Standalone application | macOS, Windows |
+| `VST3` | VST3 plugin | macOS, Windows |
+| `CLAP` | CLAP plugin | macOS, Windows |
+| `AAX` | AAX plugin (requires SDK) | macOS, Windows |
+| `AU` | Audio Unit v2 | macOS only |
+| `AUV3` | Audio Unit v3 (opt-in) | macOS, iOS |
+| `WAM` | Web Audio Module | Emscripten only |
+
+### Format Groups
+
+| Group | Expands To | Notes |
+|-------|------------|-------|
+| `ALL` | APP, VST3, CLAP, AAX, AU, WAM | Default. Excludes AUv3 |
+| `ALL_AUV3` | APP, VST3, CLAP, AAX, AU, AUV3, WAM | Includes AUv3 with embedding |
+| `DESKTOP` | APP, VST3, CLAP, AAX, AU | No iOS/Web/AUv3 |
+
+**Note:** AUv3 is opt-in because it requires additional setup (framework, appex, embedding in APP). Use `ALL_AUV3` or explicitly add `AUV3` to include it.
+
+### Examples
+
+**Standard IGraphics plugin:**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)
+```
+
+**Plugin with AUv3 support:**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+  FORMATS ALL_AUV3
+)
+```
+
+**Desktop-only plugin (no WAM/iOS):**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  FORMATS DESKTOP
+)
+```
+
+**Plugin with extra libraries:**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  LINK iPlug2::Extras::Synth iPlug2::Extras::HIIR
+)
+```
+
+**Plugin without UI (DSP-only):**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  UI NONE
+  DEFINES NO_IGRAPHICS
+  EXCLUDE_FORMATS WAM
+)
+```
+
+**WebView UI plugin:**
+
+```cmake
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MyPlugin.cpp
+    MyPlugin.h
+    resources/resource.h
+  WEB_RESOURCES
+    resources/web/index.html
+    resources/web/script.js
+  UI WEBVIEW
+  EXCLUDE_FORMATS WAM
+)
+```
+
+Note: `WEB_RESOURCES` preserves subdirectory structure. Files in `resources/web/assets/` will be placed in `Resources/web/assets/` in the bundle.
+
+See `Examples/IPlugEffect/CMakeLists.txt` for a complete working example.
+
+## Build Output
+
+### macOS
+
+```
+build/out/
+├── MyPlugin.app/                    # Standalone (with embedded AUv3)
+│   └── Contents/
+│       ├── Frameworks/
+│       │   └── MyPluginAU.framework/
+│       └── PlugIns/
+│           └── MyPlugin.appex/
+├── MyPlugin.vst3/
+├── MyPlugin.clap/
+├── MyPlugin.aaxplugin/
+├── MyPlugin.component/              # AUv2
+├── MyPluginAU.framework/            # AUv3 framework
+└── MyPlugin.appex/                  # AUv3 appex
+```
+
+### Windows
+
+```
+build/out/
+├── MyPlugin.exe                     # Standalone app
+├── MyPlugin.vst3/
+│   └── Contents/
+│       └── x86_64-win/              # or arm64ec-win
+│           └── MyPlugin.vst3
+├── MyPlugin.clap
+└── MyPlugin.aaxplugin/
+    └── Contents/
+        └── x64/                     # or ARM64EC
+            └── MyPlugin.aaxplugin
+```
+
+### Web
+
+```
+build/out/MyPlugin/
+├── scripts/
+│   ├── MyPlugin-wam.js     # WAM processor loader
+│   ├── MyPlugin-wam.wasm   # Audio processing module
+│   ├── MyPlugin-web.js     # Web controller loader
+│   └── MyPlugin-web.wasm   # UI module
+├── index.html              # Test page
+├── descriptor.json         # WAM metadata
+└── styles/                 # CSS assets
+```
+
+## Deployment
+
+### Default Deployment Paths
+
+Plugins are automatically deployed (symlinked or copied) to standard locations:
+
+**macOS:**
+- VST2: `~/Library/Audio/Plug-Ins/VST`
+- VST3: `~/Library/Audio/Plug-Ins/VST3`
+- CLAP: `~/Library/Audio/Plug-Ins/CLAP`
+- AUv2: `~/Library/Audio/Plug-Ins/Components`
+- AAX: `/Library/Application Support/Avid/Audio/Plug-Ins`
+- APP: `~/Applications`
+
+**Windows:**
+- VST2: `%PROGRAMFILES%\VstPlugins`
+- VST3: `%LOCALAPPDATA%\Programs\Common\VST3` (per-user, no admin required)
+- CLAP: `%LOCALAPPDATA%\Programs\Common\CLAP` (per-user, no admin required)
+- AAX: `%COMMONPROGRAMFILES%\Avid\Audio\Plug-Ins`
+
+> **Note:** VST3/CLAP use per-user paths by default (spec-compliant, hosts scan both locations). For system-wide installation, use `-DIPLUG_VST3_DEPLOY_PATH="%COMMONPROGRAMFILES%\VST3"`.
+
+### Deployment Options
+
+```bash
+# Disable automatic deployment
+cmake -G Ninja -DIPLUG_DEPLOY_PLUGINS=OFF ..
+
+# Use symlink instead of copy (default is COPY)
+cmake -G Ninja -DIPLUG_DEPLOY_METHOD=SYMLINK ..
+
+# Custom deployment paths
+cmake -G Ninja -DIPLUG_VST3_DEPLOY_PATH=/custom/path ..
+```
+
+## Platform-Specific Notes
+
+### macOS
+
+**Code Signing (required for AUv3):**
+
+```bash
+# Sign from innermost to outermost
+codesign -s - out/MyPlugin.app/Contents/Frameworks/MyPluginAU.framework
+codesign -s - out/MyPlugin.app/Contents/PlugIns/MyPlugin.appex
+codesign -s - out/MyPlugin.app
+
+# Run app to register AUv3
+open out/MyPlugin.app
+```
+
+> **Warning:** Ad-hoc signing (`-s -`) is for **local development only**. Ad-hoc signed apps cannot be distributed, will not run on other machines, and are blocked by Gatekeeper. For distribution, you must sign with a valid Developer ID certificate and notarize the app (see below).
+
+**Distribution signing:**
+
+```bash
+codesign -s "Developer ID Application: Your Name (TEAM_ID)" out/MyPlugin.app
+xcrun notarytool submit out/MyPlugin.app --apple-id your@email.com --team-id TEAM_ID --wait
+xcrun stapler staple out/MyPlugin.app
+```
+
+**Validating Audio Units:**
+
+```bash
+auval -a                              # List all registered AUs
+auval -v aufx <subtype> <manufacturer>  # Validate effect
+auval -v aumu <subtype> <manufacturer>  # Validate instrument
+```
+
+### Windows
+
+- MSVC uses static runtime (`/MT` for Release, `/MTd` for Debug)
+- Multi-config generators (Visual Studio) require `--config` flag when building
+- Use ARM64EC for ARM64 Windows (provides x64 plugin compatibility)
+
+### iOS
+
+- Minimum deployment target: iOS 14 (configurable)
+- Device builds require code signing
+- AUv3 is embedded in the standalone app
+
+### visionOS
+
+- Requires Xcode 15+ with visionOS SDK installed
+- Minimum deployment target: 1.0
+
+### Web/Emscripten
+
+WAM plugins consist of two WASM modules:
+1. **WAM Processor** (`-wam`) - DSP/audio (runs in AudioWorklet)
+2. **Web Controller** (`-web`) - UI/graphics (runs in main thread)
+
+**Testing:**
+
+WAM requires HTTPS with specific headers for SharedArrayBuffer support. Use [mkcert](https://github.com/FiloSottile/mkcert) to create local certificates:
+
+```bash
+# Install mkcert and create local CA
+brew install mkcert  # macOS
+mkcert -install
+mkcert localhost
+
+# Serve with HTTPS (requires a server that sets COOP/COEP headers)
+```
+
+Alternatively, use `emrun` which handles the required headers:
+
+```bash
+cd build/out/wam
+emrun --no_emrun_detect index.html
+```
+
+**Notes:**
+- WAM SDK must be downloaded via `Dependencies/download-iplug-sdks.sh`
+
+### Linux
+
+Linux is not yet supported. CMake configuration will show an error message.
+
+## Troubleshooting
+
+### General
+
+- **Missing symbols**: Verify all required frameworks/libraries are linked
+- **Source files not found**: Check paths in `target_sources()`
+
+### macOS
+
+- **AUv3 not registering**: Ensure app is signed and has been run at least once
+- **"Bundle format unrecognized"**: Check PkgInfo files exist; use `cp -R` for frameworks
+
+### Windows
+
+- **Link errors with runtime**: Ensure all libraries use same runtime (`/MT` vs `/MD`)
+- **Missing DLLs**: Use static runtime or deploy required DLLs
+
+## Examples
+
+The following examples include CMakeLists.txt and are built automatically from the root:
+
+**Standard IGraphics:**
+IPlugEffect, IPlugInstrument, IPlugControls, IPlugConvoEngine, IPlugChunks, IPlugDrumSynth, IPlugMidiEffect, IPlugOSCEditor, IPlugResponsiveUI, IPlugSideChain, IPlugSurroundEffect, IPlugVisualizer
+
+**WebView:**
+IPlugWebUI, IPlugP5js, IPlugSvelteUI
+
+**Swift/Cocoa (Xcode generator only):**
+IPlugSwiftUI, IPlugCocoaUI - Automatically included when using `-G Xcode` on macOS.
+
+**REAPER:**
+IPlugReaperExtension, IPlugReaperPlugin
+
+**Tests:**
+IGraphicsTest, IGraphicsStressTest, MetaParamTest
+
+## See Also
+
+- [iPlug2 Documentation](https://iplug2.github.io/docs)
+- [CMake Documentation](https://cmake.org/documentation/)
+- [Examples/IPlugEffect/CMakeLists.txt](../Examples/IPlugEffect/CMakeLists.txt) - Reference CMake template

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.14)
+project(iPlug2Examples)
+
+# Standard IGraphics examples
+set(CMAKE_FOLDER "Examples/IGraphics")
+add_subdirectory(IPlugEffect)
+add_subdirectory(IPlugInstrument)
+add_subdirectory(IPlugControls)
+add_subdirectory(IPlugConvoEngine)
+add_subdirectory(IPlugChunks)
+add_subdirectory(IPlugDrumSynth)
+add_subdirectory(IPlugMidiEffect)
+add_subdirectory(IPlugOSCEditor)
+add_subdirectory(IPlugResponsiveUI)
+add_subdirectory(IPlugSideChain)
+add_subdirectory(IPlugSurroundEffect)
+add_subdirectory(IPlugVisualizer)
+
+# WebView examples
+set(CMAKE_FOLDER "Examples/WebView")
+add_subdirectory(IPlugWebUI)
+add_subdirectory(IPlugP5js)
+add_subdirectory(IPlugSvelteUI)
+
+# Swift/Cocoa examples (requires Xcode generator)
+if(APPLE AND XCODE)
+  set(CMAKE_FOLDER "Examples/Native UI")
+  add_subdirectory(IPlugSwiftUI)
+  add_subdirectory(IPlugCocoaUI)
+endif()
+
+# REAPER examples
+set(CMAKE_FOLDER "Examples/REAPER")
+add_subdirectory(IPlugReaperExtension)
+add_subdirectory(IPlugReaperPlugin)

--- a/Examples/IPlugChunks/CMakeLists.txt
+++ b/Examples/IPlugChunks/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugChunks VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugChunks.cpp
+    IPlugChunks.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugCocoaUI/CMakeLists.txt
+++ b/Examples/IPlugCocoaUI/CMakeLists.txt
@@ -1,0 +1,242 @@
+cmake_minimum_required(VERSION 3.16)
+project(IPlugCocoaUI VERSION 1.0.0 LANGUAGES C CXX OBJC OBJCXX)
+
+# Cocoa UI requires Xcode generator for Swift support (and doesn't support Emscripten)
+if(NOT CMAKE_GENERATOR MATCHES "Xcode" OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  message(STATUS "IPlugCocoaUI requires Xcode generator for Swift support. Skipping.")
+  return()
+endif()
+
+# Enable Swift language
+enable_language(Swift)
+
+# Discover IPLUG2_DIR if not already set (for independent builds)
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Standard plugin setup
+set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(PLUG_RESOURCES_DIR ${PROJECT_DIR}/resources)
+
+# C++/Objective-C++ source files
+set(SOURCE_FILES
+  IPlugCocoaUI.h
+  IPlugCocoaUI.mm
+  IPlugCocoaUI-Shared.h
+  resources/resource.h
+)
+
+# Swift source files
+set(SWIFT_FILES
+  UI/IPlugCocoaUIViewController.swift
+  UI/TypeAliases.swift
+)
+
+# CocoaEditorDelegate sources (required for native Cocoa UI integration)
+set(COCOA_EDITOR_SRC
+  ${IPLUG2_DIR}/IPlug/Extras/Cocoa/IPlugCocoaEditorDelegate.mm
+  ${IPLUG2_DIR}/IPlug/Extras/Cocoa/IPlugCocoaViewController.mm
+)
+
+# Base library for shared code
+add_library(_${PROJECT_NAME}-base INTERFACE)
+iplug_add_target(_${PROJECT_NAME}-base INTERFACE
+  INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources
+          ${IPLUG2_DIR}/IPlug/Extras/Cocoa
+  SOURCE ${COCOA_EDITOR_SRC}
+  LINK iPlug2::IPlug
+  DEFINE NO_IGRAPHICS COCOA_EDITOR_DELEGATE
+)
+
+# ============================================================================
+# macOS targets (not iOS)
+# ============================================================================
+if(NOT IOS)
+  # ============================================================================
+  # APP Target (Standalone Application) - with Cocoa UI
+  # ============================================================================
+  add_executable(${PROJECT_NAME}-app ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-app PUBLIC
+    LINK iPlug2::APP _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-app APP ${PROJECT_NAME})
+
+  # Swift configuration
+  set_target_properties(${PROJECT_NAME}-app PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY NO
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks"
+  )
+
+  # Link MetalKit for bridging header (used in TypeAliases)
+  target_link_libraries(${PROJECT_NAME}-app PUBLIC
+    "-framework MetalKit"
+  )
+
+  # ============================================================================
+  # VST3 Target - with Cocoa UI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-vst3 MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-vst3 PUBLIC
+    LINK iPlug2::VST3 _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-vst3 VST3 ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-vst3 PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.vst3.${PROJECT_NAME}"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-vst3 PUBLIC
+    "-framework MetalKit"
+  )
+
+  # ============================================================================
+  # CLAP Target - with Cocoa UI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-clap MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-clap PUBLIC
+    LINK iPlug2::CLAP _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-clap CLAP ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-clap PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.clap.${PROJECT_NAME}"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-clap PUBLIC
+    "-framework MetalKit"
+  )
+
+  # ============================================================================
+  # AUv2 Target (macOS only) - with Cocoa UI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-au MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-au PUBLIC
+    LINK iPlug2::AUv2 _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-au AUv2 ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-au PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.audiounit.${PROJECT_NAME}"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-au PUBLIC
+    "-framework MetalKit"
+  )
+
+  # ============================================================================
+  # AAX Target (macOS only) - with Cocoa UI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-aax MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-aax PUBLIC
+    LINK iPlug2::AAX _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-aax AAX ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-aax PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.aax.${PROJECT_NAME}"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-aax PUBLIC
+    "-framework MetalKit"
+  )
+
+  # ============================================================================
+  # AUv3 Targets (macOS) - Framework + Appex embedded in APP
+  # ============================================================================
+  add_library(${PROJECT_NAME}AU-framework SHARED ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}AU-framework PUBLIC
+    LINK iPlug2::AUv3 _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}AU-framework AUv3Framework ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}AU-framework PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}.AUv3Framework"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY YES
+  )
+
+  target_link_libraries(${PROJECT_NAME}AU-framework PUBLIC
+    "-framework MetalKit"
+  )
+
+  iplug_get_auv3appex_source(${PROJECT_NAME} APPEX_SOURCE)
+  add_executable(${PROJECT_NAME}AUv3-appex ${APPEX_SOURCE})
+  iplug_configure_target(${PROJECT_NAME}AUv3-appex AUv3Appex ${PROJECT_NAME})
+
+  iplug_embed_auv3_in_app(${PROJECT_NAME}-app ${PROJECT_NAME})
+endif()
+
+# ============================================================================
+# iOS Targets - AUv3 Framework + Appex + Standalone App (Cocoa UI)
+# ============================================================================
+if(IOS)
+  # iOS AUv3 Framework containing plugin code
+  add_library(${PROJECT_NAME}AU-ios-framework SHARED ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}AU-ios-framework PUBLIC
+    LINK iPlug2::AUv3iOS _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}AU-ios-framework AUv3iOSFramework ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}AU-ios-framework PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}.AUv3Framework"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY YES
+  )
+
+  target_link_libraries(${PROJECT_NAME}AU-ios-framework PUBLIC
+    "-framework MetalKit"
+  )
+
+  # iOS AUv3 App Extension (appex)
+  iplug_get_auv3ios_appex_source(${PROJECT_NAME} IOS_APPEX_SOURCE)
+  add_executable(${PROJECT_NAME}AUv3-ios-appex ${IOS_APPEX_SOURCE})
+  iplug_configure_target(${PROJECT_NAME}AUv3-ios-appex AUv3iOSAppex ${PROJECT_NAME})
+
+  # iOS Standalone App that hosts the AUv3 for testing
+  add_executable(${PROJECT_NAME}-ios-app ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-ios-app PUBLIC
+    LINK iPlug2::AUv3iOS _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-ios-app IOSApp ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-ios-app PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugCocoaUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY NO
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-ios-app PUBLIC
+    "-framework MetalKit"
+  )
+
+  # Embed AUv3 appex and framework in the iOS app
+  iplug_embed_auv3ios_in_app(${PROJECT_NAME}-ios-app ${PROJECT_NAME})
+endif()

--- a/Examples/IPlugControls/CMakeLists.txt
+++ b/Examples/IPlugControls/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugControls VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugControls.cpp
+    IPlugControls.h
+    IconsFontaudio.h
+    IconsForkAwesome.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+    resources/fonts/fontaudio.ttf
+    resources/fonts/forkawesome-webfont.ttf
+    resources/img/button.png
+    resources/img/button@2x.png
+    resources/img/font.png
+    resources/img/font@2x.png
+    resources/img/hslider-handle.svg
+    resources/img/hslider-track.svg
+    resources/img/knob.png
+    resources/img/knob@2x.png
+    resources/img/knob-rotate.png
+    resources/img/knob-rotate@2x.png
+    resources/img/slider-handle.png
+    resources/img/slider-handle.svg
+    resources/img/slider-handle@2x.png
+    resources/img/slider-track.png
+    resources/img/slider-track.svg
+    resources/img/slider-track@2x.png
+    resources/img/switch.png
+    resources/img/switch@2x.png
+    resources/img/vector-knob.svg
+)

--- a/Examples/IPlugConvoEngine/CMakeLists.txt
+++ b/Examples/IPlugConvoEngine/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugConvoEngine VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# NO_IGRAPHICS plugin - no UI, no WAM support
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugConvoEngine.cpp
+    IPlugConvoEngine.h
+    ir.h
+    resources/resource.h
+    ${IPLUG2_DIR}/WDL/convoengine.cpp
+    ${IPLUG2_DIR}/WDL/fft.c
+    ${IPLUG2_DIR}/WDL/resample.cpp
+  UI NONE
+  DEFINES
+    WDL_FFT_REALSIZE=8
+    NO_IGRAPHICS
+  EXCLUDE_FORMATS WAM
+)

--- a/Examples/IPlugDrumSynth/CMakeLists.txt
+++ b/Examples/IPlugDrumSynth/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugDrumSynth VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugDrumSynth.cpp
+    IPlugDrumSynth.h
+    IPlugDrumSynth_DSP.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugEffect/CMakeLists.txt
+++ b/Examples/IPlugEffect/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugEffect VERSION 1.0.0)
+
+# Discover IPLUG2_DIR if not already set (for independent builds)
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+
+# IGraphics backend/renderer can be set via command line:
+#   cmake -DIGRAPHICS_BACKEND=SKIA -DIGRAPHICS_RENDERER=GL3 ..
+# Defaults: NANOVG/METAL on macOS, NANOVG/GL2 on Windows
+# See iPlug2/Scripts/cmake/IGraphics.cmake for all options
+
+find_package(iPlug2 REQUIRED)
+
+# Build all formats except AUv3 (AUv3 is opt-in)
+# To include AUv3: FORMATS ALL_AUV3
+# To select specific formats: FORMATS APP VST3 AU
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugEffect.cpp
+    IPlugEffect.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugInstrument/CMakeLists.txt
+++ b/Examples/IPlugInstrument/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugInstrument VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugInstrument.cpp
+    IPlugInstrument.h
+    IPlugInstrument_DSP.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+  LINK
+    iPlug2::Extras::Synth
+)

--- a/Examples/IPlugMidiEffect/CMakeLists.txt
+++ b/Examples/IPlugMidiEffect/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugMidiEffect VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugMidiEffect.cpp
+    IPlugMidiEffect.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugOSCEditor/CMakeLists.txt
+++ b/Examples/IPlugOSCEditor/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugOSCEditor VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugOSCEditor.cpp
+    IPlugOSCEditor.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+  LINK
+    iPlug2::Extras::OSC
+    iPlug2::Extras::IWebViewControl
+)

--- a/Examples/IPlugP5js/CMakeLists.txt
+++ b/Examples/IPlugP5js/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugP5js VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugP5js.cpp
+    IPlugP5js.h
+    resources/resource.h
+  WEB_RESOURCES
+    resources/web/index.html
+    resources/web/p5.min.js
+    resources/web/script.js
+    resources/web/sketch.js
+    resources/web/uniforms.frag
+    resources/web/uniforms.vert
+  UI WEBVIEW
+  EXCLUDE_FORMATS WAM
+)

--- a/Examples/IPlugReaperExtension/CMakeLists.txt
+++ b/Examples/IPlugReaperExtension/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugReaperExtension VERSION 1.0.0)
+
+# REAPER Extensions are macOS and Windows only (no iOS, no Emscripten)
+if(IOS OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  message(STATUS "IPlugReaperExtension is not supported on ${CMAKE_SYSTEM_NAME}. Skipping.")
+  return()
+endif()
+
+# Discover IPLUG2_DIR if not already set (for independent builds)
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Include REAPER Extension module
+include(${IPLUG2_CMAKE_DIR}/ReaperExt.cmake)
+
+# Standard plugin setup
+set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(PLUG_RESOURCES_DIR ${PROJECT_DIR}/resources)
+
+set(SOURCE_FILES
+  IPlugReaperExtension.cpp
+  IPlugReaperExtension.h
+  resources/resource.h
+  resources/roboto.cpp
+  resources/roboto.hpp
+)
+
+# Add Windows resources
+if(WIN32)
+  list(APPEND SOURCE_FILES ${PLUG_RESOURCES_DIR}/main.rc)
+endif()
+
+# Build as a shared library (MODULE for dynamic loading)
+add_library(${PROJECT_NAME} MODULE ${SOURCE_FILES})
+
+# Base configuration
+iplug_add_target(${PROJECT_NAME} PUBLIC
+  INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources
+  LINK ${IGRAPHICS_LIB}
+)
+
+# Configure as REAPER extension (sets up output, deployment, etc.)
+iplug_configure_reaperext(${PROJECT_NAME} ${PROJECT_NAME})

--- a/Examples/IPlugReaperPlugin/CMakeLists.txt
+++ b/Examples/IPlugReaperPlugin/CMakeLists.txt
@@ -1,0 +1,165 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugReaperPlugin VERSION 1.0.0)
+
+# Discover IPLUG2_DIR if not already set (for independent builds)
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Standard plugin setup
+set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(PLUG_RESOURCES_DIR ${PROJECT_DIR}/resources)
+
+set(SOURCE_FILES
+  IPlugReaperPlugin.cpp
+  IPlugReaperPlugin.h
+  resources/resource.h
+)
+
+# REAPER SDK for REAPER-specific API access
+set(REAPER_SDK_DIR ${IPLUG_DEPS_DIR}/REAPER_SDK)
+
+# Base library for shared code (includes REAPER SDK path for conditional REAPER API usage)
+add_library(_${PROJECT_NAME}-base INTERFACE)
+iplug_add_target(_${PROJECT_NAME}-base INTERFACE
+  INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources ${REAPER_SDK_DIR} ${IPLUG2_DIR}/WDL/lice
+  LINK iPlug2::IPlug
+)
+
+# Font resources for bundles
+set(FONT_FILES ${PLUG_RESOURCES_DIR}/fonts/Roboto-Regular.ttf)
+
+# Helper function to add resources to plugin bundles
+function(iplug_add_plugin_resources target)
+  target_sources(${target} PRIVATE ${FONT_FILES})
+  set_source_files_properties(${FONT_FILES} PROPERTIES
+    MACOSX_PACKAGE_LOCATION Resources
+  )
+endfunction()
+
+# ============================================================================
+# macOS/Windows targets (not iOS, not Emscripten)
+# ============================================================================
+if(NOT IOS AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  # APP Target (Standalone Application)
+  set(APP_SOURCES ${SOURCE_FILES})
+  if(WIN32)
+    list(APPEND APP_SOURCES ${PLUG_RESOURCES_DIR}/main.rc)
+    set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I\"${PLUG_RESOURCES_DIR}/fonts\" /I\"${PLUG_RESOURCES_DIR}/img\"")
+  endif()
+
+  add_executable(${PROJECT_NAME}-app ${APP_SOURCES})
+  iplug_add_target(${PROJECT_NAME}-app PUBLIC
+    LINK iPlug2::APP ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-app APP ${PROJECT_NAME})
+  iplug_add_plugin_resources(${PROJECT_NAME}-app)
+
+  # VST3 Target
+  add_library(${PROJECT_NAME}-vst3 MODULE ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}-vst3 PUBLIC
+    LINK iPlug2::VST3 ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-vst3 VST3 ${PROJECT_NAME})
+  iplug_add_plugin_resources(${PROJECT_NAME}-vst3)
+
+  # CLAP Target
+  if(IPLUG2_CLAP_SUPPORTED)
+    add_library(${PROJECT_NAME}-clap MODULE ${SOURCE_FILES})
+    iplug_add_target(${PROJECT_NAME}-clap PUBLIC
+      LINK iPlug2::CLAP ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+    )
+    iplug_configure_target(${PROJECT_NAME}-clap CLAP ${PROJECT_NAME})
+    iplug_add_plugin_resources(${PROJECT_NAME}-clap)
+  endif()
+
+  # AAX Target
+  if(IPLUG2_AAX_SUPPORTED)
+    add_library(${PROJECT_NAME}-aax MODULE ${SOURCE_FILES})
+    iplug_add_target(${PROJECT_NAME}-aax PUBLIC
+      LINK iPlug2::AAX ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+    )
+    iplug_configure_target(${PROJECT_NAME}-aax AAX ${PROJECT_NAME})
+    iplug_add_plugin_resources(${PROJECT_NAME}-aax)
+  endif()
+endif()
+
+# ============================================================================
+# AUv2 Target (macOS only)
+# ============================================================================
+if(APPLE AND NOT IOS)
+  add_library(${PROJECT_NAME}-au MODULE ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}-au PUBLIC
+    LINK iPlug2::AUv2 ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-au AUv2 ${PROJECT_NAME})
+  iplug_add_plugin_resources(${PROJECT_NAME}-au)
+endif()
+
+# ============================================================================
+# AUv3 Targets (macOS) - Framework + Appex embedded in APP
+# ============================================================================
+if(APPLE AND NOT IOS)
+  add_library(${PROJECT_NAME}AU-framework SHARED ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}AU-framework PUBLIC
+    LINK iPlug2::AUv3 ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}AU-framework AUv3Framework ${PROJECT_NAME})
+
+  iplug_get_auv3appex_source(${PROJECT_NAME} APPEX_SOURCE)
+  add_executable(${PROJECT_NAME}AUv3-appex ${APPEX_SOURCE})
+  iplug_configure_target(${PROJECT_NAME}AUv3-appex AUv3Appex ${PROJECT_NAME})
+
+  iplug_embed_auv3_in_app(${PROJECT_NAME}-app ${PROJECT_NAME})
+endif()
+
+# ============================================================================
+# iOS Targets - AUv3 Framework + Appex + Standalone App
+# ============================================================================
+if(IOS)
+  add_library(${PROJECT_NAME}AU-ios-framework SHARED ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}AU-ios-framework PUBLIC
+    LINK iPlug2::AUv3iOS ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}AU-ios-framework AUv3iOSFramework ${PROJECT_NAME})
+
+  iplug_get_auv3ios_appex_source(${PROJECT_NAME} IOS_APPEX_SOURCE)
+  add_executable(${PROJECT_NAME}AUv3-ios-appex ${IOS_APPEX_SOURCE})
+  iplug_configure_target(${PROJECT_NAME}AUv3-ios-appex AUv3iOSAppex ${PROJECT_NAME})
+
+  add_executable(${PROJECT_NAME}-ios-app ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}-ios-app PUBLIC
+    LINK iPlug2::AUv3iOS ${IGRAPHICS_LIB} _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-ios-app IOSApp ${PROJECT_NAME})
+  iplug_add_plugin_resources(${PROJECT_NAME}-ios-app)
+
+  iplug_embed_auv3ios_in_app(${PROJECT_NAME}-ios-app ${PROJECT_NAME})
+endif()
+
+# ============================================================================
+# WAM/Web Targets (Emscripten only)
+# ============================================================================
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  add_executable(${PROJECT_NAME}-wam ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}-wam PUBLIC
+    LINK iPlug2::WAM _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-wam WAM ${PROJECT_NAME})
+
+  add_executable(${PROJECT_NAME}-web ${SOURCE_FILES})
+  iplug_add_target(${PROJECT_NAME}-web PUBLIC
+    LINK iPlug2::Web _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-web Web ${PROJECT_NAME})
+
+  iplug_build_wam_dist(${PROJECT_NAME}
+    WAM_TARGET ${PROJECT_NAME}-wam
+    WEB_TARGET ${PROJECT_NAME}-web
+    SITE_ORIGIN "/"
+  )
+endif()

--- a/Examples/IPlugReaperPlugin/IPlugReaperPlugin.cpp
+++ b/Examples/IPlugReaperPlugin/IPlugReaperPlugin.cpp
@@ -114,9 +114,10 @@ void IPlugReaperPlugin::ProcessBlock(sample** inputs, sample** outputs, int nFra
 
 void IPlugReaperPlugin::OnHostIdentified()
 {
+#if defined VST2_API || defined VST3_API || defined CLAP_API
   if (GetHost() == kHostReaper)
   {
-    int errorCount = REAPERAPI_LoadAPI([this](const char* str) {
+    int errorCount = REAPERAPI_LoadAPI([this](const char* str) -> void* {
 #if defined VST2_API
       return (void*) mHostCallback(NULL, 0xdeadbeef, 0xdeadf00d, 0, (void*) str, 0.0);
 #elif defined VST3_API
@@ -125,17 +126,18 @@ void IPlugReaperPlugin::OnHostIdentified()
       return (void*) reinterpret_cast<const reaper_plugin_info_t*>(mpClapHost->get_extension(mpClapHost, "cockos.reaper_extension"))->GetFunc(str);
 #endif
     });
-    
+
 #if defined CLAP_API
     auto pRec = reinterpret_cast<const reaper_plugin_info_t*>(mpClapHost->get_extension(mpClapHost, "cockos.reaper_extension"));
     IMPAPI(clap_get_reaper_context);
 #endif
-    
+
     if (errorCount > 0)
     {
       LogToReaperConsole("some errors when loading reaper api functions\n");
     }
   }
+#endif
 }
 
 #if defined VST3_API

--- a/Examples/IPlugResponsiveUI/CMakeLists.txt
+++ b/Examples/IPlugResponsiveUI/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugResponsiveUI VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugResponsiveUI.cpp
+    IPlugResponsiveUI.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugSideChain/CMakeLists.txt
+++ b/Examples/IPlugSideChain/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugSideChain VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugSideChain.cpp
+    IPlugSideChain.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugSurroundEffect/CMakeLists.txt
+++ b/Examples/IPlugSurroundEffect/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugSurroundEffect VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugSurroundEffect.cpp
+    IPlugSurroundEffect.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugSurroundEffect/IPlugSurroundEffect.cpp
+++ b/Examples/IPlugSurroundEffect/IPlugSurroundEffect.cpp
@@ -48,6 +48,8 @@ uint64_t GetAPIBusTypeForChannelIOConfig(int configIdx, ERoute dir, int busIdx, 
     case 12: return AAX_eStemFormat_7_1_4;
     default: return AAX_eStemFormat_None;
   }
+#else
+  return 0;
 #endif
 }
 

--- a/Examples/IPlugSvelteUI/CMakeLists.txt
+++ b/Examples/IPlugSvelteUI/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugSvelteUI VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Glob web resources (Svelte build outputs have hashed filenames)
+file(GLOB WEB_RESOURCES
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/web/*.html"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/web/assets/*"
+)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugSvelteUI.cpp
+    IPlugSvelteUI.h
+    resources/resource.h
+  WEB_RESOURCES ${WEB_RESOURCES}
+  UI WEBVIEW
+  EXCLUDE_FORMATS WAM
+)

--- a/Examples/IPlugSwiftUI/CMakeLists.txt
+++ b/Examples/IPlugSwiftUI/CMakeLists.txt
@@ -1,0 +1,333 @@
+cmake_minimum_required(VERSION 3.16)
+project(IPlugSwiftUI VERSION 1.0.0 LANGUAGES C CXX OBJC OBJCXX)
+
+# SwiftUI requires Xcode generator (and doesn't support Emscripten)
+if(NOT CMAKE_GENERATOR MATCHES "Xcode" OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  message(STATUS "IPlugSwiftUI requires Xcode generator for Swift/SwiftUI support. Skipping.")
+  return()
+endif()
+
+# Enable Swift language
+enable_language(Swift)
+
+# Discover IPLUG2_DIR if not already set (for independent builds)
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+# Include iPlug2 CMake configuration
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Standard plugin setup
+set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(PLUG_RESOURCES_DIR ${PROJECT_DIR}/resources)
+
+# C++/Objective-C++ source files
+set(SOURCE_FILES
+  IPlugSwiftUI.h
+  IPlugSwiftUI.mm
+  IPlugSwiftUI-Shared.h
+  resources/resource.h
+)
+
+# Swift source files
+set(SWIFT_FILES
+  UI/BundleLocator.swift
+  UI/ContentView.swift
+  UI/GridView.swift
+  UI/IPlugSwiftUIState.swift
+  UI/IPlugSwiftUIViewController.swift
+  UI/OscilloscopeView.swift
+  UI/Param.swift
+  UI/ParamSliderView.swift
+  UI/TypeAliases.swift
+)
+
+# Metal shader files
+set(METAL_SOURCES
+  ${PROJECT_DIR}/UI/CRTEffect.metal
+  ${PROJECT_DIR}/UI/Oscilloscope.metal
+)
+
+# Determine Metal SDK and language standard based on platform
+if(IOS)
+  if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator")
+    set(METAL_SDK "iphonesimulator")
+  else()
+    set(METAL_SDK "iphoneos")
+  endif()
+  # iOS requires ios-metal2.4 for [[stitchable]] attribute
+  set(METAL_STD "-std=ios-metal2.4")
+else()
+  set(METAL_SDK "macosx")
+  # macOS requires macos-metal2.4 for [[stitchable]] attribute
+  set(METAL_STD "-std=macos-metal2.4")
+endif()
+
+# Create .air (compiled) files from .metal sources
+set(METAL_AIR_FILES)
+foreach(metal_source ${METAL_SOURCES})
+  get_filename_component(metal_name ${metal_source} NAME_WE)
+  set(air_file ${CMAKE_CURRENT_BINARY_DIR}/${metal_name}.air)
+  list(APPEND METAL_AIR_FILES ${air_file})
+  add_custom_command(
+    OUTPUT ${air_file}
+    COMMAND xcrun -sdk ${METAL_SDK} metal ${METAL_STD} -c ${metal_source} -o ${air_file}
+    DEPENDS ${metal_source}
+    COMMENT "Compiling Metal shader ${metal_name} for ${METAL_SDK}"
+  )
+endforeach()
+
+# Link .air files into default.metallib
+set(METALLIB_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/default.metallib)
+add_custom_command(
+  OUTPUT ${METALLIB_OUTPUT}
+  COMMAND xcrun -sdk ${METAL_SDK} metallib ${METAL_AIR_FILES} -o ${METALLIB_OUTPUT}
+  DEPENDS ${METAL_AIR_FILES}
+  COMMENT "Linking Metal shaders into default.metallib"
+)
+
+# Create a target to build the metallib
+add_custom_target(${PROJECT_NAME}-metallib DEPENDS ${METALLIB_OUTPUT})
+
+# Helper function to add metallib to a macOS bundle target
+function(iplug_add_metallib target)
+  add_dependencies(${target} ${PROJECT_NAME}-metallib)
+  # Copy metallib to bundle Resources folder as a post-build step (macOS bundle structure)
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${METALLIB_OUTPUT}
+      "$<TARGET_BUNDLE_DIR:${target}>/Contents/Resources/default.metallib"
+    COMMENT "Copying default.metallib to ${target} bundle"
+  )
+endfunction()
+
+# Helper function to add metallib to an iOS bundle target (flat bundle structure)
+function(iplug_add_metallib_ios target)
+  add_dependencies(${target} ${PROJECT_NAME}-metallib)
+  # Copy metallib to bundle root (iOS flat bundle structure)
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${METALLIB_OUTPUT}
+      "$<TARGET_BUNDLE_DIR:${target}>/default.metallib"
+    COMMENT "Copying default.metallib to ${target} iOS bundle"
+  )
+endfunction()
+
+# CocoaEditorDelegate sources (required for SwiftUI integration)
+set(COCOA_EDITOR_SRC
+  ${IPLUG2_DIR}/IPlug/Extras/Cocoa/IPlugCocoaEditorDelegate.mm
+  ${IPLUG2_DIR}/IPlug/Extras/Cocoa/IPlugCocoaViewController.mm
+)
+
+# Base library for shared code
+add_library(_${PROJECT_NAME}-base INTERFACE)
+iplug_add_target(_${PROJECT_NAME}-base INTERFACE
+  INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources
+          ${IPLUG2_DIR}/IPlug/Extras/Cocoa
+  SOURCE ${COCOA_EDITOR_SRC}
+  LINK iPlug2::IPlug
+  DEFINE NO_IGRAPHICS COCOA_EDITOR_DELEGATE
+)
+
+# ============================================================================
+# macOS targets (not iOS)
+# ============================================================================
+if(NOT IOS)
+  # ============================================================================
+  # APP Target (Standalone Application) - with SwiftUI
+  # ============================================================================
+  add_executable(${PROJECT_NAME}-app ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-app PUBLIC
+    LINK iPlug2::APP _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-app APP ${PROJECT_NAME})
+
+  # Swift configuration - requires macOS 15.0 for SwiftUI features
+  set_target_properties(${PROJECT_NAME}-app PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY NO
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks"
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET 15.0
+  )
+
+  # Link Metal frameworks (SwiftUI linked automatically via Swift imports)
+  target_link_libraries(${PROJECT_NAME}-app PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders
+  iplug_add_metallib(${PROJECT_NAME}-app)
+
+  # ============================================================================
+  # VST3 Target - with SwiftUI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-vst3 MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-vst3 PUBLIC
+    LINK iPlug2::VST3 _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-vst3 VST3 ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-vst3 PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.vst3.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET 15.0
+  )
+
+  target_link_libraries(${PROJECT_NAME}-vst3 PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders
+  iplug_add_metallib(${PROJECT_NAME}-vst3)
+
+  # ============================================================================
+  # CLAP Target - with SwiftUI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-clap MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-clap PUBLIC
+    LINK iPlug2::CLAP _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-clap CLAP ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-clap PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.clap.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET 15.0
+  )
+
+  target_link_libraries(${PROJECT_NAME}-clap PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders
+  iplug_add_metallib(${PROJECT_NAME}-clap)
+
+  # ============================================================================
+  # AUv2 Target (macOS only) - with SwiftUI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-au MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-au PUBLIC
+    LINK iPlug2::AUv2 _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-au AUv2 ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-au PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.audiounit.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET 15.0
+  )
+
+  target_link_libraries(${PROJECT_NAME}-au PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders
+  iplug_add_metallib(${PROJECT_NAME}-au)
+
+  # ============================================================================
+  # AAX Target (macOS only) - with SwiftUI
+  # ============================================================================
+  add_library(${PROJECT_NAME}-aax MODULE ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-aax PUBLIC
+    LINK iPlug2::AAX _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-aax AAX ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-aax PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.aax.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET 15.0
+  )
+
+  target_link_libraries(${PROJECT_NAME}-aax PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders
+  iplug_add_metallib(${PROJECT_NAME}-aax)
+endif()
+
+# ============================================================================
+# iOS Targets - AUv3 Framework + Appex + Standalone App (SwiftUI)
+# ============================================================================
+if(IOS)
+  # iOS AUv3 Framework containing plugin code
+  add_library(${PROJECT_NAME}AU-ios-framework SHARED ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}AU-ios-framework PUBLIC
+    LINK iPlug2::AUv3iOS _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}AU-ios-framework AUv3iOSFramework ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}AU-ios-framework PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}.AUv3Framework"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY YES
+  )
+
+  target_link_libraries(${PROJECT_NAME}AU-ios-framework PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders to framework
+  iplug_add_metallib_ios(${PROJECT_NAME}AU-ios-framework)
+
+  # iOS AUv3 App Extension (appex)
+  iplug_get_auv3ios_appex_source(${PROJECT_NAME} IOS_APPEX_SOURCE)
+  add_executable(${PROJECT_NAME}AUv3-ios-appex ${IOS_APPEX_SOURCE})
+  iplug_configure_target(${PROJECT_NAME}AUv3-ios-appex AUv3iOSAppex ${PROJECT_NAME})
+
+  # iOS Standalone App that hosts the AUv3 for testing
+  add_executable(${PROJECT_NAME}-ios-app ${SOURCE_FILES} ${SWIFT_FILES})
+  iplug_add_target(${PROJECT_NAME}-ios-app PUBLIC
+    LINK iPlug2::AUv3iOS _${PROJECT_NAME}-base
+  )
+  iplug_configure_target(${PROJECT_NAME}-ios-app IOSApp ${PROJECT_NAME})
+
+  set_target_properties(${PROJECT_NAME}-ios-app PROPERTIES
+    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${PROJECT_DIR}/IPlugSwiftUI-Bridging-Header.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${PROJECT_NAME}"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY NO
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+  )
+
+  target_link_libraries(${PROJECT_NAME}-ios-app PUBLIC
+    "-framework Metal"
+    "-framework MetalKit"
+    "-framework Accelerate"
+  )
+
+  # Add compiled Metal shaders to app
+  iplug_add_metallib_ios(${PROJECT_NAME}-ios-app)
+
+  # Embed AUv3 appex and framework in the iOS app
+  iplug_embed_auv3ios_in_app(${PROJECT_NAME}-ios-app ${PROJECT_NAME})
+endif()

--- a/Examples/IPlugVisualizer/CMakeLists.txt
+++ b/Examples/IPlugVisualizer/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugVisualizer VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugVisualizer.cpp
+    IPlugVisualizer.h
+    resources/resource.h
+    ${IPLUG2_DIR}/WDL/fft.c
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/Examples/IPlugWebUI/CMakeLists.txt
+++ b/Examples/IPlugWebUI/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.14)
+project(IPlugWebUI VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IPlugWebUI.cpp
+    IPlugWebUI.h
+    resources/resource.h
+  WEB_RESOURCES
+    resources/web/index.html
+    resources/web/script.js
+    resources/web/knob-control.js
+    resources/web/button-control.js
+  UI WEBVIEW
+  EXCLUDE_FORMATS WAM
+)

--- a/IPlug/AAX/IPlugAAX.h
+++ b/IPlug/AAX/IPlugAAX.h
@@ -28,7 +28,8 @@
 
 #include "AAX_Push8ByteStructAlignment.h"
 
-#if defined OS_WIN
+// CMake handles linking via target_link_libraries, so skip pragma lib references
+#if defined OS_WIN && !defined IPLUG2_CMAKE_BUILD
   #if defined _DEBUG
     #if defined ARCH_64BIT
       #pragma comment(lib, "AAXLibrary_x64_D.lib")

--- a/IPlug/IPlugOBJCPrefix.pch
+++ b/IPlug/IPlugOBJCPrefix.pch
@@ -37,6 +37,8 @@
     #define API _vst3
   #elif defined(APP_API)
     #define API _app
+  #elif defined(REAPER_EXT_API)
+    #define API _reaperext
   #endif
 
   #define CONCAT3(a,b,c) a##b##c

--- a/Scripts/cmake/AAX.cmake
+++ b/Scripts/cmake/AAX.cmake
@@ -1,0 +1,218 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AAX target configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::AAX)
+  # Define SDK path
+  set(AAX_SDK_DIR ${IPLUG_DEPS_DIR}/AAX_SDK)
+
+  # Check if AAX SDK exists (must have CMakeLists.txt, not just placeholder directory)
+  if(NOT EXISTS ${AAX_SDK_DIR}/CMakeLists.txt)
+    message(STATUS "AAX SDK not found at ${AAX_SDK_DIR}. AAX targets will not be available.")
+    set(IPLUG2_AAX_SUPPORTED FALSE CACHE INTERNAL "AAX SDK available")
+    # Create a dummy iPlug2::AAX target so projects can link to it without errors
+    add_library(iPlug2::AAX INTERFACE IMPORTED)
+    # Define stub function that excludes the target from default build
+    function(iplug_configure_aax target project_name)
+      message(STATUS "Skipping AAX target '${target}' - AAX SDK not available")
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endfunction()
+    return()
+  endif()
+
+  set(IPLUG2_AAX_SUPPORTED TRUE CACHE INTERNAL "AAX SDK available")
+
+  # Build AAX SDK library via add_subdirectory (only once)
+  # Use global property to prevent race condition in parallel builds
+  get_property(_aax_sdk_added GLOBAL PROPERTY _IPLUG2_AAX_SDK_ADDED)
+  if(NOT _aax_sdk_added AND NOT TARGET AAX_SDK::AAXLibrary)
+    set_property(GLOBAL PROPERTY _IPLUG2_AAX_SDK_ADDED TRUE)
+    # Disable examples and other optional components for faster builds
+    set(AAX_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(AAX_BUILD_PTSL_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(AAX_BUILD_JUCE_GUI_EXTENSION OFF CACHE BOOL "" FORCE)
+    set(AAX_BUILD_TI_INTERFACE OFF CACHE BOOL "" FORCE)
+    # Force static runtime (MT) for AAX SDK on Windows
+    # The AAX SDK's cmake_minimum_required(3.13) uses CMP0091 OLD policy, which ignores
+    # CMAKE_MSVC_RUNTIME_LIBRARY and instead uses the default /MD flags from CMAKE_CXX_FLAGS.
+    # We must temporarily replace /MD with /MT in the default flags before add_subdirectory.
+    if(MSVC)
+      set(_saved_cxx_flags_release "${CMAKE_CXX_FLAGS_RELEASE}")
+      set(_saved_cxx_flags_debug "${CMAKE_CXX_FLAGS_DEBUG}")
+      set(_saved_cxx_flags_relwithdebinfo "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      set(_saved_cxx_flags_minsizerel "${CMAKE_CXX_FLAGS_MINSIZEREL}")
+      string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+      string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+      string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+      string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
+    endif()
+    add_subdirectory(${AAX_SDK_DIR} ${CMAKE_BINARY_DIR}/AAX_SDK EXCLUDE_FROM_ALL)
+    # Restore original flags for any subsequent targets
+    if(MSVC)
+      set(CMAKE_CXX_FLAGS_RELEASE "${_saved_cxx_flags_release}")
+      set(CMAKE_CXX_FLAGS_DEBUG "${_saved_cxx_flags_debug}")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${_saved_cxx_flags_relwithdebinfo}")
+      set(CMAKE_CXX_FLAGS_MINSIZEREL "${_saved_cxx_flags_minsizerel}")
+    endif()
+  endif()
+
+  add_library(iPlug2::AAX INTERFACE IMPORTED)
+
+  # iPlug2 AAX wrapper sources
+  set(AAX_IPLUG_SRC
+    ${IPLUG_DIR}/AAX/IPlugAAX.cpp
+    ${IPLUG_DIR}/AAX/IPlugAAX_Describe.cpp
+    ${IPLUG_DIR}/AAX/IPlugAAX_Parameters.cpp
+  )
+
+  target_sources(iPlug2::AAX INTERFACE ${AAX_IPLUG_SRC})
+
+  target_include_directories(iPlug2::AAX INTERFACE
+    ${IPLUG_DIR}/AAX
+    ${AAX_SDK_DIR}/Interfaces
+    ${AAX_SDK_DIR}/Interfaces/ACF
+    ${AAX_SDK_DIR}/Libs/AAXLibrary/include
+  )
+
+  target_compile_definitions(iPlug2::AAX INTERFACE
+    AAX_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+    IPLUG2_CMAKE_BUILD  # Disables #pragma comment(lib) in IPlugAAX.h - CMake handles linking
+  )
+
+  # Suppress AAX SDK related warnings
+  target_compile_options(iPlug2::AAX INTERFACE
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-multichar>
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-incompatible-ms-struct>
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-pragma-pack>
+  )
+
+  if(WIN32)
+    # Windows: link against the static library and object library
+    target_link_libraries(iPlug2::AAX INTERFACE
+      AAX_SDK::AAXLibrary
+      AAX_SDK::AAX_Export
+    )
+  elseif(APPLE)
+    # macOS: Set Obj-C++ for iPlug2 AAX wrapper
+    set_source_files_properties(${AAX_IPLUG_SRC} PROPERTIES LANGUAGE OBJCXX)
+
+    target_link_libraries(iPlug2::AAX INTERFACE
+      AAX_SDK::AAXLibrary
+      AAX_SDK::AAX_Export
+      "-framework Cocoa"
+      "-framework CoreFoundation"
+    )
+  endif()
+
+  target_link_libraries(iPlug2::AAX INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for AAX targets
+function(iplug_configure_aax target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::AAX)
+
+  if(WIN32)
+    # Windows: AAX bundle structure is ProjectName.aaxplugin/Contents/x64/ProjectName.aaxplugin
+    # Determine architecture (64-bit only)
+    if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64EC")
+      set(AAX_ARCH "ARM64EC")
+    elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
+      set(AAX_ARCH "ARM64")
+    else()
+      set(AAX_ARCH "x64")
+    endif()
+
+    set(AAX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/${AAX_ARCH}")
+
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      SUFFIX ".aaxplugin"
+      LIBRARY_OUTPUT_DIRECTORY "${AAX_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${AAX_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${AAX_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${AAX_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${AAX_OUTPUT_DIR}"
+    )
+
+    # Create Resources folder and copy Pages.xml if it exists
+    set(PAGES_XML ${PLUG_RESOURCES_DIR}/${project_name}-Pages.xml)
+    if(EXISTS ${PAGES_XML})
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/Resources"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PAGES_XML}" "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/Resources/${project_name}-Pages.xml"
+        COMMENT "Creating AAX bundle structure and copying Pages.xml for ${project_name}"
+      )
+    else()
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/Resources"
+        COMMENT "Creating AAX bundle structure for ${project_name}"
+      )
+    endif()
+
+    # Copy icon file if present
+    set(ICON_FILE ${PLUG_RESOURCES_DIR}/${project_name}.ico)
+    if(EXISTS ${ICON_FILE})
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${ICON_FILE}" "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/PlugIn.ico"
+        COMMENT "Copying AAX icon for ${project_name}"
+      )
+    endif()
+
+  elseif(APPLE)
+    # macOS: AAX is a bundle with .aaxplugin extension
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "aaxplugin"
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-AAX-Info.plist
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      MACOSX_BUNDLE_BUNDLE_NAME "${project_name}"
+      OUTPUT_NAME "${project_name}"
+      XCODE_ATTRIBUTE_WRAPPER_EXTENSION "aaxplugin"
+      XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "NO"
+    )
+
+    # Create AAX-specific PkgInfo file (TDMwPTul instead of BNDL????)
+    # Generate PkgInfo at configure time for deterministic output (no platform-dependent newlines)
+    set(AAX_PKGINFO_PATH "${CMAKE_BINARY_DIR}/iplug2_pkginfo/AAX_PkgInfo")
+    file(WRITE "${AAX_PKGINFO_PATH}" "TDMwPTul")
+    if(NOT XCODE)
+      set(PKGINFO_DEST "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/PkgInfo")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${AAX_PKGINFO_PATH}" "${PKGINFO_DEST}"
+        COMMENT "Creating AAX PkgInfo for ${project_name}.aaxplugin"
+      )
+    else()
+      # Xcode: copy to bundle directory at build time
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${AAX_PKGINFO_PATH}" "$<TARGET_BUNDLE_DIR:${target}>/Contents/PkgInfo"
+        COMMENT "Creating AAX PkgInfo for ${project_name}.aaxplugin"
+      )
+    endif()
+
+    # Copy Pages.xml to Resources folder
+    set(PAGES_XML ${PLUG_RESOURCES_DIR}/${project_name}-Pages.xml)
+    if(EXISTS ${PAGES_XML})
+      if(XCODE)
+        target_sources(${target} PRIVATE ${PAGES_XML})
+        set_source_files_properties(${PAGES_XML} PROPERTIES
+          MACOSX_PACKAGE_LOCATION Resources
+        )
+      else()
+        add_custom_command(TARGET ${target} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy "${PAGES_XML}" "${CMAKE_BINARY_DIR}/out/${project_name}.aaxplugin/Contents/Resources/${project_name}-Pages.xml"
+          COMMENT "Copying AAX Pages.xml for ${project_name}"
+        )
+      endif()
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/APP.cmake
+++ b/Scripts/cmake/APP.cmake
@@ -1,0 +1,182 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# APP target configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::APP)
+  add_library(iPlug2::APP INTERFACE IMPORTED)
+
+  set(SWELL_DIR ${WDL_DIR}/swell)
+
+  # RTAudio and RTMidi directories
+  set(RTAUDIO_DIR ${IPLUG_DEPS_DIR}/RTAudio)
+  set(RTMIDI_DIR ${IPLUG_DEPS_DIR}/RTMidi)
+  
+  set(IPLUG2_APP_SRC
+    ${IPLUG2_DIR}/IPlug/APP/IPlugAPP.cpp
+    ${IPLUG2_DIR}/IPlug/APP/IPlugAPP_dialog.cpp
+    ${IPLUG2_DIR}/IPlug/APP/IPlugAPP_host.cpp
+    ${IPLUG2_DIR}/IPlug/APP/IPlugAPP_main.cpp
+    ${RTAUDIO_DIR}/RtAudio.cpp
+    ${RTMIDI_DIR}/RtMidi.cpp
+    CACHE INTERNAL "APP source files"
+  )
+
+  target_sources(iPlug2::APP INTERFACE ${IPLUG2_APP_SRC})
+  
+  target_include_directories(iPlug2::APP INTERFACE 
+    ${IPLUG2_DIR}/IPlug/APP
+    ${RTAUDIO_DIR}
+    ${RTAUDIO_DIR}/include
+    ${RTMIDI_DIR}
+  )
+  
+  target_compile_definitions(iPlug2::APP INTERFACE 
+    APP_API 
+    IPLUG_EDITOR=1 
+    IPLUG_DSP=1
+  )
+  
+  if(WIN32)
+    target_sources(iPlug2::APP INTERFACE
+      ${RTAUDIO_DIR}/include/asio.cpp
+      ${RTAUDIO_DIR}/include/asiodrivers.cpp
+      ${RTAUDIO_DIR}/include/asiolist.cpp
+      ${RTAUDIO_DIR}/include/iasiothiscallresolver.cpp
+    )
+    target_compile_definitions(iPlug2::APP INTERFACE 
+      __WINDOWS_DS__ 
+      __WINDOWS_MM__ 
+      __WINDOWS_ASIO__
+    )
+    target_link_libraries(iPlug2::APP INTERFACE 
+      dsound.lib 
+      winmm.lib
+    )
+  elseif(APPLE)
+    # Note: OBJCXX language is set on actual target sources in iplug_configure_app()
+    # because set_source_files_properties on INTERFACE library sources doesn't propagate
+    target_include_directories(iPlug2::APP INTERFACE ${SWELL_DIR})
+
+    set(IPLUG2_SWELL_SRC
+      "${SWELL_DIR}/swell-appstub.mm"
+      "${SWELL_DIR}/swellappmain.mm"
+      "${SWELL_DIR}/swell-ini.cpp"
+      "${SWELL_DIR}/swell-dlg.mm"
+      "${SWELL_DIR}/swell-kb.mm"
+      "${SWELL_DIR}/swell-miscdlg.mm"
+      "${SWELL_DIR}/swell-menu.mm"
+      "${SWELL_DIR}/swell-wnd.mm"
+      "${SWELL_DIR}/swell.cpp"
+      "${SWELL_DIR}/swell-misc.mm"
+      "${SWELL_DIR}/swell-gdi.mm"
+      CACHE INTERNAL "SWELL source files for APP"
+    )
+
+    target_sources(iPlug2::APP INTERFACE ${IPLUG2_SWELL_SRC})
+
+    # Note: swell warning suppression is set on actual target sources in iplug_configure_app()
+    # because set_source_files_properties on INTERFACE library sources doesn't propagate
+
+    target_compile_definitions(iPlug2::APP INTERFACE 
+      __MACOSX_CORE__
+      SWELL_COMPILED
+    )
+    target_link_libraries(iPlug2::APP INTERFACE
+      "-framework AppKit"
+      "-framework Carbon"
+      "-framework CoreMIDI"
+      "-framework CoreAudio"
+    )
+  elseif(UNIX AND NOT APPLE)
+    message("Error - Linux not yet supported")
+  endif()
+  
+  target_link_libraries(iPlug2::APP INTERFACE iPlug2::IPlug)
+endif()
+
+function(iplug_configure_app target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::APP)
+
+  # On Apple platforms, set language properties on the actual target sources
+  # (set_source_files_properties on INTERFACE library sources doesn't propagate)
+  if(APPLE)
+    set_source_files_properties(${IPLUG2_APP_SRC}
+      TARGET_DIRECTORY ${target}
+      PROPERTIES LANGUAGE OBJCXX
+    )
+    # swell sources need Cocoa imported before swell-internal.h.
+    # Force-include the prefix pch which imports Cocoa (with #ifdef __OBJC__ guard)
+    set_source_files_properties(${IPLUG2_SWELL_SRC}
+      TARGET_DIRECTORY ${target}
+      PROPERTIES
+      LANGUAGE OBJCXX
+      COMPILE_FLAGS "-Wno-deprecated-declarations -include ${IPLUG_DIR}/IPlugOBJCPrefix.pch"
+    )
+  endif()
+
+  if(WIN32)
+    set(APP_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      RUNTIME_OUTPUT_DIRECTORY "${APP_OUTPUT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${APP_OUTPUT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${APP_OUTPUT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${APP_OUTPUT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${APP_OUTPUT_DIR}"
+      WIN32_EXECUTABLE TRUE  # Use WinMain entry point
+    )
+  elseif(APPLE)
+    set_target_properties(${target} PROPERTIES
+      MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-macOS-Info.plist
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      OUTPUT_NAME "${project_name}"
+      # Skip code signing during build - sign manually later if needed
+      XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    )
+
+    # Compile XIB to NIB and add to bundle Resources
+    set(MAIN_MENU_XIB ${PLUG_RESOURCES_DIR}/${project_name}-macOS-MainMenu.xib)
+    if(EXISTS ${MAIN_MENU_XIB})
+      set(MAIN_MENU_NIB ${CMAKE_CURRENT_BINARY_DIR}/${project_name}-macOS-MainMenu.nib)
+      add_custom_command(
+        OUTPUT ${MAIN_MENU_NIB}
+        COMMAND ibtool --compile ${MAIN_MENU_NIB} ${MAIN_MENU_XIB}
+        DEPENDS ${MAIN_MENU_XIB}
+        COMMENT "Compiling ${project_name}-macOS-MainMenu.xib"
+      )
+      target_sources(${target} PRIVATE ${MAIN_MENU_NIB})
+      set_source_files_properties(${MAIN_MENU_NIB} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+
+    # Add icon to bundle Resources
+    set(APP_ICON ${PLUG_RESOURCES_DIR}/${project_name}.icns)
+    if(EXISTS ${APP_ICON})
+      target_sources(${target} PRIVATE ${APP_ICON})
+      set_source_files_properties(${APP_ICON} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+
+    # Create PkgInfo for non-Xcode generators (Xcode creates it automatically)
+    if(NOT XCODE)
+      set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+      file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"APPL????\")")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/Contents/PkgInfo"
+          -P "${PKGINFO_SCRIPT}"
+        COMMENT "Creating PkgInfo for ${project_name}.app"
+      )
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv2.cmake
+++ b/Scripts/cmake/AUv2.cmake
@@ -1,0 +1,87 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv2 (Audio Unit v2) target configuration for iPlug2
+# macOS only
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::AUv2)
+  if(NOT APPLE)
+    message(WARNING "AUv2 is only supported on macOS")
+    return()
+  endif()
+
+  add_library(iPlug2::AUv2 INTERFACE IMPORTED)
+
+  # iPlug2 AUv2 wrapper sources
+  set(AUV2_IPLUG_SRC
+    ${IPLUG_DIR}/AUv2/IPlugAU.cpp
+    ${IPLUG_DIR}/AUv2/IPlugAU_view_factory.mm
+    ${IPLUG_DIR}/AUv2/dfx-au-utilities.c
+  )
+
+  target_sources(iPlug2::AUv2 INTERFACE ${AUV2_IPLUG_SRC})
+
+  # Set Obj-C++ for the AU wrapper sources
+  set_source_files_properties(${IPLUG_DIR}/AUv2/IPlugAU.cpp
+    PROPERTIES LANGUAGE OBJCXX
+  )
+  set_source_files_properties(${IPLUG_DIR}/AUv2/IPlugAU_view_factory.mm
+    PROPERTIES LANGUAGE OBJCXX
+  )
+
+  target_include_directories(iPlug2::AUv2 INTERFACE
+    ${IPLUG_DIR}/AUv2
+  )
+
+  target_compile_definitions(iPlug2::AUv2 INTERFACE
+    AU_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  target_link_libraries(iPlug2::AUv2 INTERFACE
+    "-framework AudioUnit"
+    "-framework AudioToolbox"
+    "-framework CoreAudio"
+    "-framework CoreMIDI"
+    "-framework Cocoa"
+  )
+
+  target_link_libraries(iPlug2::AUv2 INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for AUv2 targets
+function(iplug_configure_auv2 target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::AUv2)
+
+  if(APPLE)
+    # AUv2 on macOS is a bundle with .component extension
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "component"
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-AU-Info.plist
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      MACOSX_BUNDLE_BUNDLE_NAME "${project_name}"
+      OUTPUT_NAME "${project_name}"
+      XCODE_ATTRIBUTE_WRAPPER_EXTENSION "component"
+      XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
+    )
+
+    # For non-Xcode generators (e.g., Ninja), create PkgInfo file manually
+    if(NOT XCODE)
+      set(PKGINFO_PATH "${CMAKE_BINARY_DIR}/out/${project_name}.component/Contents/PkgInfo")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.component/Contents"
+        COMMAND ${CMAKE_COMMAND} -E copy "${IPLUG2_PKGINFO_FILE}" "${PKGINFO_PATH}"
+        COMMENT "Creating PkgInfo for ${project_name}.component"
+      )
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3.cmake
+++ b/Scripts/cmake/AUv3.cmake
@@ -1,0 +1,128 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 (Audio Unit v3) shared definitions for iPlug2
+# macOS only - defines iPlug2::AUv3 interface and helper functions
+# Included by AUv3Framework.cmake and AUv3Appex.cmake
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::AUv3)
+  if(NOT APPLE)
+    message(WARNING "AUv3 is only supported on macOS")
+    return()
+  endif()
+
+  add_library(iPlug2::AUv3 INTERFACE IMPORTED)
+
+  # iPlug2 AUv3 wrapper sources
+  set(AUV3_IPLUG_SRC
+    ${IPLUG_DIR}/AUv3/IPlugAUv3.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.mm
+  )
+
+  target_sources(iPlug2::AUv3 INTERFACE ${AUV3_IPLUG_SRC})
+
+  # Note: ARC flag must be set by consuming targets, not here
+  # (set_source_files_properties doesn't propagate through INTERFACE targets)
+
+  target_include_directories(iPlug2::AUv3 INTERFACE
+    ${IPLUG_DIR}/AUv3
+  )
+
+  target_compile_definitions(iPlug2::AUv3 INTERFACE
+    AUv3_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  # AUv3 headers need Cocoa for NSView on macOS (only for ObjC++ files)
+  target_compile_options(iPlug2::AUv3 INTERFACE
+    "$<$<COMPILE_LANGUAGE:OBJCXX>:SHELL:-include Cocoa/Cocoa.h>"
+  )
+
+  target_link_libraries(iPlug2::AUv3 INTERFACE
+    "-framework AudioToolbox"
+    "-framework AVFoundation"
+    "-framework CoreAudioKit"
+    "-framework CoreMIDI"
+    "-framework Cocoa"
+    iPlug2::IPlug
+  )
+endif()
+
+# ============================================================================
+# Get or generate the appex source file
+# Returns the path in APPEX_SOURCE_OUT variable
+# ============================================================================
+function(iplug_get_auv3appex_source project_name APPEX_SOURCE_OUT)
+  # Check for existing appex source with either naming convention
+  if(EXISTS "${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m")
+    set(${APPEX_SOURCE_OUT} "${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m" PARENT_SCOPE)
+  else()
+    # Generate a minimal appex source file
+    set(GENERATED_APPEX "${CMAKE_CURRENT_BINARY_DIR}/${project_name}AUv3Appex.m")
+    file(WRITE ${GENERATED_APPEX}
+"// Auto-generated AUv3 appex source
+#import <Foundation/Foundation.h>
+// Dummy function to ensure linking
+void AUv3AppexDummy(void) {}
+")
+    set(${APPEX_SOURCE_OUT} "${GENERATED_APPEX}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# ============================================================================
+# Embed AUv3 appex and framework in an existing APP target
+# Structure matches Xcode: framework at App/Contents/Frameworks/,
+# appex at App/Contents/PlugIns/
+# ============================================================================
+function(iplug_embed_auv3_in_app app_target project_name)
+  set(appex_target ${project_name}AUv3-appex)
+  set(framework_target ${project_name}AU-framework)
+
+  add_dependencies(${app_target} ${appex_target})
+
+  # Post-build: Embed framework at app level, then embed appex
+  # Use cp -R to preserve symlinks in framework bundle
+  # Note: Paths use $<CONFIG> generator expression for Xcode compatibility
+  if(XCODE)
+    add_custom_command(TARGET ${app_target} POST_BUILD
+      # Copy framework to App/Contents/Frameworks/ (preserving symlinks)
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/Frameworks"
+      COMMAND cp -R
+        "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AU.framework"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/Frameworks/"
+      # Copy appex to App/Contents/PlugIns/
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/PlugIns"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AUv3.appex"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/PlugIns/${project_name}AUv3.appex"
+      COMMENT "Embedding AUv3 (framework + appex) in ${project_name}.app"
+    )
+  else()
+    add_custom_command(TARGET ${app_target} POST_BUILD
+      # Copy framework to App/Contents/Frameworks/ (preserving symlinks)
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/Frameworks"
+      COMMAND cp -R
+        "${CMAKE_BINARY_DIR}/out/${project_name}AU.framework"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/Frameworks/"
+      # Copy appex to App/Contents/PlugIns/
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/PlugIns"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Contents/PlugIns/${project_name}AUv3.appex"
+      COMMENT "Embedding AUv3 (framework + appex) in ${project_name}.app"
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3Appex.cmake
+++ b/Scripts/cmake/AUv3Appex.cmake
@@ -1,0 +1,110 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 Appex target configuration for iPlug2
+# The appex is an app extension (executable) that hosts the framework
+
+include(${CMAKE_CURRENT_LIST_DIR}/AUv3.cmake)
+
+function(iplug_configure_auv3appex target project_name)
+  set(framework_target ${project_name}AU-framework)
+
+  # Appex is an app bundle (executable) with .appex extension
+  # Uses NSExtensionMain entry point from Foundation
+  # OUTPUT_NAME matches CFBundleExecutable in Info.plist
+  # For Ninja: Use separate output dir to avoid collision with APP target
+  if(XCODE)
+    set(APPEX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+  else()
+    set(APPEX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out/appex-build")
+  endif()
+
+  set_target_properties(${target} PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-macOS-AUv3-Info.plist
+    RUNTIME_OUTPUT_DIRECTORY "${APPEX_OUTPUT_DIR}"
+    OUTPUT_NAME "${project_name}"
+    XCODE_ATTRIBUTE_WRAPPER_EXTENSION "appex"
+    # Product type must be app-extension for proper Xcode validation
+    XCODE_PRODUCT_TYPE "com.apple.product-type.app-extension"
+    # Skip code signing during build - we handle it separately
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    # Set bundle identifier to match what's in Info.plist
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.app.${project_name}.AUv3"
+    # Skip install paths check
+    XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+  )
+
+  # Use NSExtensionMain as entry point (provided by Foundation)
+  # Add rpath to find framework at App/Contents/Frameworks/ (two levels up from appex MacOS)
+  target_link_options(${target} PRIVATE
+    "-e" "_NSExtensionMain"
+    "-Wl,-rpath,@executable_path/../../Frameworks"
+  )
+
+  # Appex links to the framework binary at build time
+  # At runtime, it finds the framework via rpath in the host app
+  add_dependencies(${target} ${framework_target})
+
+  # Use generator expression to get the correct framework path
+  # For Xcode, LIBRARY_OUTPUT_DIRECTORY gets config subdirectory appended
+  target_link_libraries(${target} PRIVATE
+    "$<TARGET_FILE:${framework_target}>"
+    "-framework Foundation"
+  )
+
+  # Enable ARC for appex source
+  set(APPEX_SOURCE ${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m)
+  if(EXISTS ${APPEX_SOURCE})
+    set_source_files_properties(${APPEX_SOURCE}
+      PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+    )
+  endif()
+
+  # Post-build: Create PkgInfo and rename bundle to final name
+  # NOTE: Framework is NOT embedded in appex - it goes at app level (see iplug_embed_auv3_in_app)
+  # NOTE: For Xcode generator, XCODE_ATTRIBUTE_WRAPPER_EXTENSION handles the .appex extension
+  set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+  file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"XPC!????\")")
+
+  if(XCODE)
+    # For Xcode: XCODE_ATTRIBUTE_WRAPPER_EXTENSION creates .appex bundle directly
+    # Bundle is created as ${project_name}.appex, we rename to ${project_name}AUv3.appex
+    set(APPEX_BUNDLE "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}.appex")
+    set(APPEX_FINAL "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AUv3.appex")
+    add_custom_command(TARGET ${target} POST_BUILD
+      # Create PkgInfo
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="${APPEX_BUNDLE}/Contents/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      # Rename bundle to final name with AUv3 suffix
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${APPEX_FINAL}"
+      COMMAND ${CMAKE_COMMAND} -E rename
+        "${APPEX_BUNDLE}"
+        "${APPEX_FINAL}"
+      COMMENT "Building ${project_name}AUv3.appex"
+    )
+  else()
+    # For Ninja/other generators: Convert .app to .appex and move to final location
+    # Bundle is built in appex-build/ subdir to avoid collision with APP target
+    add_custom_command(TARGET ${target} POST_BUILD
+      # Create PkgInfo
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/Contents/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      # Copy Info.plist (CMake may not process it correctly for non-Xcode)
+      COMMAND ${CMAKE_COMMAND} -E copy
+        "${PLUG_RESOURCES_DIR}/${project_name}-macOS-AUv3-Info.plist"
+        "$<TARGET_BUNDLE_DIR:${target}>/Contents/Info.plist"
+      # Move and rename .app bundle to .appex in final location
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+      COMMAND ${CMAKE_COMMAND} -E rename
+        "$<TARGET_BUNDLE_DIR:${target}>"
+        "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+      COMMENT "Building ${project_name}AUv3.appex"
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3Framework.cmake
+++ b/Scripts/cmake/AUv3Framework.cmake
@@ -1,0 +1,84 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 Framework target configuration for iPlug2
+# The framework contains the actual plugin code and is loaded in-process
+
+include(${CMAKE_CURRENT_LIST_DIR}/AUv3.cmake)
+
+function(iplug_configure_auv3framework target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::AUv3)
+
+  # AUv3 requires ARC for its Objective-C++ sources
+  set(AUV3_SOURCES
+    ${IPLUG_DIR}/AUv3/IPlugAUv3.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.mm
+  )
+  set_source_files_properties(${AUV3_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  set_target_properties(${target} PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION A
+    MACOSX_FRAMEWORK_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-macOS-AUv3Framework-Info.plist
+    OUTPUT_NAME "${project_name}AU"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+    # Skip code signing during build - sign manually later if needed
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+  )
+
+  # Create PkgInfo file for framework bundle (FMWK = framework)
+  set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+  file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"FMWK????\")")
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/Versions/A/Resources/PkgInfo"
+      -P "${PKGINFO_SCRIPT}"
+    COMMENT "Creating PkgInfo for ${project_name}AU.framework"
+  )
+
+  # Add headers to framework (umbrella + public headers)
+  # Check for umbrella header - support both naming conventions:
+  # - ${project_name}AU.h (TemplateProject style)
+  # - AUv3Framework.h (iPlug2 Examples style)
+  if(EXISTS "${PLUG_RESOURCES_DIR}/${project_name}AU.h")
+    set(UMBRELLA_HEADER "${PLUG_RESOURCES_DIR}/${project_name}AU.h")
+  elseif(EXISTS "${PLUG_RESOURCES_DIR}/AUv3Framework.h")
+    set(UMBRELLA_HEADER "${PLUG_RESOURCES_DIR}/AUv3Framework.h")
+  else()
+    message(WARNING "No AUv3 umbrella header found for ${project_name}")
+    set(UMBRELLA_HEADER "")
+  endif()
+
+  set(FRAMEWORK_HEADERS
+    ${UMBRELLA_HEADER}
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.h
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.h
+  )
+  target_sources(${target} PRIVATE ${FRAMEWORK_HEADERS})
+  set_source_files_properties(${FRAMEWORK_HEADERS}
+    PROPERTIES MACOSX_PACKAGE_LOCATION Headers
+  )
+
+  # Compile XIB to NIB and add to framework Resources
+  set(AU_VIEW_XIB ${PLUG_RESOURCES_DIR}/IPlugAUViewController_v${project_name}.xib)
+  if(EXISTS ${AU_VIEW_XIB})
+    set(AU_VIEW_NIB ${CMAKE_CURRENT_BINARY_DIR}/IPlugAUViewController_v${project_name}.nib)
+    add_custom_command(
+      OUTPUT ${AU_VIEW_NIB}
+      COMMAND ibtool --compile ${AU_VIEW_NIB} ${AU_VIEW_XIB}
+      DEPENDS ${AU_VIEW_XIB}
+      COMMENT "Compiling IPlugAUViewController_v${project_name}.xib"
+    )
+    target_sources(${target} PRIVATE ${AU_VIEW_NIB})
+    set_source_files_properties(${AU_VIEW_NIB} PROPERTIES
+      MACOSX_PACKAGE_LOCATION Resources
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3iOS.cmake
+++ b/Scripts/cmake/AUv3iOS.cmake
@@ -1,0 +1,131 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 (Audio Unit v3) shared definitions for iPlug2 iOS
+# Defines iPlug2::AUv3iOS interface and helper functions
+# Included by AUv3iOSFramework.cmake and AUv3iOSAppex.cmake
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::AUv3iOS)
+  if(NOT IOS)
+    message(WARNING "AUv3iOS is only supported when building for iOS (CMAKE_SYSTEM_NAME=iOS)")
+    return()
+  endif()
+
+  add_library(iPlug2::AUv3iOS INTERFACE IMPORTED)
+
+  # iPlug2 AUv3 wrapper sources (same as macOS)
+  set(AUV3_IOS_IPLUG_SRC
+    ${IPLUG_DIR}/AUv3/IPlugAUv3.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.mm
+  )
+
+  target_sources(iPlug2::AUv3iOS INTERFACE ${AUV3_IOS_IPLUG_SRC})
+
+  target_include_directories(iPlug2::AUv3iOS INTERFACE
+    ${IPLUG_DIR}/AUv3
+  )
+
+  target_compile_definitions(iPlug2::AUv3iOS INTERFACE
+    AUv3_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  # iOS AUv3 headers need UIKit (not Cocoa like macOS)
+  # Force-include ObjC prefix header to customize class names and avoid conflicts
+  # Note: Use $<COMPILE_LANGUAGE:> to avoid applying to Swift sources (Swift doesn't support -include)
+  target_compile_options(iPlug2::AUv3iOS INTERFACE
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:SHELL:-include ${IPLUG_DIR}/IPlugOBJCPrefix.pch>"
+  )
+
+  # iOS-specific frameworks for AUv3
+  target_link_libraries(iPlug2::AUv3iOS INTERFACE
+    "-framework AudioToolbox"
+    "-framework AVFoundation"
+    "-framework CoreAudioKit"
+    "-framework CoreMIDI"
+    "-framework UIKit"
+    "-framework QuartzCore"
+    "-framework CoreText"
+    "-framework CoreGraphics"
+    "-framework UniformTypeIdentifiers"
+    iPlug2::IPlug
+  )
+endif()
+
+# ============================================================================
+# Get or generate the appex source file for iOS
+# Returns the path in APPEX_SOURCE_OUT variable
+# ============================================================================
+function(iplug_get_auv3ios_appex_source project_name APPEX_SOURCE_OUT)
+  # Check for existing appex source with either naming convention
+  if(EXISTS "${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m")
+    set(${APPEX_SOURCE_OUT} "${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m" PARENT_SCOPE)
+  else()
+    # Generate a minimal appex source file
+    set(GENERATED_APPEX "${CMAKE_CURRENT_BINARY_DIR}/${project_name}AUv3Appex-iOS.m")
+    file(WRITE ${GENERATED_APPEX}
+"// Auto-generated AUv3 appex source for iOS
+#import <Foundation/Foundation.h>
+// Dummy function to ensure linking
+void AUv3iOSAppexDummy(void) {}
+")
+    set(${APPEX_SOURCE_OUT} "${GENERATED_APPEX}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# ============================================================================
+# Embed AUv3 appex and framework in an existing iOS APP target
+# iOS structure: framework at App/Frameworks/, appex at App/PlugIns/
+# (Note: iOS uses flat bundle structure, not Contents/ like macOS)
+# ============================================================================
+function(iplug_embed_auv3ios_in_app app_target project_name)
+  set(appex_target ${project_name}AUv3-ios-appex)
+  set(framework_target ${project_name}AU-ios-framework)
+
+  add_dependencies(${app_target} ${appex_target})
+
+  # Post-build: Embed framework and appex in iOS app bundle
+  # iOS bundles have flat structure (no Contents/ directory)
+  if(XCODE)
+    add_custom_command(TARGET ${app_target} POST_BUILD
+      # Copy framework to App/Frameworks/ (preserving structure)
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Frameworks"
+      COMMAND cp -R
+        "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AU.framework"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Frameworks/"
+      # Copy appex to App/PlugIns/
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/PlugIns"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AUv3.appex"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/PlugIns/${project_name}AUv3.appex"
+      COMMENT "Embedding iOS AUv3 (framework + appex) in ${project_name}.app"
+    )
+  else()
+    add_custom_command(TARGET ${app_target} POST_BUILD
+      # Copy framework to App/Frameworks/
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Frameworks"
+      COMMAND cp -R
+        "${CMAKE_BINARY_DIR}/out/${project_name}AU.framework"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/Frameworks/"
+      # Copy appex to App/PlugIns/
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_BUNDLE_DIR:${app_target}>/PlugIns"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+        "$<TARGET_BUNDLE_DIR:${app_target}>/PlugIns/${project_name}AUv3.appex"
+      COMMENT "Embedding iOS AUv3 (framework + appex) in ${project_name}.app"
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3iOSAppex.cmake
+++ b/Scripts/cmake/AUv3iOSAppex.cmake
@@ -1,0 +1,108 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 Appex target configuration for iPlug2 iOS
+# The appex is an app extension (executable) that hosts the framework
+
+include(${CMAKE_CURRENT_LIST_DIR}/AUv3iOS.cmake)
+
+function(iplug_configure_auv3iosappex target project_name)
+  set(framework_target ${project_name}AU-ios-framework)
+
+  # Appex is an app bundle (executable) with .appex extension
+  # Uses NSExtensionMain entry point from Foundation
+  # For Ninja: Use separate output dir to avoid collision with APP target
+  if(XCODE)
+    set(APPEX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+  else()
+    set(APPEX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out/appex-build")
+  endif()
+
+  set_target_properties(${target} PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-iOS-AUv3-Info.plist
+    RUNTIME_OUTPUT_DIRECTORY "${APPEX_OUTPUT_DIR}"
+    OUTPUT_NAME "${project_name}AppExtension"
+    # iOS-specific Xcode attributes
+    XCODE_ATTRIBUTE_WRAPPER_EXTENSION "appex"
+    XCODE_PRODUCT_TYPE "com.apple.product-type.app-extension"
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.${project_name}.AUv3"
+    XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY "YES"
+  )
+
+  # Use NSExtensionMain as entry point (provided by Foundation)
+  # Add rpath to find framework at App/Frameworks/ (one level up from appex in PlugIns/)
+  # iOS bundle structure: App/PlugIns/appex -> App/Frameworks/
+  target_link_options(${target} PRIVATE
+    "-e" "_NSExtensionMain"
+    "-Wl,-rpath,@executable_path/../../Frameworks"
+  )
+
+  # Appex links to the framework binary at build time
+  # At runtime, it finds the framework via rpath in the host app
+  add_dependencies(${target} ${framework_target})
+
+  # Link to the framework
+  target_link_libraries(${target} PRIVATE
+    "$<TARGET_FILE:${framework_target}>"
+    "-framework Foundation"
+  )
+
+  # Enable ARC for appex source
+  set(APPEX_SOURCE ${PLUG_RESOURCES_DIR}/${project_name}AUv3Appex.m)
+  if(EXISTS ${APPEX_SOURCE})
+    set_source_files_properties(${APPEX_SOURCE}
+      PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+    )
+  endif()
+
+  # Post-build: Create PkgInfo and rename bundle
+  set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+  file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"XPC!????\")")
+
+  if(XCODE)
+    # For Xcode: XCODE_ATTRIBUTE_WRAPPER_EXTENSION creates .appex bundle directly
+    # Bundle is created as ${project_name}AppExtension.appex, we rename to ${project_name}AUv3.appex
+    set(APPEX_BUNDLE "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AppExtension.appex")
+    set(APPEX_FINAL "${CMAKE_BINARY_DIR}/out/$<CONFIG>/${project_name}AUv3.appex")
+    add_custom_command(TARGET ${target} POST_BUILD
+      # Create PkgInfo
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="${APPEX_BUNDLE}/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      # Rename bundle to final name with AUv3 suffix
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${APPEX_FINAL}"
+      COMMAND ${CMAKE_COMMAND} -E rename
+        "${APPEX_BUNDLE}"
+        "${APPEX_FINAL}"
+      # Copy Info.plist from source (Xcode may regenerate original bundle after rename)
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${PLUG_RESOURCES_DIR}/${project_name}-iOS-AUv3-Info.plist"
+        "${APPEX_FINAL}/Info.plist"
+      COMMENT "Building ${project_name}AUv3.appex (iOS)"
+    )
+  else()
+    # For Ninja/other generators: Convert .app to .appex and move to final location
+    add_custom_command(TARGET ${target} POST_BUILD
+      # Create PkgInfo
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      # Copy Info.plist
+      COMMAND ${CMAKE_COMMAND} -E copy
+        "${PLUG_RESOURCES_DIR}/${project_name}-iOS-AUv3-Info.plist"
+        "$<TARGET_BUNDLE_DIR:${target}>/Info.plist"
+      # Move and rename .app bundle to .appex in final location
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+      COMMAND ${CMAKE_COMMAND} -E rename
+        "$<TARGET_BUNDLE_DIR:${target}>"
+        "${CMAKE_BINARY_DIR}/out/${project_name}AUv3.appex"
+      COMMENT "Building ${project_name}AUv3.appex (iOS)"
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/AUv3iOSFramework.cmake
+++ b/Scripts/cmake/AUv3iOSFramework.cmake
@@ -1,0 +1,151 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# AUv3 Framework target configuration for iPlug2 iOS
+# The framework contains the actual plugin code and is loaded in-process
+
+include(${CMAKE_CURRENT_LIST_DIR}/AUv3iOS.cmake)
+
+function(iplug_configure_auv3iosframework target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::AUv3iOS)
+
+  # Define OBJC_PREFIX for ObjC class name mangling (must match storyboard customClass)
+  # Applied to all languages since Xcode doesn't properly handle OBJC/OBJCXX generator expressions
+  target_compile_definitions(${target} PRIVATE OBJC_PREFIX=v${project_name})
+
+  # AUv3 requires ARC for its Objective-C++ sources
+  set(AUV3_SOURCES
+    ${IPLUG_DIR}/AUv3/IPlugAUv3.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.mm
+  )
+  set_source_files_properties(${AUV3_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  # IGraphics sources that require ARC
+  # Note: IGraphicsIOS.mm does NOT use ARC (uses manual release), only the view does
+  set(IGRAPHICS_DIR ${IPLUG2_DIR}/IGraphics)
+  set(IGRAPHICS_ARC_SOURCES
+    ${IGRAPHICS_DIR}/Drawing/IGraphicsNanoVG_src.m
+    ${IGRAPHICS_DIR}/Platforms/IGraphicsIOS_view.mm
+  )
+  set_source_files_properties(${IGRAPHICS_ARC_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  # Generate Info.plist with correct executable name
+  set(FRAMEWORK_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${project_name}-iOS-AUv3Framework-Info.plist")
+  file(WRITE ${FRAMEWORK_PLIST}
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>${project_name}AU</string>
+	<key>CFBundleExecutable</key>
+	<string>${project_name}AU</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.AcmeInc.${project_name}.AUv3Framework</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${project_name}AU</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+</dict>
+</plist>
+")
+
+  set_target_properties(${target} PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION A
+    MACOSX_FRAMEWORK_INFO_PLIST ${FRAMEWORK_PLIST}
+    OUTPUT_NAME "${project_name}AU"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+    # iOS framework settings
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    XCODE_ATTRIBUTE_APPLICATION_EXTENSION_API_ONLY "YES"
+    XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+    XCODE_ATTRIBUTE_DEFINES_MODULE "YES"
+    XCODE_ATTRIBUTE_DYLIB_INSTALL_NAME_BASE "@rpath"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.${project_name}.AUv3Framework"
+  )
+
+  # Create PkgInfo file for framework bundle (FMWK = framework)
+  set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+  file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"FMWK????\")")
+
+  if(XCODE)
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      COMMENT "Creating PkgInfo for ${project_name}AU.framework (iOS)"
+    )
+  else()
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/PkgInfo"
+        -P "${PKGINFO_SCRIPT}"
+      COMMENT "Creating PkgInfo for ${project_name}AU.framework (iOS)"
+    )
+  endif()
+
+  # Add headers to framework (umbrella + public headers)
+  # Check for umbrella header - support both naming conventions
+  if(EXISTS "${PLUG_RESOURCES_DIR}/${project_name}AU.h")
+    set(UMBRELLA_HEADER "${PLUG_RESOURCES_DIR}/${project_name}AU.h")
+  elseif(EXISTS "${PLUG_RESOURCES_DIR}/AUv3Framework.h")
+    set(UMBRELLA_HEADER "${PLUG_RESOURCES_DIR}/AUv3Framework.h")
+  else()
+    message(WARNING "No AUv3 umbrella header found for ${project_name}")
+    set(UMBRELLA_HEADER "")
+  endif()
+
+  set(FRAMEWORK_HEADERS
+    ${UMBRELLA_HEADER}
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.h
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.h
+  )
+  target_sources(${target} PRIVATE ${FRAMEWORK_HEADERS})
+  set_source_files_properties(${FRAMEWORK_HEADERS}
+    PROPERTIES MACOSX_PACKAGE_LOCATION Headers
+  )
+
+  # Compile storyboard to storyboardc and add to framework Resources
+  # iOS uses storyboards instead of XIBs
+  set(AU_VIEW_STORYBOARD ${PLUG_RESOURCES_DIR}/${project_name}-iOS-MainInterface.storyboard)
+  if(EXISTS ${AU_VIEW_STORYBOARD})
+    set(AU_VIEW_STORYBOARDC ${CMAKE_CURRENT_BINARY_DIR}/${project_name}-iOS-MainInterface.storyboardc)
+    add_custom_command(
+      OUTPUT ${AU_VIEW_STORYBOARDC}
+      COMMAND ibtool --compile ${AU_VIEW_STORYBOARDC} ${AU_VIEW_STORYBOARD}
+        ${IPLUG2_IBTOOL_TARGET_DEVICES}
+      DEPENDS ${AU_VIEW_STORYBOARD}
+      COMMENT "Compiling ${project_name}-iOS-MainInterface.storyboard"
+    )
+    # For Xcode, set the storyboard as a resource that gets compiled automatically
+    if(XCODE)
+      target_sources(${target} PRIVATE ${AU_VIEW_STORYBOARD})
+      set_source_files_properties(${AU_VIEW_STORYBOARD} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    else()
+      # For other generators, use the compiled storyboardc
+      target_sources(${target} PRIVATE ${AU_VIEW_STORYBOARDC})
+      set_source_files_properties(${AU_VIEW_STORYBOARDC} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/CLAP.cmake
+++ b/Scripts/cmake/CLAP.cmake
@@ -1,0 +1,134 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# CLAP target configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::CLAP)
+  # Define SDK paths
+  set(CLAP_SDK_DIR ${IPLUG_DEPS_DIR}/CLAP_SDK)
+  set(CLAP_HELPERS_DIR ${IPLUG_DEPS_DIR}/CLAP_HELPERS)
+
+  # Check if CLAP SDK exists (must have include dir, not just placeholder)
+  if(NOT EXISTS ${CLAP_SDK_DIR}/include)
+    message(STATUS "CLAP SDK not found at ${CLAP_SDK_DIR}. CLAP targets will not be available.")
+    set(IPLUG2_CLAP_SUPPORTED FALSE CACHE INTERNAL "CLAP SDK available")
+    # Create a dummy iPlug2::CLAP target so projects can link to it without errors
+    add_library(iPlug2::CLAP INTERFACE IMPORTED)
+    # Define stub function that excludes the target from default build
+    function(iplug_configure_clap target project_name)
+      message(STATUS "Skipping CLAP target '${target}' - CLAP SDK not available")
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endfunction()
+    return()
+  endif()
+
+  if(NOT EXISTS ${CLAP_HELPERS_DIR}/include)
+    message(STATUS "CLAP helpers not found at ${CLAP_HELPERS_DIR}. CLAP targets will not be available.")
+    set(IPLUG2_CLAP_SUPPORTED FALSE CACHE INTERNAL "CLAP SDK available")
+    add_library(iPlug2::CLAP INTERFACE IMPORTED)
+    function(iplug_configure_clap target project_name)
+      message(STATUS "Skipping CLAP target '${target}' - CLAP helpers not available")
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endfunction()
+    return()
+  endif()
+
+  set(IPLUG2_CLAP_SUPPORTED TRUE CACHE INTERNAL "CLAP SDK available")
+
+  add_library(iPlug2::CLAP INTERFACE IMPORTED)
+
+  # iPlug2 CLAP wrapper sources
+  set(CLAP_IPLUG_SRC
+    ${IPLUG_DIR}/CLAP/IPlugCLAP.cpp
+  )
+
+  target_sources(iPlug2::CLAP INTERFACE ${CLAP_IPLUG_SRC})
+
+  target_include_directories(iPlug2::CLAP INTERFACE
+    ${IPLUG_DIR}/CLAP
+    ${CLAP_SDK_DIR}/include
+    ${CLAP_HELPERS_DIR}/include
+    ${CLAP_HELPERS_DIR}/include/clap/helpers
+  )
+
+  target_compile_definitions(iPlug2::CLAP INTERFACE
+    CLAP_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  if(WIN32)
+    # Windows CLAP support
+    # No additional sources needed - CLAP SDK is header-only
+  elseif(APPLE)
+    # Set Obj-C++ for iPlug2 CLAP wrapper on macOS
+    set_source_files_properties(${CLAP_IPLUG_SRC} PROPERTIES LANGUAGE OBJCXX)
+
+    target_link_libraries(iPlug2::CLAP INTERFACE
+      "-framework Cocoa"
+    )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    # WASM/Emscripten support - for future use
+    # CLAP SDK is header-only and works on WASM
+    # Build as STATIC library with --no-entry linker option
+  elseif(UNIX AND NOT APPLE)
+    # Linux support - to be added later
+    message(WARNING "CLAP Linux support not yet implemented")
+  endif()
+
+  target_link_libraries(iPlug2::CLAP INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for CLAP targets
+function(iplug_configure_clap target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::CLAP)
+
+  if(WIN32)
+    set(CLAP_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      SUFFIX ".clap"
+      LIBRARY_OUTPUT_DIRECTORY "${CLAP_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CLAP_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CLAP_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CLAP_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${CLAP_OUTPUT_DIR}"
+    )
+  elseif(APPLE)
+    # CLAP on macOS is a bundle with .clap extension
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "clap"
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-CLAP-Info.plist
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      MACOSX_BUNDLE_BUNDLE_NAME "${project_name}"
+      OUTPUT_NAME "${project_name}"
+      XCODE_ATTRIBUTE_WRAPPER_EXTENSION "clap"
+      XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
+    )
+
+    # For non-Xcode generators (e.g., Ninja), create PkgInfo file manually
+    if(NOT XCODE)
+      set(PKGINFO_PATH "${CMAKE_BINARY_DIR}/out/${project_name}.clap/Contents/PkgInfo")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.clap/Contents"
+        COMMAND ${CMAKE_COMMAND} -E copy "${IPLUG2_PKGINFO_FILE}" "${PKGINFO_PATH}"
+        COMMENT "Creating PkgInfo for ${project_name}.clap"
+      )
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    # WASM/Emscripten: Use --no-entry linker option
+    target_link_options(${target} PRIVATE --no-entry)
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      SUFFIX ".clap"
+    )
+  endif()
+endfunction()

--- a/Scripts/cmake/Deploy.cmake
+++ b/Scripts/cmake/Deploy.cmake
@@ -1,0 +1,298 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for more info.
+#
+#  ==============================================================================
+
+# Plugin deployment configuration for iPlug2
+# Supports symlink and copy deployment to standard system directories
+
+#------------------------------------------------------------------------
+# Options
+#------------------------------------------------------------------------
+option(IPLUG_DEPLOY_PLUGINS "Deploy built plugins to system directories" ON)
+
+set(IPLUG_DEPLOY_METHOD "COPY" CACHE STRING "Deployment method: SYMLINK or COPY")
+set_property(CACHE IPLUG_DEPLOY_METHOD PROPERTY STRINGS "SYMLINK" "COPY")
+
+# User-overridable paths (empty = use platform default)
+set(IPLUG_VST2_DEPLOY_PATH "" CACHE PATH "Override default VST2 deployment path")
+set(IPLUG_VST3_DEPLOY_PATH "" CACHE PATH "Override default VST3 deployment path")
+set(IPLUG_CLAP_DEPLOY_PATH "" CACHE PATH "Override default CLAP deployment path")
+set(IPLUG_AU_DEPLOY_PATH "" CACHE PATH "Override default AU deployment path")
+set(IPLUG_AAX_DEPLOY_PATH "" CACHE PATH "Override default AAX deployment path")
+set(IPLUG_APP_DEPLOY_PATH "" CACHE PATH "Override default APP deployment path")
+set(IPLUG_REAPEREXT_DEPLOY_PATH "" CACHE PATH "Override default REAPER extension deployment path")
+
+#------------------------------------------------------------------------
+# iplug_get_default_deploy_path
+# Get the default deployment path for a plugin format
+# Sets IPLUG_DEPLOY_PATH_${format} in parent scope
+#
+# @param format  Plugin format: VST2, VST3, CLAP, AU, AAX, APP, REAPEREXT
+#------------------------------------------------------------------------
+function(iplug_get_default_deploy_path format)
+  # Check for user override first
+  if(NOT "${IPLUG_${format}_DEPLOY_PATH}" STREQUAL "")
+    set(IPLUG_DEPLOY_PATH_${format} "${IPLUG_${format}_DEPLOY_PATH}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(APPLE)
+    if(format STREQUAL "VST2")
+      set(default_path "$ENV{HOME}/Library/Audio/Plug-Ins/VST")
+    elseif(format STREQUAL "VST3")
+      set(default_path "$ENV{HOME}/Library/Audio/Plug-Ins/VST3")
+    elseif(format STREQUAL "CLAP")
+      set(default_path "$ENV{HOME}/Library/Audio/Plug-Ins/CLAP")
+    elseif(format STREQUAL "AU" OR format STREQUAL "AUv2")
+      set(default_path "$ENV{HOME}/Library/Audio/Plug-Ins/Components")
+    elseif(format STREQUAL "AAX")
+      set(default_path "/Library/Application Support/Avid/Audio/Plug-Ins")
+    elseif(format STREQUAL "APP")
+      set(default_path "$ENV{HOME}/Applications")
+    elseif(format STREQUAL "REAPEREXT")
+      set(default_path "$ENV{HOME}/Library/Application Support/REAPER/UserPlugins")
+    else()
+      message(WARNING "[iPlug2] Unknown plugin format: ${format}")
+      return()
+    endif()
+  elseif(WIN32)
+    if(format STREQUAL "VST2")
+      set(default_path "$ENV{PROGRAMFILES}/VstPlugins")
+    elseif(format STREQUAL "VST3")
+      set(default_path "$ENV{LOCALAPPDATA}/Programs/Common/VST3")
+    elseif(format STREQUAL "CLAP")
+      set(default_path "$ENV{LOCALAPPDATA}/Programs/Common/CLAP")
+    elseif(format STREQUAL "AU" OR format STREQUAL "AUv2")
+      # AU not supported on Windows
+      return()
+    elseif(format STREQUAL "AAX")
+      set(default_path "$ENV{PROGRAMFILES}/Common Files/Avid/Audio/Plug-Ins")
+    elseif(format STREQUAL "APP")
+      # Leave APP in build directory on Windows
+      set(default_path "")
+    elseif(format STREQUAL "REAPEREXT")
+      set(default_path "$ENV{APPDATA}/REAPER/UserPlugins")
+    else()
+      message(WARNING "[iPlug2] Unknown plugin format: ${format}")
+      return()
+    endif()
+  elseif(UNIX AND NOT APPLE)
+    # Linux
+    if(format STREQUAL "VST2")
+      set(default_path "$ENV{HOME}/.vst")
+    elseif(format STREQUAL "VST3")
+      set(default_path "$ENV{HOME}/.vst3")
+    elseif(format STREQUAL "CLAP")
+      set(default_path "$ENV{HOME}/.clap")
+    elseif(format STREQUAL "AU" OR format STREQUAL "AUv2")
+      # AU not supported on Linux
+      return()
+    elseif(format STREQUAL "APP")
+      # Leave APP in build directory on Linux
+      set(default_path "")
+    else()
+      message(WARNING "[iPlug2] Unknown plugin format: ${format}")
+      return()
+    endif()
+  endif()
+
+  set(IPLUG_DEPLOY_PATH_${format} "${default_path}" PARENT_SCOPE)
+endfunction()
+
+#------------------------------------------------------------------------
+# _iplug_create_plugin_link (internal)
+# Create symlink from built plugin to destination
+#
+# @param target       The CMake target
+# @param source_path  Full path to built plugin (or generator expression)
+# @param dest_dir     Destination directory
+# @param plugin_name  Name of the plugin file/bundle
+#------------------------------------------------------------------------
+function(_iplug_create_plugin_link target source_path dest_dir plugin_name)
+  set(dest_path "${dest_dir}/${plugin_name}")
+
+  if(WIN32)
+    # Windows symlink handling
+    # Note: Requires Developer Mode or admin privileges on Windows 10+
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E echo "[iPlug2] Creating symlink: ${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${dest_dir}"
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E create_symlink "${source_path}" "${dest_path}"
+      COMMENT "[iPlug2] Deploying ${plugin_name} (symlink)"
+    )
+  else()
+    # macOS/Linux symlink using ln for better compatibility with bundles
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E echo "[iPlug2] Creating symlink: ${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${dest_dir}"
+      COMMAND rm -rf "${dest_path}"
+      COMMAND ln -sfv "${source_path}" "${dest_path}"
+      COMMENT "[iPlug2] Deploying ${plugin_name} (symlink)"
+    )
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------
+# _iplug_copy_plugin (internal)
+# Copy built plugin to destination
+#
+# @param target       The CMake target
+# @param source_path  Full path to built plugin (or generator expression)
+# @param dest_dir     Destination directory
+# @param plugin_name  Name of the plugin file/bundle
+# @param is_bundle    TRUE if plugin is a directory/bundle, FALSE if single file
+#------------------------------------------------------------------------
+function(_iplug_copy_plugin target source_path dest_dir plugin_name is_bundle)
+  set(dest_path "${dest_dir}/${plugin_name}")
+
+  if(is_bundle)
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E echo "[iPlug2] Copying plugin: ${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${dest_dir}"
+      COMMAND ${CMAKE_COMMAND} -E rm -rf "${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory "${source_path}" "${dest_path}"
+      COMMENT "[iPlug2] Deploying ${plugin_name} (copy)"
+    )
+  else()
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E echo "[iPlug2] Copying plugin: ${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${dest_dir}"
+      COMMAND ${CMAKE_COMMAND} -E rm -f "${dest_path}"
+      COMMAND ${CMAKE_COMMAND} -E copy "${source_path}" "${dest_path}"
+      COMMENT "[iPlug2] Deploying ${plugin_name} (copy)"
+    )
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------
+# iplug_deploy_target
+# Deploy a plugin target to its system directory
+# Creates symlink or copies based on IPLUG_DEPLOY_METHOD
+#
+# @param target       The CMake target for the plugin
+# @param format       Plugin format: VST3, CLAP, AU, APP
+# @param project_name The plugin name (used for the bundle/file name)
+#------------------------------------------------------------------------
+function(iplug_deploy_target target format project_name)
+  if(NOT IPLUG_DEPLOY_PLUGINS)
+    return()
+  endif()
+
+  # Get deployment path
+  iplug_get_default_deploy_path(${format})
+  set(deploy_path "${IPLUG_DEPLOY_PATH_${format}}")
+
+  if("${deploy_path}" STREQUAL "")
+    message(STATUS "[iPlug2] No deployment path for ${format} on this platform, skipping")
+    return()
+  endif()
+
+  # Determine plugin file/bundle name, extension, and whether it's a bundle or single file
+  # is_bundle: TRUE for directory bundles (macOS bundles, VST3 bundles), FALSE for single files
+  set(is_bundle TRUE)
+  if(format STREQUAL "VST2")
+    if(APPLE)
+      set(plugin_name "${project_name}.vst")
+    else()
+      set(plugin_name "${project_name}.dll")
+      set(is_bundle FALSE)
+    endif()
+  elseif(format STREQUAL "VST3")
+    set(plugin_name "${project_name}.vst3")
+    # VST3 is a bundle on all platforms
+  elseif(format STREQUAL "CLAP")
+    set(plugin_name "${project_name}.clap")
+    # CLAP is a bundle on macOS, single file on Windows/Linux
+    if(NOT APPLE)
+      set(is_bundle FALSE)
+    endif()
+  elseif(format STREQUAL "AU" OR format STREQUAL "AUv2")
+    set(plugin_name "${project_name}.component")
+  elseif(format STREQUAL "AAX")
+    set(plugin_name "${project_name}.aaxplugin")
+    # AAX is always a bundle
+  elseif(format STREQUAL "APP")
+    if(APPLE)
+      set(plugin_name "${project_name}.app")
+    else()
+      set(plugin_name "${project_name}")
+      set(is_bundle FALSE)
+    endif()
+  elseif(format STREQUAL "REAPEREXT")
+    if(APPLE)
+      set(plugin_name "${project_name}.dylib")
+    else()
+      set(plugin_name "${project_name}.dll")
+    endif()
+    set(is_bundle FALSE)
+  else()
+    message(WARNING "[iPlug2] Unknown format ${format} for deployment")
+    return()
+  endif()
+
+  # Get source path - handle both Xcode and Ninja/Make generators
+  if(CMAKE_GENERATOR MATCHES "Xcode")
+    # Xcode: use generator expression that resolves at build time
+    # REAPEREXT is a dylib (not a bundle), so use TARGET_FILE instead
+    if(format STREQUAL "REAPEREXT")
+      set(source_path "$<TARGET_FILE:${target}>")
+    else()
+      set(source_path "$<TARGET_BUNDLE_DIR:${target}>")
+    endif()
+  else()
+    # Ninja/Make: plugin is in CMAKE_BINARY_DIR/out
+    set(source_path "${CMAKE_BINARY_DIR}/out/${plugin_name}")
+  endif()
+
+  message(STATUS "[iPlug2] Will deploy ${target} to ${deploy_path} using ${IPLUG_DEPLOY_METHOD}")
+
+  # Create deployment command based on method
+  if(IPLUG_DEPLOY_METHOD STREQUAL "COPY")
+    _iplug_copy_plugin(${target} "${source_path}" "${deploy_path}" "${plugin_name}" ${is_bundle})
+  else()
+    # Default to SYMLINK
+    _iplug_create_plugin_link(${target} "${source_path}" "${deploy_path}" "${plugin_name}")
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------
+# iplug_deploy_all
+# Deploy all plugin formats for a project
+# Call this after all targets are configured
+#
+# @param project_name  The project name (used to find targets)
+# @param FORMATS       List of formats to deploy (VST3, CLAP, AU, APP)
+#------------------------------------------------------------------------
+function(iplug_deploy_all project_name)
+  cmake_parse_arguments(PARSE_ARGV 1 DEPLOY "" "" "FORMATS")
+
+  if(NOT DEPLOY_FORMATS)
+    # Default to all common formats
+    set(DEPLOY_FORMATS VST3 CLAP)
+    if(APPLE)
+      list(APPEND DEPLOY_FORMATS AU APP)
+    endif()
+  endif()
+
+  foreach(format ${DEPLOY_FORMATS})
+    # Construct target name based on common naming convention
+    string(TOLOWER ${format} format_lower)
+    set(target_name "${project_name}-${format_lower}")
+
+    # Handle AU special case (target is -au, format is AU or AUv2)
+    if(format STREQUAL "AUv2")
+      set(target_name "${project_name}-au")
+    endif()
+
+    if(TARGET ${target_name})
+      iplug_deploy_target(${target_name} ${format} ${project_name})
+    else()
+      message(STATUS "[iPlug2] Target ${target_name} not found, skipping deployment")
+    endif()
+  endforeach()
+endfunction()

--- a/Scripts/cmake/FindIPlug2.cmake
+++ b/Scripts/cmake/FindIPlug2.cmake
@@ -1,0 +1,285 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# FindiPlug2.cmake
+# This module finds the iPlug2 library and sets up the necessary variables and targets.
+
+# Include the files that defined the iPlug2 components
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/IGraphics.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/Deploy.cmake)
+
+# Include plugin format modules to set up targets and availability checks
+# These are included early so that iPlug2::* targets exist when projects link to them
+include(${CMAKE_CURRENT_LIST_DIR}/VST2.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/VST3.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/CLAP.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/AAX.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/APP.cmake)
+
+# Include iOS platform configuration if building for iOS or visionOS
+if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|visionOS)$")
+  include(${CMAKE_CURRENT_LIST_DIR}/iOS.cmake)
+endif()
+
+# Include AUv3 helper functions (macOS only)
+if(APPLE AND NOT IOS)
+  include(${CMAKE_CURRENT_LIST_DIR}/AUv3.cmake)
+endif()
+
+# Include iOS AUv3 helper functions (iOS/visionOS only)
+if(IOS)
+  include(${CMAKE_CURRENT_LIST_DIR}/AUv3iOS.cmake)
+endif()
+
+# Include WAM/Web modules for Emscripten builds
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  include(${CMAKE_CURRENT_LIST_DIR}/WAM.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/Web.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/WAMDist.cmake)
+endif()
+
+# Include the plugin helper macro (iplug_add_plugin)
+include(${CMAKE_CURRENT_LIST_DIR}/IPlugPlugin.cmake)
+
+# Set up the iPlug2 package
+set(IPLUG2_FOUND TRUE)
+
+# Define the components of iPlug2
+set(IPLUG2_COMPONENTS IPlug IGraphics)
+
+# Check which components were requested
+foreach(component ${IPLUG2_FIND_COMPONENTS})
+  if(NOT component IN_LIST IPLUG2_COMPONENTS)
+    set(IPLUG2_FOUND FALSE)
+    set(IPLUG2_NOT_FOUND_MESSAGE "Unsupported component: ${component}")
+  endif()
+endforeach()
+
+# If no components were explicitly requested, assume all are wanted
+if(NOT IPLUG2_FIND_COMPONENTS)
+  set(IPLUG2_FIND_COMPONENTS ${IPLUG2_COMPONENTS})
+endif()
+
+# Verify that requested components are available
+foreach(component ${IPLUG2_FIND_COMPONENTS})
+  if(NOT TARGET iPlug2::${component})
+    set(IPLUG2_${component}_FOUND FALSE)
+    if(IPLUG2_FIND_REQUIRED_${component})
+      set(IPLUG2_FOUND FALSE)
+      list(APPEND IPLUG2_NOT_FOUND_MESSAGE "Required component '${component}' is missing.")
+    endif()
+  else()
+    set(IPLUG2_${component}_FOUND TRUE)
+  endif()
+endforeach()
+
+# Report the result of the package search
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(iPlug2
+  REQUIRED_VARS IPLUG2_DIR
+  FAIL_MESSAGE "iPlug2 not found. Please set IPLUG2_DIR to the root directory of iPlug2."
+)
+
+# If found, set up an overall iPlug2 interface target
+if(IPLUG2_FOUND AND NOT TARGET iPlug2::iPlug2)
+  add_library(iPlug2::iPlug2 INTERFACE IMPORTED)
+  target_link_libraries(iPlug2::iPlug2 INTERFACE iPlug2::IPlug)
+endif()
+
+# Helper function to set up a target (app, plug-in etc)
+function(iplug_add_target target visibility)
+  cmake_parse_arguments(PARSE_ARGV 2 CONFIG
+    ""
+    ""
+    "INCLUDE;SOURCE;DEFINE;OPTION;LINK;LINK_DIR;DEPEND;FEATURE;RESOURCE"
+  )
+
+  if(CONFIG_INCLUDE)
+    target_include_directories(${target} ${visibility} ${CONFIG_INCLUDE})
+  endif()
+  
+  if(CONFIG_SOURCE)
+    target_sources(${target} ${visibility} ${CONFIG_SOURCE})
+  endif()
+  
+  if(CONFIG_DEFINE)
+    target_compile_definitions(${target} ${visibility} ${CONFIG_DEFINE})
+  endif()
+  
+  if(CONFIG_OPTION)
+    target_compile_options(${target} ${visibility} ${CONFIG_OPTION})
+  endif()
+  
+  if(CONFIG_LINK)
+    target_link_libraries(${target} ${visibility} ${CONFIG_LINK})
+  endif()
+  
+  if(CONFIG_LINK_DIR)
+    target_link_directories(${target} ${visibility} ${CONFIG_LINK_DIR})
+  endif()
+  
+  if(CONFIG_DEPEND)
+    add_dependencies(${target} ${CONFIG_DEPEND})
+  endif()
+  
+  if(CONFIG_FEATURE)
+    target_compile_features(${target} ${visibility} ${CONFIG_FEATURE})
+  endif()
+  
+  if(CONFIG_RESOURCE)
+    set_target_properties(${target} PROPERTIES RESOURCE "${CONFIG_RESOURCE}")
+  endif()
+
+  if(CONFIG_UNPARSED_ARGUMENTS)
+    message(WARNING "Unused arguments: ${CONFIG_UNPARSED_ARGUMENTS}")
+  endif()
+endfunction()
+
+# Helper function to apply the ObjC prefix header to a target
+# This ensures all ObjC/ObjC++ sources use the namespaced class names.
+# Uses -include flag for all generators (including Xcode) for reliability.
+# Note: We avoid GCC_PRECOMPILE_PREFIX_HEADER=YES because Xcode's shared PCH
+# mechanism can fail in CI environments with parallel builds.
+function(iplug_apply_objc_prefix_header target)
+  if(NOT APPLE)
+    return()
+  endif()
+
+  # Force-include the prefix header on ObjC/ObjC++ sources
+  # The Xcode generator doesn't always properly map COMPILE_LANGUAGE:OBJCXX to
+  # OTHER_CPLUSPLUSFLAGS, so we apply to all C-family languages.
+  # The prefix header is guarded by #ifdef __OBJC__ so it's safe for C/C++ files.
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:C>:SHELL:-include ${IPLUG_DIR}/IPlugOBJCPrefix.pch>"
+    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include ${IPLUG_DIR}/IPlugOBJCPrefix.pch>"
+    "$<$<COMPILE_LANGUAGE:OBJC>:SHELL:-include ${IPLUG_DIR}/IPlugOBJCPrefix.pch>"
+    "$<$<COMPILE_LANGUAGE:OBJCXX>:SHELL:-include ${IPLUG_DIR}/IPlugOBJCPrefix.pch>"
+  )
+endfunction()
+
+# Helper function to configure a target based on its type
+function(iplug_configure_target target target_type project_name)
+  set(SUPPORTED_TYPES
+    APP
+    VST2
+    VST3
+    CLAP
+    AUv2
+    AAX
+    AUv3Framework
+    AUv3Appex
+    # iOS targets
+    IOSApp
+    AUv3iOSFramework
+    AUv3iOSAppex
+    # Web/Emscripten targets
+    WAM
+    Web
+  )
+
+  if(NOT ${target_type} IN_LIST SUPPORTED_TYPES)
+    message(FATAL_ERROR "Unsupported target type '${target_type}' for target '${target}'")
+  endif()
+
+  set_target_properties(${target} PROPERTIES
+    CXX_STANDARD ${IPLUG2_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+  )
+
+  # Set unique OBJC_PREFIX per target to avoid namespace conflicts when
+  # a DAW loads multiple plugin formats of the same plugin simultaneously.
+  # The API suffix (_vst3, _au, etc.) is added by IPlugOBJCPrefix.pch based on
+  # the format-specific API defines (VST3_API, AU_API, etc.)
+  if(APPLE)
+    target_compile_definitions(${target} PRIVATE OBJC_PREFIX=v${project_name})
+
+    # Prevent Xcode from combining @1x/@2x PNGs into TIFF files
+    # IPlug expects the original PNG filenames at runtime
+    set_target_properties(${target} PROPERTIES
+      XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "NO"
+    )
+
+    # Apply the ObjC prefix header (works for both Xcode and non-Xcode generators)
+    iplug_apply_objc_prefix_header(${target})
+
+    # Configure WebView sources if present (requires ARC)
+    # This handles targets that link to iPlug2::Extras::IWebViewControl
+    if(DEFINED IPLUG2_WEBVIEW_MAC_SOURCE)
+      iplug_configure_webview_sources(${target})
+    endif()
+  endif()
+
+  # Include and configure based on target type
+  include("${IPLUG2_CMAKE_DIR}/${target_type}.cmake")
+
+  string(TOLOWER ${target_type} lowercase_type)
+  string(REPLACE "_" "-" function_suffix ${lowercase_type})
+  cmake_language(CALL iplug_configure_${function_suffix} ${target} ${project_name})
+
+  # Auto-deploy main plugin formats (skip AUv3 intermediate targets)
+  set(DEPLOYABLE_TYPES APP VST2 VST3 CLAP AUv2 AAX)
+  if(${target_type} IN_LIST DEPLOYABLE_TYPES)
+    iplug_deploy_target(${target} ${target_type} ${project_name})
+  endif()
+
+  # Debuggable plugin types
+  set(DEBUGGABLE_TYPES "")
+  if(IPLUG2_VST2_SUPPORTED)
+    list(APPEND DEBUGGABLE_TYPES VST2)
+  endif()
+  if(IPLUG2_VST3_SUPPORTED)
+    list(APPEND DEBUGGABLE_TYPES VST3)
+  endif()
+  if(IPLUG2_CLAP_SUPPORTED)
+    list(APPEND DEBUGGABLE_TYPES CLAP)
+  endif()
+  if(IPLUG2_AAX_SUPPORTED)
+    list(APPEND DEBUGGABLE_TYPES AAX)
+  endif()
+  list(APPEND DEBUGGABLE_TYPES AUv2)
+
+  # Set Visual Studio debugger properties for plugin targets (Windows only)
+  if(WIN32 AND IPLUG2_DEBUG_HOST AND ${target_type} IN_LIST DEBUGGABLE_TYPES)
+    set_target_properties(${target} PROPERTIES
+      VS_DEBUGGER_COMMAND "${IPLUG2_DEBUG_HOST}"
+    )
+    if(IPLUG2_DEBUG_HOST_ARGS)
+      set_target_properties(${target} PROPERTIES
+        VS_DEBUGGER_COMMAND_ARGUMENTS "${IPLUG2_DEBUG_HOST_ARGS}"
+      )
+    endif()
+    get_filename_component(_debug_host_dir "${IPLUG2_DEBUG_HOST}" DIRECTORY)
+    if(_debug_host_dir)
+      set_target_properties(${target} PROPERTIES
+        VS_DEBUGGER_WORKING_DIRECTORY "${_debug_host_dir}"
+      )
+    endif()
+  endif()
+
+  # Set Xcode scheme properties for plugin targets (macOS only)
+  # Generates schemes with "Ask on Launch" behavior (no executable set)
+  # or uses IPLUG2_DEBUG_HOST if provided
+  if(APPLE AND XCODE AND ${target_type} IN_LIST DEBUGGABLE_TYPES)
+    set_target_properties(${target} PROPERTIES
+      XCODE_GENERATE_SCHEME TRUE
+      XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING NO
+    )
+    if(IPLUG2_DEBUG_HOST)
+      set_target_properties(${target} PROPERTIES
+        XCODE_SCHEME_EXECUTABLE "${IPLUG2_DEBUG_HOST}"
+      )
+      if(IPLUG2_DEBUG_HOST_ARGS)
+        set_target_properties(${target} PROPERTIES
+          XCODE_SCHEME_ARGUMENTS "${IPLUG2_DEBUG_HOST_ARGS}"
+        )
+      endif()
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/IGraphics.cmake
+++ b/Scripts/cmake/IGraphics.cmake
@@ -1,0 +1,500 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# IGraphics configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+set(IGRAPHICS_DEPS_DIR ${DEPS_DIR}/IGraphics)
+
+if(NOT TARGET iPlug2::IGraphics)
+  add_library(iPlug2::IGraphics INTERFACE IMPORTED)
+
+  set(IGRAPHICS_DIR ${IPLUG2_DIR}/IGraphics)
+
+  set(IGRAPHICS_SRC
+    ${IGRAPHICS_DIR}/IControl.cpp
+    ${IGRAPHICS_DIR}/IGraphics.cpp
+    ${IGRAPHICS_DIR}/IGraphicsEditorDelegate.cpp
+    ${IGRAPHICS_DIR}/Controls/IControls.cpp
+    ${IGRAPHICS_DIR}/Controls/IPopupMenuControl.cpp
+    ${IGRAPHICS_DIR}/Controls/ITextEntryControl.cpp
+  )
+
+  if(WIN32)
+    list(APPEND IGRAPHICS_SRC ${IGRAPHICS_DIR}/Platforms/IGraphicsWin.cpp)
+  elseif(IOS)
+    # iOS-specific platform sources
+    list(APPEND IGRAPHICS_SRC
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsIOS.mm
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsIOS_view.mm
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsCoreText.mm
+    )
+  elseif(APPLE)
+    # macOS platform sources
+    list(APPEND IGRAPHICS_SRC
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsMac.mm
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsMac_view.mm
+      ${IGRAPHICS_DIR}/Platforms/IGraphicsCoreText.mm
+    )
+  elseif(UNIX AND NOT APPLE)
+    message("Error - Linux not yet supported")
+  endif()
+
+  target_sources(iPlug2::IGraphics INTERFACE ${IGRAPHICS_SRC})
+
+  target_include_directories(iPlug2::IGraphics INTERFACE
+    ${IGRAPHICS_DIR}
+    ${IGRAPHICS_DIR}/Controls
+    ${IGRAPHICS_DIR}/Drawing
+    ${IGRAPHICS_DIR}/Platforms
+    ${IGRAPHICS_DIR}/Extras
+    ${IGRAPHICS_DEPS_DIR}/STB
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+  )
+
+  if(IOS)
+    # iOS-specific compile options and frameworks
+    # Note: ObjC prefix header is set per source file in platform-specific modules
+    # OBJC_PREFIX is set per-target in iplug_configure_target
+    target_link_libraries(iPlug2::IGraphics INTERFACE
+      "-framework UIKit"
+      "-framework QuartzCore"
+      "-framework CoreText"
+      "-framework CoreGraphics"
+      "-framework Accelerate"
+    )
+  elseif(APPLE)
+    # macOS-specific compile options and frameworks
+    # Note: ObjC prefix header is set per source file in platform-specific modules
+    # OBJC_PREFIX is set per-target in iplug_configure_target
+    target_link_libraries(iPlug2::IGraphics INTERFACE
+      "-framework Cocoa"
+      "-framework Carbon"
+      "-framework Accelerate"
+      "-framework QuartzCore"
+    )
+  elseif(UNIX AND NOT APPLE)
+    message("Error - Linux not yet supported")
+  endif()
+
+  target_link_libraries(iPlug2::IGraphics INTERFACE iPlug2::IPlug)
+endif()
+
+# NanoVG OpenGL object library (macOS only)
+# Compiles IGraphicsNanoVG_src.m which includes nanovg.c
+# Shared by GL2 and GL3 targets on macOS
+if(NOT TARGET iPlug2_IGraphics_NanoVG_GL_obj)
+  if(APPLE AND NOT IOS)
+    add_library(iPlug2_IGraphics_NanoVG_GL_obj OBJECT
+      ${IGRAPHICS_DIR}/Drawing/IGraphicsNanoVG_src.m
+    )
+
+    target_include_directories(iPlug2_IGraphics_NanoVG_GL_obj PRIVATE
+      ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+      ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+      ${IGRAPHICS_DIR}
+      ${IGRAPHICS_DIR}/Controls
+      ${IGRAPHICS_DIR}/Platforms
+      ${IGRAPHICS_DIR}/Drawing
+    )
+
+    # Define IGRAPHICS_NANOVG but NOT IGRAPHICS_METAL so nanovg_mtl.m is not included
+    target_compile_definitions(iPlug2_IGraphics_NanoVG_GL_obj PRIVATE
+      IGRAPHICS_NANOVG
+    )
+
+    # This source file requires ARC
+    target_compile_options(iPlug2_IGraphics_NanoVG_GL_obj PRIVATE -fobjc-arc)
+
+    set_target_properties(iPlug2_IGraphics_NanoVG_GL_obj PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+  endif()
+endif()
+
+# NanoVG drawing backend with OpenGL GL2 (simpler cross-platform option)
+if(NOT TARGET iPlug2::IGraphics::NanoVG)
+  add_library(iPlug2::IGraphics::NanoVG INTERFACE IMPORTED)
+
+  # Platform-specific NanoVG source handling:
+  # - Windows: IGraphicsWin.cpp unity-builds nanovg.c and glad.c
+  # - macOS: Use the object library above
+  if(NOT WIN32 AND NOT APPLE)
+    set(NANOVG_SRC ${IGRAPHICS_DEPS_DIR}/NanoVG/src/nanovg.c)
+    target_sources(iPlug2::IGraphics::NanoVG INTERFACE ${NANOVG_SRC})
+  endif()
+
+  target_include_directories(iPlug2::IGraphics::NanoVG INTERFACE
+    ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+  )
+
+  if(WIN32)
+    # glad_GL2/src is needed because IGraphicsWin.cpp does #include "glad.c"
+    # nanovg/src is needed because IGraphicsWin.cpp does #include "nanovg.c"
+    target_include_directories(iPlug2::IGraphics::NanoVG INTERFACE
+      ${IGRAPHICS_DEPS_DIR}/glad_GL2/include
+      ${IGRAPHICS_DEPS_DIR}/glad_GL2/src
+    )
+  endif()
+
+  target_compile_definitions(iPlug2::IGraphics::NanoVG INTERFACE
+    IGRAPHICS_NANOVG
+    IGRAPHICS_GL2
+  )
+
+  if(APPLE AND NOT IOS)
+    # Force-include OpenGL header so GL types are defined before NanoVG uses them
+    target_compile_options(iPlug2::IGraphics::NanoVG INTERFACE
+      -include OpenGL/gl.h
+    )
+    # Link object files from the GL object library
+    target_sources(iPlug2::IGraphics::NanoVG INTERFACE
+      $<TARGET_OBJECTS:iPlug2_IGraphics_NanoVG_GL_obj>
+    )
+    target_link_libraries(iPlug2::IGraphics::NanoVG INTERFACE
+      "-framework OpenGL"
+    )
+  endif()
+
+  target_link_libraries(iPlug2::IGraphics::NanoVG INTERFACE iPlug2::IGraphics)
+endif()
+
+# NanoVG with GL3 backend
+if(NOT TARGET iPlug2::IGraphics::NanoVG::GL3)
+  add_library(iPlug2::IGraphics::NanoVG::GL3 INTERFACE IMPORTED)
+
+  # Platform-specific NanoVG source handling (same as GL2)
+  if(NOT WIN32 AND NOT APPLE)
+    set(NANOVG_GL3_SRC ${IGRAPHICS_DEPS_DIR}/NanoVG/src/nanovg.c)
+    target_sources(iPlug2::IGraphics::NanoVG::GL3 INTERFACE ${NANOVG_GL3_SRC})
+  endif()
+
+  target_include_directories(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+    ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+  )
+
+  if(WIN32)
+    # glad_GL3/src is needed because IGraphicsWin.cpp does #include "glad.c"
+    target_include_directories(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+      ${IGRAPHICS_DEPS_DIR}/glad_GL3/include
+      ${IGRAPHICS_DEPS_DIR}/glad_GL3/src
+    )
+  endif()
+
+  target_compile_definitions(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+    IGRAPHICS_NANOVG
+    IGRAPHICS_GL3
+  )
+
+  if(APPLE AND NOT IOS)
+    target_compile_options(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+      -include OpenGL/gl3.h
+    )
+    # Link object files from the GL object library
+    target_sources(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+      $<TARGET_OBJECTS:iPlug2_IGraphics_NanoVG_GL_obj>
+    )
+    target_link_libraries(iPlug2::IGraphics::NanoVG::GL3 INTERFACE
+      "-framework OpenGL"
+    )
+  endif()
+
+  target_link_libraries(iPlug2::IGraphics::NanoVG::GL3 INTERFACE iPlug2::IGraphics)
+endif()
+
+# NanoVG with Metal backend (macOS and iOS)
+# We use an OBJECT library so we can set -fobjc-arc only on the Metal source file
+if(NOT TARGET iPlug2_IGraphics_NanoVG_Metal_obj)
+  if(APPLE OR IOS)
+    add_library(iPlug2_IGraphics_NanoVG_Metal_obj OBJECT
+      ${IGRAPHICS_DIR}/Drawing/IGraphicsNanoVG_src.m
+    )
+
+    target_include_directories(iPlug2_IGraphics_NanoVG_Metal_obj PRIVATE
+      ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+      ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+      ${IGRAPHICS_DEPS_DIR}/MetalNanoVG/src
+      ${IGRAPHICS_DIR}
+      ${IGRAPHICS_DIR}/Controls
+      ${IGRAPHICS_DIR}/Platforms
+      ${IGRAPHICS_DIR}/Drawing
+    )
+
+    target_compile_definitions(iPlug2_IGraphics_NanoVG_Metal_obj PRIVATE
+      IGRAPHICS_NANOVG
+      IGRAPHICS_METAL
+    )
+
+    # This source file requires ARC
+    target_compile_options(iPlug2_IGraphics_NanoVG_Metal_obj PRIVATE -fobjc-arc)
+
+    set_target_properties(iPlug2_IGraphics_NanoVG_Metal_obj PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+  endif()
+endif()
+
+if(NOT TARGET iPlug2::IGraphics::NanoVG::Metal)
+  if(APPLE OR IOS)
+    add_library(iPlug2::IGraphics::NanoVG::Metal INTERFACE IMPORTED)
+
+    target_include_directories(iPlug2::IGraphics::NanoVG::Metal INTERFACE
+      ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+      ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+      ${IGRAPHICS_DEPS_DIR}/MetalNanoVG/src
+    )
+
+    target_compile_definitions(iPlug2::IGraphics::NanoVG::Metal INTERFACE
+      IGRAPHICS_NANOVG
+      IGRAPHICS_METAL
+    )
+
+    # Link object files using generator expression
+    target_sources(iPlug2::IGraphics::NanoVG::Metal INTERFACE
+      $<TARGET_OBJECTS:iPlug2_IGraphics_NanoVG_Metal_obj>
+    )
+
+    target_link_libraries(iPlug2::IGraphics::NanoVG::Metal INTERFACE
+      "-framework Metal"
+      "-framework MetalKit"
+      iPlug2::IGraphics
+    )
+  endif()
+endif()
+
+# OpenGL configurations
+if(NOT TARGET iPlug2::IGraphics::GL2)
+  add_library(iPlug2::IGraphics::GL2 INTERFACE IMPORTED)
+  target_include_directories(iPlug2::IGraphics::GL2 INTERFACE 
+    ${IGRAPHICS_DEPS_DIR}/glad_GL2/include 
+    ${IGRAPHICS_DEPS_DIR}/glad_GL2/src
+  )
+  target_compile_definitions(iPlug2::IGraphics::GL2 INTERFACE IGRAPHICS_GL2)
+endif()
+
+if(NOT TARGET iPlug2::IGraphics::GL3)
+  add_library(iPlug2::IGraphics::GL3 INTERFACE IMPORTED)
+  target_include_directories(iPlug2::IGraphics::GL3 INTERFACE 
+    ${IGRAPHICS_DEPS_DIR}/glad_GL3/include 
+    ${IGRAPHICS_DEPS_DIR}/glad_GL3/src
+  )
+  target_compile_definitions(iPlug2::IGraphics::GL3 INTERFACE IGRAPHICS_GL3)
+endif()
+
+# Metal configuration for Apple platforms (macOS and iOS)
+if(APPLE OR IOS)
+  if(NOT TARGET iPlug2::IGraphics::Metal)
+    add_library(iPlug2::IGraphics::Metal INTERFACE IMPORTED)
+    target_compile_definitions(iPlug2::IGraphics::Metal INTERFACE IGRAPHICS_METAL)
+  endif()
+endif()
+
+# Skia drawing backend
+if(NOT TARGET iPlug2::IGraphics::Skia)
+  add_library(iPlug2::IGraphics::Skia INTERFACE IMPORTED)
+  target_link_libraries(iPlug2::IGraphics::Skia INTERFACE iPlug2::IGraphics)
+  target_compile_definitions(iPlug2::IGraphics::Skia INTERFACE IGRAPHICS_SKIA)
+
+  set(SKIA_PATH ${DEPS_DIR}/Build/src/skia)
+  target_include_directories(iPlug2::IGraphics::Skia INTERFACE
+    ${SKIA_PATH}
+    ${SKIA_PATH}/include
+    ${SKIA_PATH}/include/core
+    ${SKIA_PATH}/include/effects
+    ${SKIA_PATH}/include/config
+    ${SKIA_PATH}/include/utils
+    ${SKIA_PATH}/include/utils/mac
+    ${SKIA_PATH}/include/gpu
+    ${SKIA_PATH}/include/private
+    ${SKIA_PATH}/modules/svg/include
+    ${SKIA_PATH}/modules/skcms
+  )
+
+  if(WIN32)
+    set(SKIA_LIB_PATH ${SKIA_PATH}/out/Release-x64)
+    target_link_libraries(iPlug2::IGraphics::Skia INTERFACE
+      ${SKIA_LIB_PATH}/skia.lib
+      ${SKIA_LIB_PATH}/svg.lib
+    )
+  elseif(APPLE)
+    set(SKIA_LIB_PATH ${DEPS_DIR}/Build/mac/lib)
+    target_link_libraries(iPlug2::IGraphics::Skia INTERFACE
+      ${SKIA_LIB_PATH}/libskia.a
+      ${SKIA_LIB_PATH}/libsvg.a
+      ${SKIA_LIB_PATH}/libskshaper.a
+      ${SKIA_LIB_PATH}/libskparagraph.a
+      ${SKIA_LIB_PATH}/libskunicode_core.a
+      ${SKIA_LIB_PATH}/libskunicode_icu.a
+    )
+  endif()
+endif()
+
+# Skia with Metal backend (macOS and iOS)
+if(APPLE OR IOS)
+  if(NOT TARGET iPlug2::IGraphics::Skia::Metal)
+    add_library(iPlug2::IGraphics::Skia::Metal INTERFACE IMPORTED)
+
+    target_compile_definitions(iPlug2::IGraphics::Skia::Metal INTERFACE
+      IGRAPHICS_SKIA
+      IGRAPHICS_METAL
+    )
+
+    target_link_libraries(iPlug2::IGraphics::Skia::Metal INTERFACE
+      "-framework Metal"
+      "-framework MetalKit"
+      iPlug2::IGraphics::Skia
+    )
+  endif()
+endif()
+
+# Skia with GL3 backend
+if(NOT TARGET iPlug2::IGraphics::Skia::GL3)
+  add_library(iPlug2::IGraphics::Skia::GL3 INTERFACE IMPORTED)
+
+  target_compile_definitions(iPlug2::IGraphics::Skia::GL3 INTERFACE
+    IGRAPHICS_SKIA
+    IGRAPHICS_GL3
+  )
+
+  if(APPLE)
+    target_link_libraries(iPlug2::IGraphics::Skia::GL3 INTERFACE
+      "-framework OpenGL"
+    )
+  endif()
+
+  target_link_libraries(iPlug2::IGraphics::Skia::GL3 INTERFACE
+    iPlug2::IGraphics::Skia
+  )
+endif()
+
+# Skia with CPU backend (software rendering)
+if(NOT TARGET iPlug2::IGraphics::Skia::CPU)
+  add_library(iPlug2::IGraphics::Skia::CPU INTERFACE IMPORTED)
+
+  target_compile_definitions(iPlug2::IGraphics::Skia::CPU INTERFACE
+    IGRAPHICS_SKIA
+    IGRAPHICS_CPU
+  )
+
+  target_link_libraries(iPlug2::IGraphics::Skia::CPU INTERFACE
+    iPlug2::IGraphics::Skia
+  )
+endif()
+
+# =============================================================================
+# IGraphics Extras - Optional modules
+# =============================================================================
+
+# FlexBox layout support (requires Yoga)
+# Use OBJECT library to avoid duplicate symbols when multiple targets link to FlexBox.
+# IGraphicsFlexBox.cpp uses a unity build pattern (#includes Yoga sources), so we
+# compile it in the object library and define IPLUG2_YOGA_COMPILED_SEPARATELY to skip
+# those includes.
+set(YOGA_DIR ${IGRAPHICS_DEPS_DIR}/yoga)
+
+if(NOT TARGET iPlug2_Extras_FlexBox_obj)
+  add_library(iPlug2_Extras_FlexBox_obj OBJECT
+    ${IGRAPHICS_DIR}/Extras/IGraphicsFlexBox.cpp
+  )
+
+  target_include_directories(iPlug2_Extras_FlexBox_obj PUBLIC
+    ${YOGA_DIR}
+    ${YOGA_DIR}/yoga
+    ${IGRAPHICS_DIR}
+    ${IGRAPHICS_DIR}/Controls
+    ${IGRAPHICS_DIR}/Platforms
+    ${IGRAPHICS_DIR}/Drawing
+    ${IGRAPHICS_DIR}/Extras
+    ${IGRAPHICS_DEPS_DIR}/STB
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+    ${IPLUG_DIR}
+    ${WDL_DIR}
+  )
+
+  set_target_properties(iPlug2_Extras_FlexBox_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_STANDARD ${IPLUG2_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED ON
+  )
+
+  if(WIN32)
+    target_compile_definitions(iPlug2_Extras_FlexBox_obj PRIVATE NOMINMAX)
+  endif()
+  if(MSVC)
+    target_compile_options(iPlug2_Extras_FlexBox_obj PRIVATE /MT$<$<CONFIG:Debug>:d>)
+  endif()
+endif()
+
+if(NOT TARGET iPlug2::Extras::FlexBox)
+  add_library(iPlug2::Extras::FlexBox INTERFACE IMPORTED)
+
+  target_sources(iPlug2::Extras::FlexBox INTERFACE
+    $<TARGET_OBJECTS:iPlug2_Extras_FlexBox_obj>
+  )
+
+  target_include_directories(iPlug2::Extras::FlexBox INTERFACE
+    ${YOGA_DIR}
+    ${YOGA_DIR}/yoga
+  )
+
+  target_link_libraries(iPlug2::Extras::FlexBox INTERFACE iPlug2::IGraphics)
+endif()
+
+# =============================================================================
+# IGraphics Backend Selection - Convenience Variables
+# =============================================================================
+# These can be overridden by setting IGRAPHICS_BACKEND and/or IGRAPHICS_RENDERER
+# BEFORE including iPlug2.cmake or calling find_package(iPlug2)
+
+# Backend selection (NANOVG or SKIA)
+if(NOT DEFINED IGRAPHICS_BACKEND)
+  set(IGRAPHICS_BACKEND "NANOVG" CACHE STRING "IGraphics drawing backend")
+  set_property(CACHE IGRAPHICS_BACKEND PROPERTY STRINGS "NANOVG" "SKIA")
+endif()
+
+# Renderer selection with platform-aware defaults
+# NANOVG supports: GL2, GL3, METAL (Metal is macOS/iOS only)
+# SKIA supports: GL3, METAL, CPU
+if(NOT DEFINED IGRAPHICS_RENDERER)
+  if(WIN32)
+    set(DEFAULT_RENDERER "GL2")
+  elseif(APPLE OR IOS)
+    set(DEFAULT_RENDERER "METAL")
+  else()
+    set(DEFAULT_RENDERER "GL2")
+  endif()
+  set(IGRAPHICS_RENDERER "${DEFAULT_RENDERER}" CACHE STRING "IGraphics renderer")
+  set_property(CACHE IGRAPHICS_RENDERER PROPERTY STRINGS "GL2" "GL3" "METAL" "CPU")
+endif()
+
+# Construct IGRAPHICS_LIB target based on selections
+if(NOT DEFINED IGRAPHICS_LIB)
+  if(IGRAPHICS_BACKEND STREQUAL "SKIA")
+    if(IGRAPHICS_RENDERER STREQUAL "CPU")
+      set(IGRAPHICS_LIB iPlug2::IGraphics::Skia::CPU)
+    elseif(IGRAPHICS_RENDERER STREQUAL "GL3")
+      set(IGRAPHICS_LIB iPlug2::IGraphics::Skia::GL3)
+    else()
+      set(IGRAPHICS_LIB iPlug2::IGraphics::Skia::Metal)
+    endif()
+  else()
+    # NanoVG
+    if(IGRAPHICS_RENDERER STREQUAL "GL3")
+      set(IGRAPHICS_LIB iPlug2::IGraphics::NanoVG::GL3)
+    elseif(IGRAPHICS_RENDERER STREQUAL "METAL")
+      set(IGRAPHICS_LIB iPlug2::IGraphics::NanoVG::Metal)
+    else()
+      # Default to GL2 for NanoVG
+      set(IGRAPHICS_LIB iPlug2::IGraphics::NanoVG)
+    endif()
+  endif()
+  message(STATUS "IGraphics: ${IGRAPHICS_BACKEND}/${IGRAPHICS_RENDERER} -> ${IGRAPHICS_LIB}")
+endif()

--- a/Scripts/cmake/IOSApp.cmake
+++ b/Scripts/cmake/IOSApp.cmake
@@ -1,0 +1,182 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# iOS Standalone App target configuration for iPlug2
+# Creates a standalone iOS app that hosts the AUv3 plugin for testing
+
+include(${CMAKE_CURRENT_LIST_DIR}/AUv3iOS.cmake)
+
+# Define iOS App helper sources
+set(IPLUG_IOS_APP_SOURCES
+  ${IPLUG_DIR}/AUv3/iOSApp/main.m
+  ${IPLUG_DIR}/AUv3/iOSApp/AppDelegate.m
+  ${IPLUG_DIR}/AUv3/iOSApp/AppDelegate.h
+  ${IPLUG_DIR}/AUv3/iOSApp/AppViewController.mm
+  ${IPLUG_DIR}/AUv3/iOSApp/AppViewController.h
+  ${IPLUG_DIR}/AUv3/iOSApp/IPlugAUPlayer.mm
+  ${IPLUG_DIR}/AUv3/iOSApp/IPlugAUPlayer.h
+)
+
+function(iplug_configure_iosapp target project_name)
+  # Determine iOS app icon name - examples use "ProjectiOSAppIcon", others may use "Project-iOS"
+  set(IOS_APPICON_NAME "${project_name}iOSAppIcon")
+  if(EXISTS "${PLUG_RESOURCES_DIR}/Images.xcassets/${project_name}-iOS.appiconset")
+    set(IOS_APPICON_NAME "${project_name}-iOS")
+  endif()
+
+  # Link AUv3iOS interface for the app (same headers/frameworks as the plugin)
+  target_link_libraries(${target} PUBLIC iPlug2::AUv3iOS)
+
+  # Define OBJC_PREFIX for ObjC class name mangling (must match storyboard customClass)
+  # Applied to all languages since Xcode doesn't properly handle OBJC/OBJCXX generator expressions
+  target_compile_definitions(${target} PRIVATE OBJC_PREFIX=v${project_name})
+
+  # Add iOS App helper sources
+  target_sources(${target} PRIVATE ${IPLUG_IOS_APP_SOURCES})
+
+  # Set ARC for ObjC/ObjC++ sources
+  set(ARC_SOURCES
+    ${IPLUG_DIR}/AUv3/iOSApp/main.m
+    ${IPLUG_DIR}/AUv3/iOSApp/AppDelegate.m
+    ${IPLUG_DIR}/AUv3/iOSApp/AppViewController.mm
+    ${IPLUG_DIR}/AUv3/iOSApp/IPlugAUPlayer.mm
+  )
+  set_source_files_properties(${ARC_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  # AUv3 wrapper sources also need ARC
+  set(AUV3_SOURCES
+    ${IPLUG_DIR}/AUv3/IPlugAUv3.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUAudioUnit.mm
+    ${IPLUG_DIR}/AUv3/IPlugAUViewController.mm
+  )
+  set_source_files_properties(${AUV3_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  # IGraphics sources that require ARC
+  # Note: IGraphicsIOS.mm does NOT use ARC (uses manual release), only the view does
+  set(IGRAPHICS_DIR ${IPLUG2_DIR}/IGraphics)
+  set(IGRAPHICS_ARC_SOURCES
+    ${IGRAPHICS_DIR}/Drawing/IGraphicsNanoVG_src.m
+    ${IGRAPHICS_DIR}/Platforms/IGraphicsIOS_view.mm
+  )
+  set_source_files_properties(${IGRAPHICS_ARC_SOURCES}
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+
+  set_target_properties(${target} PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-iOS-Info.plist
+    OUTPUT_NAME "${project_name}"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+    # iOS App Xcode attributes
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.AcmeInc.${project_name}"
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "${IPLUG2_TARGETED_DEVICE_FAMILY}"
+    XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "${IOS_APPICON_NAME}"
+  )
+
+  # Create PkgInfo for app bundle
+  set(PKGINFO_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_pkginfo_${target}.cmake")
+  file(WRITE ${PKGINFO_SCRIPT} "file(WRITE \"\${PKGINFO_PATH}\" \"APPL????\")")
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -DPKGINFO_PATH="$<TARGET_BUNDLE_DIR:${target}>/PkgInfo"
+      -P "${PKGINFO_SCRIPT}"
+    COMMENT "Creating PkgInfo for ${project_name}.app (iOS)"
+  )
+
+  # Compile storyboards
+  # Main storyboard
+  set(MAIN_STORYBOARD ${PLUG_RESOURCES_DIR}/${project_name}-iOS.storyboard)
+  if(EXISTS ${MAIN_STORYBOARD})
+    if(XCODE)
+      # Xcode handles storyboard compilation automatically
+      target_sources(${target} PRIVATE ${MAIN_STORYBOARD})
+      set_source_files_properties(${MAIN_STORYBOARD} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    else()
+      # For other generators, compile storyboard manually
+      set(MAIN_STORYBOARDC ${CMAKE_CURRENT_BINARY_DIR}/${project_name}-iOS.storyboardc)
+      add_custom_command(
+        OUTPUT ${MAIN_STORYBOARDC}
+        COMMAND ibtool --compile ${MAIN_STORYBOARDC} ${MAIN_STORYBOARD}
+          ${IPLUG2_IBTOOL_TARGET_DEVICES}
+        DEPENDS ${MAIN_STORYBOARD}
+        COMMENT "Compiling ${project_name}-iOS.storyboard"
+      )
+      target_sources(${target} PRIVATE ${MAIN_STORYBOARDC})
+      set_source_files_properties(${MAIN_STORYBOARDC} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+  endif()
+
+  # Launch screen storyboard
+  set(LAUNCH_STORYBOARD ${PLUG_RESOURCES_DIR}/${project_name}-iOS-LaunchScreen.storyboard)
+  if(EXISTS ${LAUNCH_STORYBOARD})
+    if(XCODE)
+      target_sources(${target} PRIVATE ${LAUNCH_STORYBOARD})
+      set_source_files_properties(${LAUNCH_STORYBOARD} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    else()
+      set(LAUNCH_STORYBOARDC ${CMAKE_CURRENT_BINARY_DIR}/${project_name}-iOS-LaunchScreen.storyboardc)
+      add_custom_command(
+        OUTPUT ${LAUNCH_STORYBOARDC}
+        COMMAND ibtool --compile ${LAUNCH_STORYBOARDC} ${LAUNCH_STORYBOARD}
+          ${IPLUG2_IBTOOL_TARGET_DEVICES}
+        DEPENDS ${LAUNCH_STORYBOARD}
+        COMMENT "Compiling ${project_name}-iOS-LaunchScreen.storyboard"
+      )
+      target_sources(${target} PRIVATE ${LAUNCH_STORYBOARDC})
+      set_source_files_properties(${LAUNCH_STORYBOARDC} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+  endif()
+
+  # AUv3 MainInterface storyboard - needed in app bundle for AppViewController to load
+  # (AppViewController loads it with bundle:nil which searches main bundle)
+  set(MAININTERFACE_STORYBOARD ${PLUG_RESOURCES_DIR}/${project_name}-iOS-MainInterface.storyboard)
+  if(EXISTS ${MAININTERFACE_STORYBOARD})
+    if(XCODE)
+      target_sources(${target} PRIVATE ${MAININTERFACE_STORYBOARD})
+      set_source_files_properties(${MAININTERFACE_STORYBOARD} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    else()
+      set(MAININTERFACE_STORYBOARDC ${CMAKE_CURRENT_BINARY_DIR}/${project_name}-iOS-MainInterface-app.storyboardc)
+      add_custom_command(
+        OUTPUT ${MAININTERFACE_STORYBOARDC}
+        COMMAND ibtool --compile ${MAININTERFACE_STORYBOARDC} ${MAININTERFACE_STORYBOARD}
+          ${IPLUG2_IBTOOL_TARGET_DEVICES}
+        DEPENDS ${MAININTERFACE_STORYBOARD}
+        COMMENT "Compiling ${project_name}-iOS-MainInterface.storyboard for app"
+      )
+      target_sources(${target} PRIVATE ${MAININTERFACE_STORYBOARDC})
+      set_source_files_properties(${MAININTERFACE_STORYBOARDC} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+  endif()
+
+  # Add asset catalog for app icons
+  set(ASSET_CATALOG ${PLUG_RESOURCES_DIR}/Images.xcassets)
+  if(EXISTS ${ASSET_CATALOG})
+    if(XCODE)
+      target_sources(${target} PRIVATE ${ASSET_CATALOG})
+      set_source_files_properties(${ASSET_CATALOG} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+      )
+    endif()
+    # For non-Xcode builds, asset catalogs need actool compilation (complex, skip for now)
+  endif()
+endfunction()

--- a/Scripts/cmake/IPlug.cmake
+++ b/Scripts/cmake/IPlug.cmake
@@ -1,0 +1,286 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# Configuration for IPlug Core
+
+# C++ standard - iPlug2 requires C++17
+if(NOT DEFINED IPLUG2_CXX_STANDARD)
+  set(IPLUG2_CXX_STANDARD 17 CACHE STRING "C++ standard for iPlug2")
+endif()
+
+# Option to disable deprecation warnings (useful for CI)
+option(IPLUG2_DISABLE_DEPRECATION_WARNINGS "Disable deprecation warnings" ON)
+
+if(NOT TARGET iPlug2::IPlug)
+  add_library(iPlug2::IPlug INTERFACE IMPORTED)
+
+  set(IPLUG_DIR ${IPLUG2_DIR}/IPlug)
+  set(WDL_DIR ${IPLUG2_DIR}/WDL)
+  set(DEPS_DIR ${IPLUG2_DIR}/Dependencies)
+  set(IPLUG_DEPS_DIR ${DEPS_DIR}/IPlug)
+
+  set(IPLUG_SRC
+    ${IPLUG_DIR}/IPlugAPIBase.h
+    ${IPLUG_DIR}/IPlugAPIBase.cpp
+    ${IPLUG_DIR}/IPlugConstants.h
+    ${IPLUG_DIR}/IPlugEditorDelegate.h
+    ${IPLUG_DIR}/IPlugLogger.h
+    ${IPLUG_DIR}/IPlugMidi.h
+    ${IPLUG_DIR}/IPlugParameter.h
+    ${IPLUG_DIR}/IPlugParameter.cpp
+    ${IPLUG_DIR}/IPlugPaths.h
+    ${IPLUG_DIR}/IPlugPaths.cpp
+    ${IPLUG_DIR}/IPlugPlatform.h
+    ${IPLUG_DIR}/IPlugPluginBase.h
+    ${IPLUG_DIR}/IPlugPluginBase.cpp
+    ${IPLUG_DIR}/IPlugProcessor.h
+    ${IPLUG_DIR}/IPlugProcessor.cpp
+    ${IPLUG_DIR}/IPlugQueue.h
+    ${IPLUG_DIR}/IPlugStructs.h
+    ${IPLUG_DIR}/IPlugTimer.h
+    ${IPLUG_DIR}/IPlugTimer.cpp
+    ${IPLUG_DIR}/IPlugUtilities.h
+  )
+
+  if(APPLE)
+    list(APPEND IPLUG_SRC ${IPLUG_DIR}/IPlugPaths.mm)
+  endif()
+  
+  target_sources(iPlug2::IPlug INTERFACE ${IPLUG_SRC})
+  
+  target_include_directories(iPlug2::IPlug INTERFACE
+    ${IPLUG_DIR}
+    ${WDL_DIR}
+    ${WDL_DIR}/libpng
+    ${WDL_DIR}/zlib
+    ${IPLUG_DIR}/Extras
+  )
+  
+  target_compile_definitions(iPlug2::IPlug INTERFACE
+    NOMINMAX  # Prevent min/max macros from Windows.h and SWELL
+    $<$<CONFIG:Debug>:DEBUG>
+    $<$<CONFIG:Debug>:_DEBUG>
+  )
+  
+  if(MSVC)
+    target_compile_definitions(iPlug2::IPlug INTERFACE
+      _CRT_SECURE_NO_WARNINGS
+      _CRT_SECURE_NO_DEPRECATE
+      _CRT_NONSTDC_NO_DEPRECATE
+      _MBCS
+    )
+    target_compile_options(iPlug2::IPlug INTERFACE
+      /wd4250 /wd4018 /wd4267 /wd4068
+      /MT$<$<CONFIG:Debug>:d>
+    )
+  endif()
+
+  # Suppress deprecation warnings if requested (useful for CI)
+  if(IPLUG2_DISABLE_DEPRECATION_WARNINGS)
+    if(MSVC)
+      target_compile_options(iPlug2::IPlug INTERFACE /wd4996)
+      target_compile_definitions(iPlug2::IPlug INTERFACE
+        _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+      )
+    else()
+      # Use generator expression to only apply to C/C++/ObjC (not Swift)
+      target_compile_options(iPlug2::IPlug INTERFACE
+        $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-Wno-deprecated-declarations>
+      )
+    endif()
+  endif()
+  
+  if(WIN32)
+    target_link_libraries(iPlug2::IPlug INTERFACE 
+      Shlwapi.lib
+      comctl32.lib
+      wininet.lib
+    )
+  elseif(APPLE)
+    target_link_libraries(iPlug2::IPlug INTERFACE
+      "-framework CoreData"
+      "-framework CoreFoundation"
+      "-framework CoreServices"
+      "-framework Foundation"
+    )
+  elseif(UNIX AND NOT APPLE)
+    message("Error - Linux not yet supported")
+  endif()
+
+  # Generate PkgInfo file for macOS bundles (used by VST2, CLAP, etc.)
+  # This file is created once at configure time and copied to each bundle at build time
+  if(APPLE)
+    set(IPLUG2_PKGINFO_FILE "${CMAKE_BINARY_DIR}/PkgInfo" CACHE INTERNAL "Path to PkgInfo file for macOS bundles")
+    file(WRITE "${IPLUG2_PKGINFO_FILE}" "BNDL????")
+  endif()
+endif()
+
+# =============================================================================
+# IPlug Extras - Optional modules
+# =============================================================================
+
+# OSC (Open Sound Control) support
+if(NOT TARGET iPlug2::Extras::OSC)
+  add_library(iPlug2::Extras::OSC INTERFACE IMPORTED)
+
+  target_sources(iPlug2::Extras::OSC INTERFACE
+    ${IPLUG_DIR}/Extras/OSC/IPlugOSC.cpp
+    ${IPLUG_DIR}/Extras/OSC/IPlugOSC_msg.cpp
+    ${WDL_DIR}/jnetlib/asyncdns.cpp
+    ${WDL_DIR}/jnetlib/connection.cpp
+    ${WDL_DIR}/jnetlib/listen.cpp
+    ${WDL_DIR}/jnetlib/util.cpp
+  )
+
+  target_include_directories(iPlug2::Extras::OSC INTERFACE
+    ${IPLUG_DIR}/Extras/OSC
+  )
+
+  target_link_libraries(iPlug2::Extras::OSC INTERFACE iPlug2::IPlug)
+
+  if(WIN32)
+    target_link_libraries(iPlug2::Extras::OSC INTERFACE ws2_32.lib)
+  endif()
+endif()
+
+# Synth utilities (MidiSynth, VoiceAllocator)
+if(NOT TARGET iPlug2::Extras::Synth)
+  add_library(iPlug2::Extras::Synth INTERFACE IMPORTED)
+
+  target_sources(iPlug2::Extras::Synth INTERFACE
+    ${IPLUG_DIR}/Extras/Synth/MidiSynth.cpp
+    ${IPLUG_DIR}/Extras/Synth/VoiceAllocator.cpp
+  )
+
+  target_include_directories(iPlug2::Extras::Synth INTERFACE
+    ${IPLUG_DIR}/Extras/Synth
+  )
+
+  target_link_libraries(iPlug2::Extras::Synth INTERFACE iPlug2::IPlug)
+endif()
+
+# HIIR oversampling/downsampling
+if(NOT TARGET iPlug2::Extras::HIIR)
+  add_library(iPlug2::Extras::HIIR INTERFACE IMPORTED)
+
+  target_sources(iPlug2::Extras::HIIR INTERFACE
+    ${IPLUG_DIR}/Extras/HIIR/PolyphaseIIR2Designer.cpp
+  )
+
+  target_include_directories(iPlug2::Extras::HIIR INTERFACE
+    ${IPLUG_DIR}/Extras/HIIR
+  )
+
+  target_link_libraries(iPlug2::Extras::HIIR INTERFACE iPlug2::IPlug)
+endif()
+
+# IWebViewControl support for IGraphics plugins (minimal - no EditorDelegate)
+# Use this when embedding IWebViewControl in an IGraphics UI
+# Note: IPlugWebView.cpp and IPlugWK*.mm are #included by platform-specific files (unity build)
+
+# Object library for macOS WebView (requires ARC)
+if(NOT TARGET iPlug2_Extras_IWebViewControl_obj)
+  if(APPLE)
+    add_library(iPlug2_Extras_IWebViewControl_obj OBJECT
+      ${IPLUG_DIR}/Extras/WebView/IPlugWebView_mac.mm
+    )
+
+    target_include_directories(iPlug2_Extras_IWebViewControl_obj PRIVATE
+      ${IPLUG_DIR}
+      ${IPLUG_DIR}/Extras/WebView
+      ${WDL_DIR}
+    )
+
+    target_compile_options(iPlug2_Extras_IWebViewControl_obj PRIVATE -fobjc-arc)
+
+    set_target_properties(iPlug2_Extras_IWebViewControl_obj PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+      CXX_STANDARD ${IPLUG2_CXX_STANDARD}
+      CXX_STANDARD_REQUIRED ON
+    )
+  endif()
+endif()
+
+if(NOT TARGET iPlug2::Extras::IWebViewControl)
+  add_library(iPlug2::Extras::IWebViewControl INTERFACE IMPORTED)
+
+  if(WIN32)
+    target_sources(iPlug2::Extras::IWebViewControl INTERFACE
+      ${IPLUG_DIR}/Extras/WebView/IPlugWebView_win.cpp
+    )
+
+    # Fetch WIL (Windows Implementation Libraries) - header-only
+    include(FetchContent)
+    FetchContent_Declare(
+      wil
+      GIT_REPOSITORY https://github.com/microsoft/wil.git
+      GIT_TAG v1.0.240803.1
+      GIT_SHALLOW TRUE
+    )
+    # Disable WIL tests (they require Detours and other dependencies)
+    set(WIL_BUILD_PACKAGING OFF CACHE BOOL "" FORCE)
+    set(WIL_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(wil)
+
+    # Fetch WebView2 NuGet package
+    set(WEBVIEW2_VERSION "1.0.2903.40")
+    set(WEBVIEW2_DIR "${CMAKE_BINARY_DIR}/_deps/webview2")
+    set(WEBVIEW2_NUGET_URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}")
+
+    if(NOT EXISTS "${WEBVIEW2_DIR}/build/native/include/WebView2.h")
+      message(STATUS "Downloading WebView2 SDK ${WEBVIEW2_VERSION}...")
+      file(DOWNLOAD
+        "${WEBVIEW2_NUGET_URL}"
+        "${WEBVIEW2_DIR}/webview2.zip"
+        SHOW_PROGRESS
+        STATUS DOWNLOAD_STATUS
+      )
+      list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+      if(NOT STATUS_CODE EQUAL 0)
+        message(FATAL_ERROR "Failed to download WebView2 SDK")
+      endif()
+
+      file(ARCHIVE_EXTRACT
+        INPUT "${WEBVIEW2_DIR}/webview2.zip"
+        DESTINATION "${WEBVIEW2_DIR}"
+      )
+      file(REMOVE "${WEBVIEW2_DIR}/webview2.zip")
+    endif()
+
+    set(WEBVIEW2_INCLUDE_DIR "${WEBVIEW2_DIR}/build/native/include")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(WEBVIEW2_LIB_DIR "${WEBVIEW2_DIR}/build/native/x64")
+    else()
+      set(WEBVIEW2_LIB_DIR "${WEBVIEW2_DIR}/build/native/x86")
+    endif()
+
+    target_include_directories(iPlug2::Extras::IWebViewControl INTERFACE
+      ${wil_SOURCE_DIR}/include
+      ${WEBVIEW2_INCLUDE_DIR}
+    )
+    target_link_libraries(iPlug2::Extras::IWebViewControl INTERFACE
+      "${WEBVIEW2_LIB_DIR}/WebView2LoaderStatic.lib"
+    )
+  elseif(APPLE)
+    target_sources(iPlug2::Extras::IWebViewControl INTERFACE
+      $<TARGET_OBJECTS:iPlug2_Extras_IWebViewControl_obj>
+    )
+  endif()
+
+  target_include_directories(iPlug2::Extras::IWebViewControl INTERFACE
+    ${IPLUG_DIR}/Extras/WebView
+  )
+
+  if(APPLE)
+    target_link_libraries(iPlug2::Extras::IWebViewControl INTERFACE
+      "-framework WebKit"
+    )
+  endif()
+
+  target_link_libraries(iPlug2::Extras::IWebViewControl INTERFACE iPlug2::IPlug)
+endif()

--- a/Scripts/cmake/IPlugPlugin.cmake
+++ b/Scripts/cmake/IPlugPlugin.cmake
@@ -1,0 +1,425 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# IPlugPlugin.cmake
+# Provides iplug_add_plugin() macro to simplify example/project CMakeLists.txt files
+# Reduces ~190 lines of boilerplate to ~15 lines
+
+#[=============================================================================[
+iplug_add_plugin(<name>
+  SOURCES <file1> [file2 ...]
+  [RESOURCES <file1> [file2 ...]]        # Goes into Resources/
+  [WEB_RESOURCES <file1> [file2 ...]]    # Goes into Resources/web/ (for WebView UI)
+  [FORMATS <format1> [format2 ...]]      # Defaults to ALL
+  [EXCLUDE_FORMATS <format1> [format2 ...]]
+  [LINK <library1> [library2 ...]]       # Extra dependencies
+  [DEFINES <def1> [def2 ...]]
+  [UI <IGRAPHICS|WEBVIEW|NONE>]          # Defaults to IGRAPHICS
+  [WAM_SITE_ORIGIN <origin>]             # Defaults to "/"
+)
+
+Format names:
+  APP      - Standalone application (no embedded AUv3 by default)
+  VST2     - VST2 plugin (if SDK available) - DEPRECATED
+  VST3     - VST3 plugin
+  CLAP     - CLAP plugin (if SDK available)
+  AAX      - AAX plugin (if SDK available)
+  AU       - AUv2 (macOS only)
+  AUV3     - AUv3 with framework/appex/embedding (macOS + iOS) - OPT-IN
+  WAM      - Web Audio Module (Emscripten only)
+
+Format groups:
+  ALL            - All formats (APP, VST2, VST3, CLAP, AAX, AU, AUV3, WAM)
+  ALL_PLUGINS    - All plugin formats without APP (VST2, VST3, CLAP, AAX, AU, AUV3, WAM)
+  ALL_DESKTOP    - All desktop formats including AUv3 (APP, VST2, VST3, CLAP, AAX, AU, AUV3)
+  MINIMAL_PLUGINS - Core plugin formats (VST3, CLAP, AU)
+  DESKTOP        - Desktop formats without AUv3/VST2 (APP, VST3, CLAP, AAX, AU)
+  WEB            - Web formats only (WAM)
+#]=============================================================================]
+
+# ============================================================================
+# Expand format groups to individual formats
+# ============================================================================
+function(_iplug_expand_formats input_formats output_var)
+  set(result)
+  foreach(fmt ${input_formats})
+    if(fmt STREQUAL "ALL")
+      list(APPEND result APP VST2 VST3 CLAP AAX AU AUV3 WAM)
+    elseif(fmt STREQUAL "ALL_PLUGINS")
+      list(APPEND result VST2 VST3 CLAP AAX AU AUV3 WAM)
+    elseif(fmt STREQUAL "ALL_DESKTOP")
+      list(APPEND result APP VST2 VST3 CLAP AAX AU AUV3)
+    elseif(fmt STREQUAL "MINIMAL_PLUGINS")
+      list(APPEND result VST3 CLAP AU)
+    elseif(fmt STREQUAL "DESKTOP")
+      list(APPEND result APP VST3 CLAP AAX AU)
+    elseif(fmt STREQUAL "WEB")
+      list(APPEND result WAM)
+    else()
+      list(APPEND result ${fmt})
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES result)
+  set(${output_var} ${result} PARENT_SCOPE)
+endfunction()
+
+# ============================================================================
+# Add resources to a bundle target (macOS/iOS)
+# ============================================================================
+function(_iplug_add_resources target resources)
+  if(NOT resources)
+    return()
+  endif()
+  target_sources(${target} PRIVATE ${resources})
+  set_source_files_properties(${resources} PROPERTIES
+    MACOSX_PACKAGE_LOCATION Resources
+  )
+endfunction()
+
+# ============================================================================
+# Create APP, VST3, CLAP, AAX targets (macOS/Windows only)
+# ============================================================================
+function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resources web_resources base_lib)
+  # Skip on iOS and Emscripten
+  if(IOS OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    return()
+  endif()
+
+  # APP target (uses add_executable, needs .rc on Windows)
+  if("APP" IN_LIST formats)
+    set(_app_sources ${sources})
+    set(_rc_file "${CMAKE_CURRENT_SOURCE_DIR}/resources/main.rc")
+    if(WIN32 AND EXISTS "${_rc_file}")
+      list(APPEND _app_sources "${_rc_file}")
+      # Tell RC compiler where to find resources (fonts, images, etc.)
+      # The .rc file references files like "Roboto-Regular.ttf" without path
+      set_source_files_properties("${_rc_file}" PROPERTIES
+        COMPILE_FLAGS "/I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/fonts\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/img\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources\""
+      )
+    endif()
+    add_executable(${plugin_name}-app ${_app_sources})
+    iplug_add_target(${plugin_name}-app PUBLIC
+      LINK iPlug2::APP ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-app APP ${plugin_name})
+    _iplug_add_resources(${plugin_name}-app "${resources}")
+    _iplug_add_web_resources(${plugin_name}-app "${web_resources}")
+  endif()
+
+  # VST2 (conditional on SDK availability - deprecated)
+  if("VST2" IN_LIST formats AND IPLUG2_VST2_SUPPORTED)
+    add_library(${plugin_name}-vst2 MODULE ${sources})
+    iplug_add_target(${plugin_name}-vst2 PUBLIC
+      LINK iPlug2::VST2 ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-vst2 VST2 ${plugin_name})
+    _iplug_add_resources(${plugin_name}-vst2 "${resources}")
+    _iplug_add_web_resources(${plugin_name}-vst2 "${web_resources}")
+  endif()
+
+  # VST3 (always available)
+  if("VST3" IN_LIST formats)
+    add_library(${plugin_name}-vst3 MODULE ${sources})
+    iplug_add_target(${plugin_name}-vst3 PUBLIC
+      LINK iPlug2::VST3 ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-vst3 VST3 ${plugin_name})
+    _iplug_add_resources(${plugin_name}-vst3 "${resources}")
+    _iplug_add_web_resources(${plugin_name}-vst3 "${web_resources}")
+  endif()
+
+  # CLAP (conditional on SDK availability)
+  if("CLAP" IN_LIST formats AND IPLUG2_CLAP_SUPPORTED)
+    add_library(${plugin_name}-clap MODULE ${sources})
+    iplug_add_target(${plugin_name}-clap PUBLIC
+      LINK iPlug2::CLAP ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-clap CLAP ${plugin_name})
+    _iplug_add_resources(${plugin_name}-clap "${resources}")
+    _iplug_add_web_resources(${plugin_name}-clap "${web_resources}")
+  endif()
+
+  # AAX (conditional on SDK availability)
+  if("AAX" IN_LIST formats AND IPLUG2_AAX_SUPPORTED)
+    add_library(${plugin_name}-aax MODULE ${sources})
+    iplug_add_target(${plugin_name}-aax PUBLIC
+      LINK iPlug2::AAX ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-aax AAX ${plugin_name})
+    _iplug_add_resources(${plugin_name}-aax "${resources}")
+    _iplug_add_web_resources(${plugin_name}-aax "${web_resources}")
+  endif()
+endfunction()
+
+# ============================================================================
+# Create AUv2 target (macOS only)
+# ============================================================================
+function(_iplug_create_au_targets plugin_name formats sources ui_lib resources web_resources base_lib)
+  # AUv2 is macOS desktop only
+  if(NOT APPLE OR IOS)
+    return()
+  endif()
+
+  if("AU" IN_LIST formats)
+    add_library(${plugin_name}-au MODULE ${sources})
+    iplug_add_target(${plugin_name}-au PUBLIC
+      LINK iPlug2::AUv2 ${ui_lib} ${base_lib}
+    )
+    iplug_configure_target(${plugin_name}-au AUv2 ${plugin_name})
+    _iplug_add_resources(${plugin_name}-au "${resources}")
+    _iplug_add_web_resources(${plugin_name}-au "${web_resources}")
+  endif()
+endfunction()
+
+# ============================================================================
+# Create AUv3 targets (macOS only) - Framework + Appex + embedding in APP
+# This is OPT-IN - only created if AUV3 is explicitly in formats
+# ============================================================================
+function(_iplug_create_auv3_targets plugin_name formats sources ui_lib resources web_resources base_lib)
+  # AUv3 on macOS requires explicit opt-in
+  if(NOT APPLE OR IOS)
+    return()
+  endif()
+
+  if(NOT "AUV3" IN_LIST formats)
+    return()
+  endif()
+
+  # Framework containing AUv3 plugin code
+  # Note: Resources are NOT added to the framework - the appex loads them
+  # from the parent app's Resources folder (see IPlugPaths.mm)
+  add_library(${plugin_name}AU-framework SHARED ${sources})
+  iplug_add_target(${plugin_name}AU-framework PUBLIC
+    LINK iPlug2::AUv3 ${ui_lib} ${base_lib}
+  )
+  iplug_configure_target(${plugin_name}AU-framework AUv3Framework ${plugin_name})
+
+  # App Extension (appex) - executable using NSExtensionMain entry point
+  iplug_get_auv3appex_source(${plugin_name} APPEX_SOURCE)
+  add_executable(${plugin_name}AUv3-appex ${APPEX_SOURCE})
+  iplug_configure_target(${plugin_name}AUv3-appex AUv3Appex ${plugin_name})
+
+  # Embed AUv3 appex in the APP target if it exists
+  if("APP" IN_LIST formats AND TARGET ${plugin_name}-app)
+    iplug_embed_auv3_in_app(${plugin_name}-app ${plugin_name})
+  endif()
+endfunction()
+
+# ============================================================================
+# Create iOS targets - AUv3 Framework + Appex + Standalone App
+# iOS always builds AUv3 (it's the only plugin format for iOS)
+# ============================================================================
+function(_iplug_create_ios_targets plugin_name formats sources ui_lib resources web_resources base_lib)
+  if(NOT IOS)
+    return()
+  endif()
+
+  # iOS AUv3 Framework containing plugin code
+  # Note: Resources are NOT added to the framework - the appex loads them
+  # from the parent app's Resources folder (see IPlugPaths.mm)
+  add_library(${plugin_name}AU-ios-framework SHARED ${sources})
+  iplug_add_target(${plugin_name}AU-ios-framework PUBLIC
+    LINK iPlug2::AUv3iOS ${ui_lib} ${base_lib}
+  )
+  iplug_configure_target(${plugin_name}AU-ios-framework AUv3iOSFramework ${plugin_name})
+
+  # iOS AUv3 App Extension (appex)
+  iplug_get_auv3ios_appex_source(${plugin_name} IOS_APPEX_SOURCE)
+  add_executable(${plugin_name}AUv3-ios-appex ${IOS_APPEX_SOURCE})
+  iplug_configure_target(${plugin_name}AUv3-ios-appex AUv3iOSAppex ${plugin_name})
+
+  # iOS Standalone App that hosts the AUv3 for testing
+  add_executable(${plugin_name}-ios-app ${sources})
+  iplug_add_target(${plugin_name}-ios-app PUBLIC
+    LINK iPlug2::AUv3iOS ${ui_lib} ${base_lib}
+  )
+  iplug_configure_target(${plugin_name}-ios-app IOSApp ${plugin_name})
+  _iplug_add_resources(${plugin_name}-ios-app "${resources}")
+  _iplug_add_web_resources(${plugin_name}-ios-app "${web_resources}")
+
+  # Embed AUv3 appex and framework in the iOS app
+  iplug_embed_auv3ios_in_app(${plugin_name}-ios-app ${plugin_name})
+endfunction()
+
+# ============================================================================
+# Create WAM/Web targets (Emscripten only)
+# ============================================================================
+function(_iplug_create_wam_targets plugin_name formats sources site_origin base_lib)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    return()
+  endif()
+
+  if(NOT "WAM" IN_LIST formats)
+    return()
+  endif()
+
+  # Default site origin
+  if(NOT site_origin)
+    set(site_origin "/")
+  endif()
+
+  # WAM Processor target (DSP/audio worklet)
+  add_executable(${plugin_name}-wam ${sources})
+  iplug_add_target(${plugin_name}-wam PUBLIC
+    LINK iPlug2::WAM ${base_lib}
+  )
+  iplug_configure_target(${plugin_name}-wam WAM ${plugin_name})
+
+  # Web Controller target (UI/graphics)
+  add_executable(${plugin_name}-web ${sources})
+  iplug_add_target(${plugin_name}-web PUBLIC
+    LINK iPlug2::Web ${base_lib}
+  )
+  iplug_configure_target(${plugin_name}-web Web ${plugin_name})
+
+  # Combined WAM distribution target
+  iplug_build_wam_dist(${plugin_name}
+    WAM_TARGET ${plugin_name}-wam
+    WEB_TARGET ${plugin_name}-web
+    SITE_ORIGIN "${site_origin}"
+  )
+endfunction()
+
+# ============================================================================
+# Add web resources to a bundle target (preserves subdirectory structure under Resources/web/)
+# ============================================================================
+function(_iplug_add_web_resources target resources)
+  if(NOT resources)
+    return()
+  endif()
+  target_sources(${target} PRIVATE ${resources})
+  foreach(resource ${resources})
+    # Get the path relative to resources/web/ to preserve subdirectories
+    get_filename_component(_abs_path "${resource}" ABSOLUTE)
+    string(FIND "${_abs_path}" "/resources/web/" _web_pos)
+    if(_web_pos GREATER -1)
+      math(EXPR _start "${_web_pos} + 15")  # length of "/resources/web/"
+      string(SUBSTRING "${_abs_path}" ${_start} -1 _rel_path)
+      get_filename_component(_subdir "${_rel_path}" DIRECTORY)
+      if(_subdir)
+        set(_location "Resources/web/${_subdir}")
+      else()
+        set(_location "Resources/web")
+      endif()
+    else()
+      set(_location "Resources/web")
+    endif()
+    set_source_files_properties(${resource} PROPERTIES
+      MACOSX_PACKAGE_LOCATION "${_location}"
+    )
+  endforeach()
+endfunction()
+
+# ============================================================================
+# Main macro: iplug_add_plugin
+# ============================================================================
+macro(iplug_add_plugin plugin_name)
+  cmake_parse_arguments(PLUGIN
+    ""
+    "UI;WAM_SITE_ORIGIN"
+    "SOURCES;RESOURCES;WEB_RESOURCES;FORMATS;EXCLUDE_FORMATS;LINK;DEFINES"
+    ${ARGN}
+  )
+
+  # ---------------------------------------------------------------------------
+  # Input validation
+  # ---------------------------------------------------------------------------
+
+  # Check for unparsed/unknown arguments
+  if(PLUGIN_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "iplug_add_plugin(${plugin_name}): Unknown arguments: ${PLUGIN_UNPARSED_ARGUMENTS}\n"
+      "Valid options: SOURCES, RESOURCES, WEB_RESOURCES, FORMATS, EXCLUDE_FORMATS, LINK, DEFINES, UI, WAM_SITE_ORIGIN")
+  endif()
+
+  # Validate plugin name
+  if("${plugin_name}" STREQUAL "")
+    message(FATAL_ERROR "iplug_add_plugin: Plugin name is required")
+  endif()
+  if("${plugin_name}" MATCHES "^[0-9]" OR "${plugin_name}" MATCHES "[^a-zA-Z0-9_-]")
+    message(FATAL_ERROR "iplug_add_plugin: Invalid plugin name '${plugin_name}'\n"
+      "Plugin name must start with a letter and contain only alphanumeric characters, underscores, and hyphens")
+  endif()
+
+  # Validate SOURCES (required)
+  if(NOT PLUGIN_SOURCES)
+    message(FATAL_ERROR "iplug_add_plugin(${plugin_name}): SOURCES is required")
+  endif()
+
+  # Validate UI type
+  set(_iplug_valid_ui_types IGRAPHICS WEBVIEW NONE)
+  if(PLUGIN_UI AND NOT PLUGIN_UI IN_LIST _iplug_valid_ui_types)
+    message(FATAL_ERROR "iplug_add_plugin(${plugin_name}): Invalid UI type '${PLUGIN_UI}'\n"
+      "Valid UI types: ${_iplug_valid_ui_types}")
+  endif()
+
+  # Validate FORMATS
+  set(_iplug_valid_formats APP VST2 VST3 CLAP AAX AU AUV3 WAM)
+  set(_iplug_valid_format_groups ALL ALL_PLUGINS ALL_DESKTOP MINIMAL_PLUGINS DESKTOP WEB)
+  if(PLUGIN_FORMATS)
+    foreach(_fmt ${PLUGIN_FORMATS})
+      if(NOT _fmt IN_LIST _iplug_valid_formats AND NOT _fmt IN_LIST _iplug_valid_format_groups)
+        message(FATAL_ERROR "iplug_add_plugin(${plugin_name}): Invalid format '${_fmt}'\n"
+          "Valid formats: ${_iplug_valid_formats}\n"
+          "Valid format groups: ${_iplug_valid_format_groups}")
+      endif()
+    endforeach()
+  endif()
+
+  # Validate EXCLUDE_FORMATS
+  if(PLUGIN_EXCLUDE_FORMATS)
+    foreach(_fmt ${PLUGIN_EXCLUDE_FORMATS})
+      if(NOT _fmt IN_LIST _iplug_valid_formats)
+        message(FATAL_ERROR "iplug_add_plugin(${plugin_name}): Invalid exclude format '${_fmt}'\n"
+          "Valid formats for exclusion: ${_iplug_valid_formats}")
+      endif()
+    endforeach()
+  endif()
+
+  # Set defaults
+  if(NOT PLUGIN_UI)
+    set(PLUGIN_UI "IGRAPHICS")
+  endif()
+  if(NOT PLUGIN_FORMATS)
+    set(PLUGIN_FORMATS "ALL")
+  endif()
+
+  # Expand format groups and apply exclusions
+  _iplug_expand_formats("${PLUGIN_FORMATS}" _iplug_formats)
+  if(PLUGIN_EXCLUDE_FORMATS)
+    list(REMOVE_ITEM _iplug_formats ${PLUGIN_EXCLUDE_FORMATS})
+  endif()
+
+  # Determine UI library and include necessary modules
+  if(PLUGIN_UI STREQUAL "IGRAPHICS")
+    set(_iplug_ui_lib ${IGRAPHICS_LIB})
+  elseif(PLUGIN_UI STREQUAL "WEBVIEW")
+    include(${IPLUG2_CMAKE_DIR}/WebView.cmake)
+    set(_iplug_ui_lib iPlug2::WebView)
+  else()
+    set(_iplug_ui_lib "")
+  endif()
+
+  # Standard project setup
+  set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  set(PLUG_RESOURCES_DIR ${PROJECT_DIR}/resources)
+
+  # Create base interface library for shared configuration
+  add_library(_${plugin_name}-base INTERFACE)
+  iplug_add_target(_${plugin_name}-base INTERFACE
+    INCLUDE ${PROJECT_DIR} ${PROJECT_DIR}/resources
+    LINK iPlug2::IPlug ${PLUGIN_LINK}
+    DEFINE ${PLUGIN_DEFINES}
+  )
+
+  # Create format targets
+  _iplug_create_desktop_targets(${plugin_name} "${_iplug_formats}" "${PLUGIN_SOURCES}" "${_iplug_ui_lib}" "${PLUGIN_RESOURCES}" "${PLUGIN_WEB_RESOURCES}" "_${plugin_name}-base")
+  _iplug_create_au_targets(${plugin_name} "${_iplug_formats}" "${PLUGIN_SOURCES}" "${_iplug_ui_lib}" "${PLUGIN_RESOURCES}" "${PLUGIN_WEB_RESOURCES}" "_${plugin_name}-base")
+  _iplug_create_auv3_targets(${plugin_name} "${_iplug_formats}" "${PLUGIN_SOURCES}" "${_iplug_ui_lib}" "${PLUGIN_RESOURCES}" "${PLUGIN_WEB_RESOURCES}" "_${plugin_name}-base")
+  _iplug_create_ios_targets(${plugin_name} "${_iplug_formats}" "${PLUGIN_SOURCES}" "${_iplug_ui_lib}" "${PLUGIN_RESOURCES}" "${PLUGIN_WEB_RESOURCES}" "_${plugin_name}-base")
+  _iplug_create_wam_targets(${plugin_name} "${_iplug_formats}" "${PLUGIN_SOURCES}" "${PLUGIN_WAM_SITE_ORIGIN}" "_${plugin_name}-base")
+endmacro()

--- a/Scripts/cmake/ReaperExt.cmake
+++ b/Scripts/cmake/ReaperExt.cmake
@@ -1,0 +1,127 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# REAPER Extension configuration for iPlug2
+# This module provides ReaperExtBase for building REAPER extension plugins
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::ReaperExt)
+  add_library(iPlug2::ReaperExt INTERFACE IMPORTED)
+
+  set(REAPER_EXT_DIR ${IPLUG2_DIR}/IPlug/ReaperExt)
+  set(REAPER_SDK_DIR ${IPLUG_DEPS_DIR}/REAPER_SDK)
+  set(SWELL_DIR ${WDL_DIR}/swell)
+
+  # Note: ReaperExtBase.cpp is #included by ReaperExt_include_in_plug_src.h
+  # so we don't add it as a separate source file
+  set(REAPER_EXT_SRC
+    ${REAPER_EXT_DIR}/ReaperExtBase.h
+    ${REAPER_EXT_DIR}/ReaperExt_include_in_plug_hdr.h
+    ${REAPER_EXT_DIR}/ReaperExt_include_in_plug_src.h
+  )
+
+  target_sources(iPlug2::ReaperExt INTERFACE ${REAPER_EXT_SRC})
+
+  target_include_directories(iPlug2::ReaperExt INTERFACE
+    ${REAPER_EXT_DIR}
+    ${REAPER_SDK_DIR}
+  )
+
+  target_compile_definitions(iPlug2::ReaperExt INTERFACE
+    REAPER_EXT_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  if(WIN32)
+    # Windows builds as DLL
+    target_link_libraries(iPlug2::ReaperExt INTERFACE
+      iPlug2::IPlug
+    )
+  elseif(APPLE)
+    # macOS needs SWELL for dialogs and window management
+    target_include_directories(iPlug2::ReaperExt INTERFACE ${SWELL_DIR})
+
+    set(SWELL_SRC
+      "${SWELL_DIR}/swell.cpp"
+      "${SWELL_DIR}/swell-ini.cpp"
+      "${SWELL_DIR}/swell-dlg.mm"
+      "${SWELL_DIR}/swell-gdi.mm"
+      "${SWELL_DIR}/swell-kb.mm"
+      "${SWELL_DIR}/swell-menu.mm"
+      "${SWELL_DIR}/swell-misc.mm"
+      "${SWELL_DIR}/swell-miscdlg.mm"
+      "${SWELL_DIR}/swell-wnd.mm"
+    )
+
+    target_sources(iPlug2::ReaperExt INTERFACE ${SWELL_SRC})
+
+    # SWELL uses deprecated functions
+    set_source_files_properties(${SWELL_SRC}
+      PROPERTIES
+      COMPILE_FLAGS "-Wno-deprecated-declarations"
+    )
+
+    target_compile_definitions(iPlug2::ReaperExt INTERFACE
+      SWELL_PROVIDED_BY_APP
+    )
+
+    target_link_libraries(iPlug2::ReaperExt INTERFACE
+      "-framework Cocoa"
+      "-framework Carbon"
+      "-undefined dynamic_lookup"
+      iPlug2::IPlug
+    )
+  endif()
+endif()
+
+# Configure a REAPER extension target
+function(iplug_configure_reaperext target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::ReaperExt)
+
+  set_target_properties(${target} PROPERTIES
+    CXX_STANDARD ${IPLUG2_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+  )
+
+  if(APPLE)
+    target_compile_definitions(${target} PRIVATE OBJC_PREFIX=v${project_name}_reaperext)
+
+    iplug_apply_objc_prefix_header(${target})
+  endif()
+
+  if(WIN32)
+    set(REAPER_EXT_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      LIBRARY_OUTPUT_DIRECTORY "${REAPER_EXT_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${REAPER_EXT_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${REAPER_EXT_OUTPUT_DIR}"
+      SUFFIX ".dll"
+    )
+  elseif(APPLE)
+    set(REAPER_EXT_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      LIBRARY_OUTPUT_DIRECTORY "${REAPER_EXT_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${REAPER_EXT_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${REAPER_EXT_OUTPUT_DIR}"
+      SUFFIX ".dylib"
+      PREFIX ""
+      # Skip code signing during build
+      XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    )
+  endif()
+
+  # Auto-deploy to REAPER UserPlugins if enabled
+  if(IPLUG_DEPLOY_PLUGINS)
+    iplug_deploy_target(${target} REAPEREXT ${project_name})
+  endif()
+endfunction()

--- a/Scripts/cmake/VST2.cmake
+++ b/Scripts/cmake/VST2.cmake
@@ -1,0 +1,112 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# VST2 target configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::VST2)
+  # Define SDK path
+  set(VST2_SDK_DIR ${IPLUG_DEPS_DIR}/VST2_SDK)
+
+  # Check if VST2 SDK exists (must have aeffectx.h header)
+  if(NOT EXISTS ${VST2_SDK_DIR}/pluginterfaces/vst2.x/aeffectx.h)
+    # Also check root directory for older SDK layouts
+    if(NOT EXISTS ${VST2_SDK_DIR}/aeffectx.h)
+      message(STATUS "VST2 SDK not found at ${VST2_SDK_DIR}. VST2 targets will not be available.")
+      set(IPLUG2_VST2_SUPPORTED FALSE CACHE INTERNAL "VST2 SDK available")
+      # Create a dummy iPlug2::VST2 target so projects can link to it without errors
+      add_library(iPlug2::VST2 INTERFACE IMPORTED)
+      # Define stub function that excludes the target from default build
+      function(iplug_configure_vst2 target project_name)
+        message(STATUS "Skipping VST2 target '${target}' - VST2 SDK not available")
+        set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endfunction()
+      return()
+    endif()
+  endif()
+
+  set(IPLUG2_VST2_SUPPORTED TRUE CACHE INTERNAL "VST2 SDK available")
+
+  add_library(iPlug2::VST2 INTERFACE IMPORTED)
+
+  # iPlug2 VST2 wrapper sources
+  set(VST2_IPLUG_SRC
+    ${IPLUG_DIR}/VST2/IPlugVST2.cpp
+  )
+
+  target_sources(iPlug2::VST2 INTERFACE ${VST2_IPLUG_SRC})
+
+  target_include_directories(iPlug2::VST2 INTERFACE
+    ${IPLUG_DIR}/VST2
+    ${VST2_SDK_DIR}
+  )
+
+  target_compile_definitions(iPlug2::VST2 INTERFACE
+    VST2_API
+    VST_FORCE_DEPRECATED
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+  )
+
+  if(WIN32)
+    # Windows VST2 support - no additional dependencies
+  elseif(APPLE)
+    # Set Obj-C++ for iPlug2 VST2 wrapper on macOS
+    set_source_files_properties(${VST2_IPLUG_SRC} PROPERTIES LANGUAGE OBJCXX)
+
+    target_link_libraries(iPlug2::VST2 INTERFACE
+      "-framework Cocoa"
+    )
+  elseif(UNIX AND NOT APPLE)
+    # Linux support - to be added later
+    message(WARNING "VST2 Linux support not yet implemented")
+  endif()
+
+  target_link_libraries(iPlug2::VST2 INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for VST2 targets
+function(iplug_configure_vst2 target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::VST2)
+
+  if(WIN32)
+    set(VST2_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out")
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      SUFFIX ".dll"
+      LIBRARY_OUTPUT_DIRECTORY "${VST2_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${VST2_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${VST2_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${VST2_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${VST2_OUTPUT_DIR}"
+    )
+  elseif(APPLE)
+    # VST2 on macOS is a bundle with .vst extension
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "vst"
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-VST2-Info.plist
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      MACOSX_BUNDLE_BUNDLE_NAME "${project_name}"
+      OUTPUT_NAME "${project_name}"
+      XCODE_ATTRIBUTE_WRAPPER_EXTENSION "vst"
+      XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
+    )
+
+    # For non-Xcode generators (e.g., Ninja), create PkgInfo file manually
+    if(NOT XCODE)
+      set(PKGINFO_PATH "${CMAKE_BINARY_DIR}/out/${project_name}.vst/Contents/PkgInfo")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.vst/Contents"
+        COMMAND ${CMAKE_COMMAND} -E copy "${IPLUG2_PKGINFO_FILE}" "${PKGINFO_PATH}"
+        COMMENT "Creating PkgInfo for ${project_name}.vst"
+      )
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/VST3.cmake
+++ b/Scripts/cmake/VST3.cmake
@@ -1,0 +1,194 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# VST3 target configuration for iPlug2
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::VST3)
+  # Define SDK path
+  set(VST3_SDK_DIR ${IPLUG_DEPS_DIR}/VST3_SDK)
+
+  # Check if VST3 SDK exists
+  if(NOT EXISTS ${VST3_SDK_DIR})
+    message(STATUS "VST3 SDK not found at ${VST3_SDK_DIR}. VST3 targets will not be available.")
+    set(IPLUG2_VST3_SUPPORTED FALSE CACHE INTERNAL "VST3 SDK available")
+    # Create a dummy iPlug2::VST3 target so projects can link to it without errors
+    add_library(iPlug2::VST3 INTERFACE IMPORTED)
+    # Define stub function that excludes the target from default build
+    function(iplug_configure_vst3 target project_name)
+      message(STATUS "Skipping VST3 target '${target}' - VST3 SDK not available")
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endfunction()
+    return()
+  endif()
+
+  set(IPLUG2_VST3_SUPPORTED TRUE CACHE INTERNAL "VST3 SDK available")
+
+  add_library(iPlug2::VST3 INTERFACE IMPORTED)
+
+  # iPlug2 VST3 wrapper sources
+  set(VST3_IPLUG_SRC
+    ${IPLUG_DIR}/VST3/IPlugVST3.cpp
+    ${IPLUG_DIR}/VST3/IPlugVST3_ProcessorBase.cpp
+  )
+
+  # VST3 SDK base sources
+  set(VST3_SDK_BASE_SRC
+    ${VST3_SDK_DIR}/base/source/baseiids.cpp
+    ${VST3_SDK_DIR}/base/source/fdebug.cpp
+    ${VST3_SDK_DIR}/base/source/fobject.cpp
+    ${VST3_SDK_DIR}/base/source/fstring.cpp
+    ${VST3_SDK_DIR}/base/source/updatehandler.cpp
+    ${VST3_SDK_DIR}/base/thread/source/flock.cpp
+  )
+
+  # VST3 SDK pluginterfaces sources
+  set(VST3_SDK_PLUGINTERFACES_SRC
+    ${VST3_SDK_DIR}/pluginterfaces/base/funknown.cpp
+    ${VST3_SDK_DIR}/pluginterfaces/base/ustring.cpp
+    ${VST3_SDK_DIR}/pluginterfaces/base/coreiids.cpp
+  )
+
+  # VST3 SDK common sources
+  set(VST3_SDK_COMMON_SRC
+    ${VST3_SDK_DIR}/public.sdk/source/common/pluginview.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/common/commoniids.cpp
+  )
+
+  # VST3 SDK vst sources (single component effect pattern)
+  set(VST3_SDK_VST_SRC
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstbus.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstcomponent.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstcomponentbase.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstparameters.cpp
+    ${VST3_SDK_DIR}/public.sdk/source/vst/vstsinglecomponenteffect.cpp
+  )
+
+  # Combine all SDK sources
+  set(VST3_SDK_SRC
+    ${VST3_SDK_BASE_SRC}
+    ${VST3_SDK_PLUGINTERFACES_SRC}
+    ${VST3_SDK_COMMON_SRC}
+    ${VST3_SDK_VST_SRC}
+  )
+
+  target_sources(iPlug2::VST3 INTERFACE
+    ${VST3_IPLUG_SRC}
+    ${VST3_SDK_SRC}
+  )
+
+  target_include_directories(iPlug2::VST3 INTERFACE
+    ${IPLUG_DIR}/VST3
+    ${VST3_SDK_DIR}
+    ${VST3_SDK_DIR}/pluginterfaces
+    ${VST3_SDK_DIR}/public.sdk
+    ${VST3_SDK_DIR}/public.sdk/source
+    ${VST3_SDK_DIR}/base
+  )
+
+  target_compile_definitions(iPlug2::VST3 INTERFACE
+    VST3_API
+    IPLUG_EDITOR=1
+    IPLUG_DSP=1
+    # VST3 SDK requires one of: DEVELOPMENT, RELEASE, _DEBUG, NDEBUG
+    $<$<CONFIG:Debug>:DEVELOPMENT>
+    $<$<NOT:$<CONFIG:Debug>>:RELEASE>
+  )
+
+  # VST3 SDK main sources (common)
+  target_sources(iPlug2::VST3 INTERFACE
+    ${VST3_SDK_DIR}/public.sdk/source/main/pluginfactory.cpp
+  )
+
+  if(WIN32)
+    target_sources(iPlug2::VST3 INTERFACE
+      ${VST3_SDK_DIR}/public.sdk/source/main/dllmain.cpp
+    )
+  elseif(APPLE)
+    # Set Obj-C++ for iPlug2 VST3 wrapper on macOS
+    set_source_files_properties(${VST3_IPLUG_SRC} PROPERTIES LANGUAGE OBJCXX)
+
+    # macOS entry point
+    target_sources(iPlug2::VST3 INTERFACE
+      ${VST3_SDK_DIR}/public.sdk/source/main/macmain.cpp
+    )
+    target_link_libraries(iPlug2::VST3 INTERFACE
+      "-framework Cocoa"
+    )
+  elseif(UNIX AND NOT APPLE)
+    # Linux support - to be added later
+    message(WARNING "VST3 Linux support not yet implemented")
+  endif()
+
+  target_link_libraries(iPlug2::VST3 INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for VST3 targets
+function(iplug_configure_vst3 target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::VST3)
+
+  if(WIN32)
+    # Determine architecture for VST3 bundle path
+    # VST3 spec: x86_64-win, x86-win, arm64-win, arm64ec-win
+    if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64EC")
+      set(VST3_ARCH "arm64ec-win")
+    elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
+      set(VST3_ARCH "arm64-win")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(VST3_ARCH "x86_64-win")
+    else()
+      set(VST3_ARCH "x86-win")
+    endif()
+
+    set(VST3_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out/${project_name}.vst3/Contents/${VST3_ARCH}")
+
+    # Build directly into bundle structure
+    # Set for all configs to avoid multi-config generator adding /Release/ etc
+    set_target_properties(${target} PROPERTIES
+      OUTPUT_NAME "${project_name}"
+      SUFFIX ".vst3"
+      LIBRARY_OUTPUT_DIRECTORY "${VST3_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${VST3_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${VST3_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${VST3_OUTPUT_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${VST3_OUTPUT_DIR}"
+    )
+
+    # Create Resources folder for bundle completeness
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/out/${project_name}.vst3/Contents/Resources"
+      COMMENT "Creating VST3 bundle structure for ${project_name}"
+    )
+  elseif(APPLE)
+    # VST3 on macOS is a bundle with .vst3 extension
+    set_target_properties(${target} PROPERTIES
+      BUNDLE TRUE
+      BUNDLE_EXTENSION "vst3"
+      MACOSX_BUNDLE_INFO_PLIST ${PLUG_RESOURCES_DIR}/${project_name}-VST3-Info.plist
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out"
+      MACOSX_BUNDLE_BUNDLE_NAME "${project_name}"
+      OUTPUT_NAME "${project_name}"
+      XCODE_ATTRIBUTE_WRAPPER_EXTENSION "vst3"
+      XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
+    )
+
+    # For non-Xcode generators (e.g., Ninja), create PkgInfo file manually
+    # Generate PkgInfo at configure time for deterministic output (no platform-dependent newlines)
+    if(NOT XCODE)
+      set(VST3_PKGINFO_PATH "${CMAKE_BINARY_DIR}/iplug2_pkginfo/VST3_PkgInfo")
+      file(WRITE "${VST3_PKGINFO_PATH}" "BNDL????")
+      set(PKGINFO_DEST "${CMAKE_BINARY_DIR}/out/${project_name}.vst3/Contents/PkgInfo")
+      add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${VST3_PKGINFO_PATH}" "${PKGINFO_DEST}"
+        COMMENT "Creating PkgInfo for ${project_name}.vst3"
+      )
+    endif()
+  endif()
+endfunction()

--- a/Scripts/cmake/WAM.cmake
+++ b/Scripts/cmake/WAM.cmake
@@ -1,0 +1,105 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# WAM (Web Audio Module) processor target configuration for iPlug2
+# This creates the DSP/audio worklet WASM module
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::WAM)
+  # Only create WAM target when building with Emscripten
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    message(STATUS "WAM target requires Emscripten toolchain - skipping")
+    return()
+  endif()
+
+  add_library(iPlug2::WAM INTERFACE IMPORTED)
+
+  # WAM SDK path
+  set(WAM_SDK_DIR ${IPLUG_DEPS_DIR}/WAM_SDK/wamsdk)
+  set(IPLUG_WEB_DIR ${IPLUG_DIR}/WEB)
+
+  # Check WAM SDK exists
+  if(NOT EXISTS ${WAM_SDK_DIR})
+    message(WARNING "WAM_SDK not found at ${WAM_SDK_DIR}. WAM target will not be available.")
+    return()
+  endif()
+
+  # WAM processor sources
+  set(WAM_SRC
+    ${IPLUG_WEB_DIR}/IPlugWAM.cpp
+    ${WAM_SDK_DIR}/processor.cpp
+    ${IPLUG_DIR}/IPlugProcessor.cpp
+  )
+
+  target_sources(iPlug2::WAM INTERFACE ${WAM_SRC})
+
+  set(IGRAPHICS_DIR ${IPLUG2_DIR}/IGraphics)
+  set(IGRAPHICS_DEPS_DIR ${DEPS_DIR}/IGraphics)
+
+  # Include IGraphics paths so plugin sources can find headers even with NO_IGRAPHICS
+  # (the headers need to exist for includes, but NO_IGRAPHICS prevents compilation)
+  target_include_directories(iPlug2::WAM INTERFACE
+    ${IPLUG_WEB_DIR}
+    ${WAM_SDK_DIR}
+    ${IGRAPHICS_DIR}
+    ${IGRAPHICS_DIR}/Controls
+    ${IGRAPHICS_DIR}/Platforms
+    ${IGRAPHICS_DIR}/Drawing
+    ${IGRAPHICS_DIR}/Extras
+    ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+    ${IGRAPHICS_DEPS_DIR}/STB
+    ${IGRAPHICS_DEPS_DIR}/yoga
+    ${IGRAPHICS_DEPS_DIR}/yoga/yoga
+  )
+
+  target_compile_definitions(iPlug2::WAM INTERFACE
+    WAM_API
+    IPLUG_DSP=1
+    NO_IGRAPHICS
+    SAMPLE_TYPE_FLOAT
+    WDL_NO_DEFINE_MINMAX
+    NDEBUG=1
+  )
+
+  # WAM processor exported functions
+  set(WAM_EXPORTS "'_malloc','_free','_createModule','_wam_init','_wam_terminate','_wam_resize','_wam_onprocess','_wam_onmidi','_wam_onsysex','_wam_onparam','_wam_onmessageN','_wam_onmessageS','_wam_onmessageA','_wam_onpatch'")
+
+  # Emscripten link flags for WAM processor
+  # - SINGLE_FILE=1: Embed WASM as BASE64 in JS (required for AudioWorklet)
+  # - BINARYEN_ASYNC_COMPILATION=0: Sync compilation (required for worklet scope)
+  # - EXPORT_NAME: Factory function name for the module
+  target_link_options(iPlug2::WAM INTERFACE
+    "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+    "--bind"
+    "SHELL:-s EXPORTED_FUNCTIONS=[${WAM_EXPORTS}]"
+    "SHELL:-s EXPORTED_RUNTIME_METHODS=['ccall','cwrap','setValue','UTF8ToString']"
+    "SHELL:-s BINARYEN_ASYNC_COMPILATION=0"
+    "SHELL:-s SINGLE_FILE=1"
+    "SHELL:-s EXPORT_NAME='ModuleFactory'"
+    "SHELL:-s ASSERTIONS=0"
+    "--pre-js=${IPLUG2_DIR}/IPlug/WEB/Template/scripts/atob-polyfill.js"
+  )
+
+  target_compile_options(iPlug2::WAM INTERFACE
+    -Wno-bitwise-op-parentheses
+  )
+
+  target_link_libraries(iPlug2::WAM INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for WAM targets
+function(iplug_configure_wam target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::WAM)
+
+  set_target_properties(${target} PROPERTIES
+    OUTPUT_NAME "${project_name}-wam"
+    SUFFIX ".js"
+  )
+endfunction()

--- a/Scripts/cmake/WAMDist.cmake
+++ b/Scripts/cmake/WAMDist.cmake
@@ -1,0 +1,341 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# WAMDist.cmake - WAM distribution build orchestration
+#
+# This module provides functions for building a complete WAM distribution:
+# - Resource bundling (fonts, images, SVGs)
+# - JavaScript post-processing
+# - Template copying and configuration
+# - Build orchestration
+
+# Only available with Emscripten toolchain
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  return()
+endif()
+
+# Find Python (required for file_packager.py and template configuration)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Path to iPlug2 helper scripts
+set(IPLUG2_SCRIPTS_DIR ${IPLUG2_DIR}/Scripts)
+set(IPLUG2_CMAKE_SCRIPTS_DIR ${IPLUG2_SCRIPTS_DIR}/cmake)
+
+# WAM template and SDK paths
+set(WAM_TEMPLATE_DIR ${IPLUG2_DIR}/IPlug/WEB/Template)
+set(WAM_SDK_DIR ${IPLUG_DEPS_DIR}/WAM_SDK/wamsdk)
+set(WAM_AWP_DIR ${IPLUG_DEPS_DIR}/WAM_AWP)
+
+# ============================================================================
+# Parse channel I/O from config.h
+# ============================================================================
+function(iplug_parse_channel_io project_dir out_max_inputs out_max_outputs)
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} ${IPLUG2_SCRIPTS_DIR}/parse_iostr.py ${project_dir} inputs
+    OUTPUT_VARIABLE max_in
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE result_in
+  )
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} ${IPLUG2_SCRIPTS_DIR}/parse_iostr.py ${project_dir} outputs
+    OUTPUT_VARIABLE max_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE result_out
+  )
+
+  if(NOT result_in EQUAL 0)
+    message(WARNING "Failed to parse inputs from config.h, defaulting to 0")
+    set(max_in 0)
+  endif()
+  if(NOT result_out EQUAL 0)
+    message(WARNING "Failed to parse outputs from config.h, defaulting to 2")
+    set(max_out 2)
+  endif()
+
+  set(${out_max_inputs} ${max_in} PARENT_SCOPE)
+  set(${out_max_outputs} ${max_out} PARENT_SCOPE)
+endfunction()
+
+# ============================================================================
+# Bundle resources using Emscripten's file_packager.py
+# ============================================================================
+function(iplug_bundle_web_resources project_name resource_dir output_dir)
+  # Find file_packager.py from EMSDK
+  if(NOT DEFINED ENV{EMSDK})
+    message(WARNING "EMSDK environment variable not set - resource bundling may fail")
+    set(FILE_PACKAGER "file_packager.py")
+  else()
+    set(FILE_PACKAGER "$ENV{EMSDK}/upstream/emscripten/tools/file_packager.py")
+  endif()
+
+  # Output files
+  set(FONTS_DATA "${output_dir}/fonts.data")
+  set(FONTS_JS "${output_dir}/fonts.js")
+  set(IMGS_DATA "${output_dir}/imgs.data")
+  set(IMGS_JS "${output_dir}/imgs.js")
+  set(SVGS_DATA "${output_dir}/svgs.data")
+  set(SVGS_JS "${output_dir}/svgs.js")
+  set(IMGS2X_DATA "${output_dir}/imgs@2x.data")
+  set(IMGS2X_JS "${output_dir}/imgs@2x.js")
+
+  # Create resource bundling commands
+  set(RESOURCE_OUTPUTS "")
+  set(RESOURCE_COMMANDS "")
+
+  # Bundle fonts
+  if(EXISTS "${resource_dir}/fonts")
+    list(APPEND RESOURCE_OUTPUTS ${FONTS_DATA} ${FONTS_JS})
+    add_custom_command(
+      OUTPUT ${FONTS_DATA} ${FONTS_JS}
+      COMMAND ${Python3_EXECUTABLE} ${FILE_PACKAGER} ${FONTS_DATA}
+        --preload "${resource_dir}/fonts/"
+        --exclude "*DS_Store"
+        --js-output=${FONTS_JS}
+      WORKING_DIRECTORY ${output_dir}
+      COMMENT "Bundling fonts for ${project_name}"
+      VERBATIM
+    )
+  endif()
+
+  # Bundle SVGs
+  file(GLOB SVG_FILES "${resource_dir}/img/*.svg")
+  if(SVG_FILES)
+    list(APPEND RESOURCE_OUTPUTS ${SVGS_DATA} ${SVGS_JS})
+    add_custom_command(
+      OUTPUT ${SVGS_DATA} ${SVGS_JS}
+      COMMAND ${Python3_EXECUTABLE} ${FILE_PACKAGER} ${SVGS_DATA}
+        --preload "${resource_dir}/img/"
+        --exclude "*.png"
+        --exclude "*DS_Store"
+        --js-output=${SVGS_JS}
+      WORKING_DIRECTORY ${output_dir}
+      COMMENT "Bundling SVGs for ${project_name}"
+      VERBATIM
+    )
+  endif()
+
+  # Bundle @1x PNGs
+  file(GLOB PNG_FILES "${resource_dir}/img/*.png")
+  # Filter out @2x files
+  list(FILTER PNG_FILES EXCLUDE REGEX "@2x")
+  if(PNG_FILES)
+    list(APPEND RESOURCE_OUTPUTS ${IMGS_DATA} ${IMGS_JS})
+    add_custom_command(
+      OUTPUT ${IMGS_DATA} ${IMGS_JS}
+      COMMAND ${Python3_EXECUTABLE} ${FILE_PACKAGER} ${IMGS_DATA}
+        --use-preload-plugins
+        --preload "${resource_dir}/img/"
+        --use-preload-cache
+        --indexedDB-name="/${project_name}_pkg"
+        --exclude "*DS_Store"
+        --exclude "*@2x.png"
+        --exclude "*.svg"
+        --js-output=${IMGS_JS}
+      WORKING_DIRECTORY ${output_dir}
+      COMMENT "Bundling images for ${project_name}"
+      VERBATIM
+    )
+  endif()
+
+  # Bundle @2x PNGs
+  file(GLOB PNG2X_FILES "${resource_dir}/img/*@2x*.png")
+  if(PNG2X_FILES)
+    list(APPEND RESOURCE_OUTPUTS ${IMGS2X_DATA} ${IMGS2X_JS})
+    add_custom_command(
+      OUTPUT ${IMGS2X_DATA} ${IMGS2X_JS}
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}/2x"
+      COMMAND ${CMAKE_COMMAND} -E copy ${PNG2X_FILES} "${output_dir}/2x/"
+      COMMAND ${Python3_EXECUTABLE} ${FILE_PACKAGER} ${IMGS2X_DATA}
+        --use-preload-plugins
+        --preload "${output_dir}/2x@/resources/img/"
+        --use-preload-cache
+        --indexedDB-name="/${project_name}_pkg"
+        --exclude "*DS_Store"
+        --js-output=${IMGS2X_JS}
+      COMMAND ${CMAKE_COMMAND} -E remove_directory "${output_dir}/2x"
+      WORKING_DIRECTORY ${output_dir}
+      COMMENT "Bundling @2x images for ${project_name}"
+      VERBATIM
+    )
+  endif()
+
+  # Create custom target for resource bundling
+  if(RESOURCE_OUTPUTS)
+    add_custom_target(${project_name}_wam_resources
+      DEPENDS ${RESOURCE_OUTPUTS}
+    )
+    set(${project_name}_WAM_RESOURCES_TARGET ${project_name}_wam_resources PARENT_SCOPE)
+  endif()
+endfunction()
+
+# ============================================================================
+# Post-process WAM JS with AudioWorkletGlobalScope wrapper
+# ============================================================================
+function(iplug_postprocess_wam_js wam_target project_name output_dir)
+  set(WAM_JS "${output_dir}/scripts/${project_name}-wam.js")
+  set(WAM_JS_TMP "${WAM_JS}.tmp")
+
+  # The WAM JS needs to be wrapped with AudioWorkletGlobalScope setup
+  # This prefix is prepended to the emscripten output
+  set(AWG_PREFIX "AudioWorkletGlobalScope.WAM = AudioWorkletGlobalScope.WAM || {}; AudioWorkletGlobalScope.WAM.${project_name} = { ENVIRONMENT: 'WEB' }; const ModuleFactory = AudioWorkletGlobalScope.WAM.${project_name};")
+
+  add_custom_command(TARGET ${wam_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "${AWG_PREFIX}" > "${WAM_JS_TMP}"
+    COMMAND ${CMAKE_COMMAND} -E cat "${WAM_JS}" >> "${WAM_JS_TMP}"
+    COMMAND ${CMAKE_COMMAND} -E rename "${WAM_JS_TMP}" "${WAM_JS}"
+    COMMENT "Post-processing ${project_name}-wam.js for AudioWorkletGlobalScope"
+    VERBATIM
+  )
+endfunction()
+
+# ============================================================================
+# Copy WAM SDK and polyfill scripts
+# ============================================================================
+function(iplug_copy_wam_sdk_scripts web_target output_dir)
+  add_custom_command(TARGET ${web_target} POST_BUILD
+    # WAM SDK scripts
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${WAM_SDK_DIR}/wam-controller.js"
+      "${output_dir}/scripts/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${WAM_SDK_DIR}/wam-processor.js"
+      "${output_dir}/scripts/"
+    # AudioWorklet polyfill
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${WAM_AWP_DIR}/audioworklet.js"
+      "${output_dir}/scripts/"
+    COMMENT "Copying WAM SDK scripts"
+    VERBATIM
+  )
+endfunction()
+
+# ============================================================================
+# Copy and configure template files (HTML, JS, CSS)
+# ============================================================================
+function(iplug_copy_web_templates web_target project_name output_dir site_origin max_inputs max_outputs)
+  set(CONFIGURE_SCRIPT "${IPLUG2_CMAKE_SCRIPTS_DIR}/configure_web_template.py")
+
+  # Configure index.html
+  add_custom_command(TARGET ${web_target} POST_BUILD
+    COMMAND ${Python3_EXECUTABLE} "${CONFIGURE_SCRIPT}"
+      --input "${WAM_TEMPLATE_DIR}/index.html"
+      --output "${output_dir}/index.html"
+      --name "${project_name}"
+      --origin "${site_origin}"
+      --max-inputs "${max_inputs}"
+      --max-outputs "${max_outputs}"
+    COMMENT "Configuring index.html for ${project_name}"
+    VERBATIM
+  )
+
+  # Configure AWN (Audio Worklet Node) script
+  add_custom_command(TARGET ${web_target} POST_BUILD
+    COMMAND ${Python3_EXECUTABLE} "${CONFIGURE_SCRIPT}"
+      --input "${WAM_TEMPLATE_DIR}/scripts/IPlugWAM-awn.js"
+      --output "${output_dir}/scripts/${project_name}-awn.js"
+      --name "${project_name}"
+      --origin "${site_origin}"
+    COMMENT "Configuring ${project_name}-awn.js"
+    VERBATIM
+  )
+
+  # Configure AWP (Audio Worklet Processor) script
+  add_custom_command(TARGET ${web_target} POST_BUILD
+    COMMAND ${Python3_EXECUTABLE} "${CONFIGURE_SCRIPT}"
+      --input "${WAM_TEMPLATE_DIR}/scripts/IPlugWAM-awp.js"
+      --output "${output_dir}/scripts/${project_name}-awp.js"
+      --name "${project_name}"
+    COMMENT "Configuring ${project_name}-awp.js"
+    VERBATIM
+  )
+
+  # Copy styles and favicon
+  add_custom_command(TARGET ${web_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}/styles"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${WAM_TEMPLATE_DIR}/styles/style.css"
+      "${output_dir}/styles/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${WAM_TEMPLATE_DIR}/favicon.ico"
+      "${output_dir}/"
+    COMMENT "Copying styles and favicon"
+    VERBATIM
+  )
+endfunction()
+
+# ============================================================================
+# Build complete WAM distribution
+# ============================================================================
+function(iplug_build_wam_dist project_name)
+  cmake_parse_arguments(PARSE_ARGV 1 WAM_DIST
+    ""
+    "WAM_TARGET;WEB_TARGET;SITE_ORIGIN;OUTPUT_DIR"
+    ""
+  )
+
+  # Default values
+  if(NOT WAM_DIST_SITE_ORIGIN)
+    set(WAM_DIST_SITE_ORIGIN "/")
+  endif()
+  if(NOT WAM_DIST_OUTPUT_DIR)
+    # Use project-specific subdirectory to avoid conflicts when building multiple plugins
+    set(WAM_DIST_OUTPUT_DIR "${CMAKE_BINARY_DIR}/out/${project_name}")
+  endif()
+
+  set(OUTPUT_DIR ${WAM_DIST_OUTPUT_DIR})
+  set(SCRIPTS_DIR "${OUTPUT_DIR}/scripts")
+
+  # Create output directories at configure time
+  file(MAKE_DIRECTORY ${OUTPUT_DIR})
+  file(MAKE_DIRECTORY ${SCRIPTS_DIR})
+
+  # Get channel I/O info from config.h
+  iplug_parse_channel_io(${PROJECT_DIR} MAX_INPUTS MAX_OUTPUTS)
+  message(STATUS "${project_name} WAM: max inputs=${MAX_INPUTS}, max outputs=${MAX_OUTPUTS}")
+
+  # 1. Set up WAM processor target output
+  set_target_properties(${WAM_DIST_WAM_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${SCRIPTS_DIR}
+    OUTPUT_NAME "${project_name}-wam"
+    SUFFIX ".js"
+  )
+
+  # 2. Set up Web controller target output
+  set_target_properties(${WAM_DIST_WEB_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${SCRIPTS_DIR}
+    OUTPUT_NAME "${project_name}-web"
+    SUFFIX ".js"
+  )
+
+  # 3. Bundle resources (fonts, images, SVGs)
+  iplug_bundle_web_resources(${project_name} ${PLUG_RESOURCES_DIR} ${OUTPUT_DIR})
+
+  # 4. Post-process WAM JS with AudioWorkletGlobalScope wrapper
+  iplug_postprocess_wam_js(${WAM_DIST_WAM_TARGET} ${project_name} ${OUTPUT_DIR})
+
+  # 5. Copy WAM SDK scripts
+  iplug_copy_wam_sdk_scripts(${WAM_DIST_WEB_TARGET} ${OUTPUT_DIR})
+
+  # 6. Copy and configure template files
+  iplug_copy_web_templates(${WAM_DIST_WEB_TARGET} ${project_name} ${OUTPUT_DIR}
+    "${WAM_DIST_SITE_ORIGIN}" ${MAX_INPUTS} ${MAX_OUTPUTS})
+
+  # Create aggregate target for convenience
+  add_custom_target(${project_name}-wam-dist ALL
+    DEPENDS ${WAM_DIST_WAM_TARGET} ${WAM_DIST_WEB_TARGET}
+    COMMENT "Building complete WAM distribution for ${project_name}"
+  )
+
+  # Add resource dependency if resources exist
+  if(TARGET ${project_name}_wam_resources)
+    add_dependencies(${project_name}-wam-dist ${project_name}_wam_resources)
+  endif()
+
+  message(STATUS "WAM distribution target: ${project_name}-wam-dist")
+  message(STATUS "WAM output directory: ${OUTPUT_DIR}")
+endfunction()

--- a/Scripts/cmake/Web.cmake
+++ b/Scripts/cmake/Web.cmake
@@ -1,0 +1,111 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# Web controller target configuration for iPlug2
+# This creates the UI/graphics WASM module (runs on main thread)
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::Web)
+  # Only create Web target when building with Emscripten
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    message(STATUS "Web target requires Emscripten toolchain - skipping")
+    return()
+  endif()
+
+  add_library(iPlug2::Web INTERFACE IMPORTED)
+
+  set(IGRAPHICS_DIR ${IPLUG2_DIR}/IGraphics)
+  set(IGRAPHICS_DEPS_DIR ${DEPS_DIR}/IGraphics)
+  set(IPLUG_WEB_DIR ${IPLUG_DIR}/WEB)
+
+  # Web controller sources (IGraphics + IPlugWeb)
+  # Note: IGraphicsWeb.cpp #includes IGraphicsNanoVG.cpp (unity build style)
+  # so we do NOT compile IGraphicsNanoVG.cpp separately
+  set(WEB_SRC
+    # IPlug Web API
+    ${IPLUG_WEB_DIR}/IPlugWeb.cpp
+    # IGraphics core
+    ${IGRAPHICS_DIR}/IGraphics.cpp
+    ${IGRAPHICS_DIR}/IControl.cpp
+    ${IGRAPHICS_DIR}/IGraphicsEditorDelegate.cpp
+    # IGraphics controls
+    ${IGRAPHICS_DIR}/Controls/IControls.cpp
+    ${IGRAPHICS_DIR}/Controls/IPopupMenuControl.cpp
+    ${IGRAPHICS_DIR}/Controls/ITextEntryControl.cpp
+    # IGraphics Web platform (includes IGraphicsNanoVG.cpp)
+    ${IGRAPHICS_DIR}/Platforms/IGraphicsWeb.cpp
+  )
+
+  target_sources(iPlug2::Web INTERFACE ${WEB_SRC})
+
+  target_include_directories(iPlug2::Web INTERFACE
+    ${IPLUG_WEB_DIR}
+    ${IGRAPHICS_DIR}
+    ${IGRAPHICS_DIR}/Controls
+    ${IGRAPHICS_DIR}/Platforms
+    ${IGRAPHICS_DIR}/Drawing
+    ${IGRAPHICS_DIR}/Extras
+    ${IGRAPHICS_DEPS_DIR}/NanoVG/src
+    ${IGRAPHICS_DEPS_DIR}/NanoSVG/src
+    ${IGRAPHICS_DEPS_DIR}/STB
+    ${IGRAPHICS_DEPS_DIR}/yoga
+    ${IGRAPHICS_DEPS_DIR}/yoga/yoga
+  )
+
+  target_compile_definitions(iPlug2::Web INTERFACE
+    WEB_API
+    IPLUG_EDITOR=1
+    IGRAPHICS_NANOVG
+    IGRAPHICS_GLES2
+    OS_WEB
+    WDL_NO_DEFINE_MINMAX
+    NDEBUG=1
+  )
+
+  # Web controller exported functions
+  set(WEB_EXPORTS "'_malloc','_free','_main','_iplug_fsready','_iplug_syncfs'")
+
+  # Emscripten link flags for Web controller
+  # - BINARYEN_ASYNC_COMPILATION=1: Async compilation (can run on main thread)
+  # - FORCE_FILESYSTEM=1: Enable IndexedDB filesystem
+  # - USE_WEBGL2=0, FULL_ES3=1: WebGL/GLES configuration for NanoVG
+  target_link_options(iPlug2::Web INTERFACE
+    "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+    "--bind"
+    "SHELL:-s EXPORTED_FUNCTIONS=[${WEB_EXPORTS}]"
+    "SHELL:-s EXPORTED_RUNTIME_METHODS=['ccall','UTF8ToString']"
+    "SHELL:-s BINARYEN_ASYNC_COMPILATION=1"
+    "SHELL:-s FORCE_FILESYSTEM=1"
+    "SHELL:-s ENVIRONMENT=web"
+    "SHELL:-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['\$Browser']"
+    "-lidbfs.js"
+    "SHELL:-s ASSERTIONS=0"
+    # NanoVG WebGL settings
+    "SHELL:-s USE_WEBGL2=0"
+    "SHELL:-s FULL_ES3=1"
+  )
+
+  target_compile_options(iPlug2::Web INTERFACE
+    -Wno-bitwise-op-parentheses
+    # Force-include GLES2 header so GL types are defined before NanoVG
+    -include GLES2/gl2.h
+  )
+
+  target_link_libraries(iPlug2::Web INTERFACE iPlug2::IPlug)
+endif()
+
+# Configuration function for Web targets
+function(iplug_configure_web target project_name)
+  target_link_libraries(${target} PUBLIC iPlug2::Web)
+
+  set_target_properties(${target} PROPERTIES
+    OUTPUT_NAME "${project_name}-web"
+    SUFFIX ".js"
+  )
+endfunction()

--- a/Scripts/cmake/WebView.cmake
+++ b/Scripts/cmake/WebView.cmake
@@ -1,0 +1,121 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# WebView configuration for iPlug2
+# This module provides WebViewEditorDelegate for plugins that use WebView UI instead of IGraphics
+
+include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
+
+if(NOT TARGET iPlug2::WebView)
+  add_library(iPlug2::WebView INTERFACE IMPORTED)
+
+  set(WEBVIEW_DIR ${IPLUG2_DIR}/IPlug/Extras/WebView)
+
+  # Platform-specific WebView sources
+  # Note: IPlugWebView.cpp is #included by IPlugWebView_mac.mm (unity build style)
+  # IPlugWebView_mac.mm also #includes IPlugWKWebView*.mm files
+  if(APPLE)
+    # Files that require ARC
+    set(WEBVIEW_SRC_ARC
+      ${WEBVIEW_DIR}/IPlugWebView_mac.mm
+    )
+    # Files that must NOT use ARC
+    set(WEBVIEW_SRC_NO_ARC
+      ${WEBVIEW_DIR}/IPlugWebViewEditorDelegate.mm
+    )
+    set(WEBVIEW_SRC ${WEBVIEW_SRC_ARC} ${WEBVIEW_SRC_NO_ARC})
+
+    # Set ARC compile option for files that need it
+    set_source_files_properties(${WEBVIEW_SRC_ARC} PROPERTIES
+      COMPILE_FLAGS "-fobjc-arc"
+    )
+  elseif(WIN32)
+    set(WEBVIEW_SRC
+      ${WEBVIEW_DIR}/IPlugWebViewEditorDelegate.cpp
+      ${WEBVIEW_DIR}/IPlugWebView_win.cpp
+    )
+
+    # Fetch WIL (Windows Implementation Libraries) - header-only
+    include(FetchContent)
+    FetchContent_Declare(
+      wil
+      GIT_REPOSITORY https://github.com/microsoft/wil.git
+      GIT_TAG v1.0.240803.1
+      GIT_SHALLOW TRUE
+    )
+    # Disable WIL tests (they require Detours and other dependencies)
+    set(WIL_BUILD_PACKAGING OFF CACHE BOOL "" FORCE)
+    set(WIL_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(wil)
+
+    # Fetch WebView2 NuGet package
+    set(WEBVIEW2_VERSION "1.0.2903.40")
+    set(WEBVIEW2_DIR "${CMAKE_BINARY_DIR}/_deps/webview2")
+    set(WEBVIEW2_NUGET_URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}")
+
+    if(NOT EXISTS "${WEBVIEW2_DIR}/build/native/include/WebView2.h")
+      message(STATUS "Downloading WebView2 SDK ${WEBVIEW2_VERSION}...")
+      file(DOWNLOAD
+        "${WEBVIEW2_NUGET_URL}"
+        "${WEBVIEW2_DIR}/webview2.zip"
+        SHOW_PROGRESS
+        STATUS DOWNLOAD_STATUS
+      )
+      list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+      if(NOT STATUS_CODE EQUAL 0)
+        message(FATAL_ERROR "Failed to download WebView2 SDK")
+      endif()
+
+      file(ARCHIVE_EXTRACT
+        INPUT "${WEBVIEW2_DIR}/webview2.zip"
+        DESTINATION "${WEBVIEW2_DIR}"
+      )
+      file(REMOVE "${WEBVIEW2_DIR}/webview2.zip")
+    endif()
+
+    set(WEBVIEW2_INCLUDE_DIR "${WEBVIEW2_DIR}/build/native/include")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(WEBVIEW2_LIB_DIR "${WEBVIEW2_DIR}/build/native/x64")
+    else()
+      set(WEBVIEW2_LIB_DIR "${WEBVIEW2_DIR}/build/native/x86")
+    endif()
+  endif()
+
+  target_sources(iPlug2::WebView INTERFACE ${WEBVIEW_SRC})
+
+  target_include_directories(iPlug2::WebView INTERFACE
+    ${WEBVIEW_DIR}
+    ${DEPS_DIR}/Extras/nlohmann
+  )
+
+  target_compile_definitions(iPlug2::WebView INTERFACE
+    WEBVIEW_EDITOR_DELEGATE
+    NO_IGRAPHICS
+  )
+
+  if(APPLE)
+    target_link_libraries(iPlug2::WebView INTERFACE
+      "-framework WebKit"
+      iPlug2::IPlug
+    )
+    # WebView uses std::filesystem::path which requires macOS 10.15+
+    # Set compile definition so code can check, and require 10.15 deployment target
+    target_compile_definitions(iPlug2::WebView INTERFACE
+      IPLUG_WEBVIEW_REQUIRES_10_15
+    )
+  elseif(WIN32)
+    target_include_directories(iPlug2::WebView INTERFACE
+      ${wil_SOURCE_DIR}/include
+      ${WEBVIEW2_INCLUDE_DIR}
+    )
+    target_link_libraries(iPlug2::WebView INTERFACE
+      iPlug2::IPlug
+      "${WEBVIEW2_LIB_DIR}/WebView2LoaderStatic.lib"
+    )
+  endif()
+endif()

--- a/Scripts/cmake/configure_web_template.py
+++ b/Scripts/cmake/configure_web_template.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Configure web template files with placeholder replacement.
+
+This script replaces placeholders in iPlug2 web template files (HTML, JS)
+with project-specific values.
+
+Placeholders:
+  NAME_PLACEHOLDER - Project name
+  ORIGIN_PLACEHOLDER - Site origin for script paths (default: "/")
+  MAXNINPUTS_PLACEHOLDER - Maximum number of audio inputs
+  MAXNOUTPUTS_PLACEHOLDER - Maximum number of audio outputs
+"""
+
+import argparse
+import sys
+import os
+
+def configure_template(input_path, output_path, name, origin="/", max_inputs=0, max_outputs=2):
+    """
+    Read a template file and replace placeholders with actual values.
+
+    Args:
+        input_path: Path to template file
+        output_path: Path for output file
+        name: Project name to replace NAME_PLACEHOLDER
+        origin: Site origin to replace ORIGIN_PLACEHOLDER
+        max_inputs: Max audio inputs to replace MAXNINPUTS_PLACEHOLDER
+        max_outputs: Max audio outputs to replace MAXNOUTPUTS_PLACEHOLDER
+    """
+    with open(input_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Replace all placeholders
+    content = content.replace('NAME_PLACEHOLDER', name)
+    content = content.replace('ORIGIN_PLACEHOLDER', origin)
+
+    # For max inputs, use empty string if 0 (instruments don't need input)
+    max_inputs_str = str(max_inputs) if max_inputs > 0 else ''
+    content = content.replace('MAXNINPUTS_PLACEHOLDER', max_inputs_str)
+    content = content.replace('MAXNOUTPUTS_PLACEHOLDER', str(max_outputs))
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Configure iPlug2 web template files with project-specific values'
+    )
+    parser.add_argument('--input', '-i', required=True,
+                        help='Input template file path')
+    parser.add_argument('--output', '-o', required=True,
+                        help='Output file path')
+    parser.add_argument('--name', '-n', required=True,
+                        help='Project name (replaces NAME_PLACEHOLDER)')
+    parser.add_argument('--origin', default='/',
+                        help='Site origin for script paths (default: /)')
+    parser.add_argument('--max-inputs', type=int, default=0,
+                        help='Maximum number of audio inputs (default: 0)')
+    parser.add_argument('--max-outputs', type=int, default=2,
+                        help='Maximum number of audio outputs (default: 2)')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: Input file not found: {args.input}", file=sys.stderr)
+        return 1
+
+    try:
+        configure_template(
+            args.input,
+            args.output,
+            args.name,
+            args.origin,
+            args.max_inputs,
+            args.max_outputs
+        )
+        print(f"Configured: {args.output}")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/cmake/iOS.cmake
+++ b/Scripts/cmake/iOS.cmake
@@ -1,0 +1,113 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# iOS platform configuration for iPlug2
+# Handles SDK selection, deployment targets, and platform-specific settings
+
+# Only proceed if building for iOS or visionOS
+if(NOT CMAKE_SYSTEM_NAME MATCHES "^(iOS|visionOS)$")
+  return()
+endif()
+
+# Set IOS variable for use in conditionals throughout the build
+set(IOS TRUE)
+
+# Detect visionOS from CMAKE_SYSTEM_NAME (CMake 3.28+)
+if(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
+  set(VISIONOS TRUE)
+endif()
+
+# iOS platform option: OS (device), SIMULATOR, or VISIONOS
+# Auto-detect from CMAKE_SYSTEM_NAME for visionOS (CMake 3.28+)
+if(NOT DEFINED IPLUG2_IOS_PLATFORM)
+  if(VISIONOS)
+    # Detect simulator vs device from CMAKE_OSX_SYSROOT if set
+    if(CMAKE_OSX_SYSROOT MATCHES "simulator")
+      set(IPLUG2_IOS_PLATFORM "VISIONOS_SIMULATOR" CACHE STRING "iOS platform")
+    else()
+      set(IPLUG2_IOS_PLATFORM "VISIONOS" CACHE STRING "iOS platform")
+    endif()
+  else()
+    set(IPLUG2_IOS_PLATFORM "OS" CACHE STRING "iOS platform to build for (OS, SIMULATOR, VISIONOS, VISIONOS_SIMULATOR)")
+  endif()
+endif()
+
+# Configure SDK based on platform
+# Note: FORCE is required because CMake's iOS toolchain sets CMAKE_OSX_SYSROOT before our code runs
+if(IPLUG2_IOS_PLATFORM STREQUAL "SIMULATOR")
+  set(CMAKE_OSX_SYSROOT "iphonesimulator" CACHE STRING "iOS SDK" FORCE)
+  set(IPLUG2_IOS_SDK "iphonesimulator")
+elseif(IPLUG2_IOS_PLATFORM STREQUAL "VISIONOS")
+  set(CMAKE_OSX_SYSROOT "xros" CACHE STRING "visionOS SDK" FORCE)
+  set(IPLUG2_IOS_SDK "xros")
+elseif(IPLUG2_IOS_PLATFORM STREQUAL "VISIONOS_SIMULATOR")
+  set(CMAKE_OSX_SYSROOT "xrsimulator" CACHE STRING "visionOS Simulator SDK" FORCE)
+  set(IPLUG2_IOS_SDK "xrsimulator")
+else()
+  # Default to device SDK
+  set(CMAKE_OSX_SYSROOT "iphoneos" CACHE STRING "iOS SDK" FORCE)
+  set(IPLUG2_IOS_SDK "iphoneos")
+endif()
+
+# iOS deployment target
+if(IPLUG2_IOS_PLATFORM MATCHES "VISIONOS")
+  if(NOT DEFINED IPLUG2_XROS_DEPLOYMENT_TARGET)
+    set(IPLUG2_XROS_DEPLOYMENT_TARGET "1.0" CACHE STRING "Minimum visionOS version")
+  endif()
+  set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET ${IPLUG2_XROS_DEPLOYMENT_TARGET})
+else()
+  if(NOT DEFINED IPLUG2_IOS_DEPLOYMENT_TARGET)
+    set(IPLUG2_IOS_DEPLOYMENT_TARGET "14" CACHE STRING "Minimum iOS version")
+  endif()
+  set(CMAKE_OSX_DEPLOYMENT_TARGET ${IPLUG2_IOS_DEPLOYMENT_TARGET})
+  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${IPLUG2_IOS_DEPLOYMENT_TARGET})
+endif()
+
+# Set architectures based on platform
+# Note: FORCE is required because CMake's toolchain may set CMAKE_OSX_ARCHITECTURES before our code runs
+if(IPLUG2_IOS_PLATFORM STREQUAL "SIMULATOR")
+  # iOS Simulator supports both arm64 (Apple Silicon Mac) and x86_64 (Intel Mac)
+  set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "iOS Simulator architectures" FORCE)
+elseif(IPLUG2_IOS_PLATFORM STREQUAL "VISIONOS_SIMULATOR")
+  # visionOS Simulator is arm64 only (no Intel Macs support visionOS)
+  set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "visionOS Simulator architectures" FORCE)
+elseif(IPLUG2_IOS_PLATFORM MATCHES "VISIONOS")
+  set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "visionOS architectures" FORCE)
+else()
+  # iOS device is arm64 only (since iOS 11)
+  set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "iOS device architectures" FORCE)
+endif()
+
+# Set target device family and ibtool flags based on platform
+# Device families: 1=iPhone, 2=iPad, 7=visionOS
+if(IPLUG2_IOS_PLATFORM MATCHES "VISIONOS")
+  set(IPLUG2_TARGETED_DEVICE_FAMILY "7" CACHE STRING "visionOS device family")
+  set(IPLUG2_IBTOOL_TARGET_DEVICES "--target-device" "apple-vision")
+  set(IPLUG2_DEPLOYMENT_TARGET_DISPLAY ${IPLUG2_XROS_DEPLOYMENT_TARGET})
+else()
+  set(IPLUG2_TARGETED_DEVICE_FAMILY "1,2" CACHE STRING "iOS device family")
+  set(IPLUG2_IBTOOL_TARGET_DEVICES "--target-device" "iphone" "--target-device" "ipad")
+  set(IPLUG2_DEPLOYMENT_TARGET_DISPLAY ${IPLUG2_IOS_DEPLOYMENT_TARGET})
+endif()
+
+# Xcode-specific settings
+if(XCODE)
+  # Set SDK root for Xcode
+  set(CMAKE_XCODE_ATTRIBUTE_SDKROOT ${CMAKE_OSX_SYSROOT})
+
+  # Set targeted device family
+  set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY ${IPLUG2_TARGETED_DEVICE_FAMILY})
+
+  # Skip install for iOS builds (not deploying to system locations)
+  set(CMAKE_XCODE_ATTRIBUTE_SKIP_INSTALL "YES")
+
+  # Enable bitcode (optional, deprecated in Xcode 14+)
+  set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
+endif()
+
+message(STATUS "iPlug2 iOS: Platform=${IPLUG2_IOS_PLATFORM}, SDK=${CMAKE_OSX_SYSROOT}, Deployment=${IPLUG2_DEPLOYMENT_TARGET_DISPLAY}")

--- a/Scripts/encode-proprietary-sdks.sh
+++ b/Scripts/encode-proprietary-sdks.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Creates base64-encoded tarballs of proprietary SDKs for GitHub Actions secrets
+# Usage: ./encode-proprietary-sdks.sh
+#
+# Output files can be used as GitHub repository secrets:
+#   VST2_SDK_B64 -> contents of vst2_sdk.b64
+#   AAX_SDK_B64  -> contents of aax_sdk.b64
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SDK_DIR="$REPO_ROOT/Dependencies/IPlug"
+OUTPUT_DIR="$REPO_ROOT"
+
+# Detect base64 command options (macOS vs GNU)
+if base64 --help 2>&1 | grep -q '\-w'; then
+    B64_OPTS="-w 0"  # GNU base64: no line wrapping
+else
+    B64_OPTS=""      # macOS base64: no wrapping by default
+fi
+
+encode_sdk() {
+    local sdk_name="$1"
+    local output_file="$2"
+    shift 2
+    local excludes=("$@")
+    local sdk_path="$SDK_DIR/$sdk_name"
+
+    if [ ! -d "$sdk_path" ]; then
+        echo "Warning: $sdk_path not found, skipping"
+        return 1
+    fi
+
+    echo "Encoding $sdk_name..."
+    local original_size=$(du -sh "$sdk_path" | cut -f1)
+
+    # Build exclude arguments
+    local tar_excludes=""
+    for excl in "${excludes[@]}"; do
+        tar_excludes="$tar_excludes --exclude=$excl"
+    done
+
+    tar -czf - -C "$SDK_DIR" $tar_excludes "$sdk_name" | base64 $B64_OPTS > "$OUTPUT_DIR/$output_file"
+
+    local encoded_size=$(du -sh "$OUTPUT_DIR/$output_file" | cut -f1)
+    echo "  Original: $original_size -> Encoded: $encoded_size"
+    echo "  Output: $OUTPUT_DIR/$output_file"
+}
+
+echo "Creating base64-encoded SDK tarballs for GitHub Actions..."
+echo ""
+
+encode_sdk "VST2_SDK" "vst2_sdk.b64"
+
+# AAX_SDK: create minimal tarball with only CMake-required files
+# Required: CMakeLists.txt, cmake/, Interfaces/, Libs/AAXLibrary/{source,include,CMakeLists.txt}, Extensions/GUI/CMakeLists.txt
+echo "Encoding AAX_SDK (minimal CMake build)..."
+SDK_PATH="$SDK_DIR/AAX_SDK"
+if [ ! -d "$SDK_PATH" ]; then
+    echo "Warning: $SDK_PATH not found, skipping"
+else
+    original_size=$(du -sh "$SDK_PATH" | cut -f1)
+
+    # Create tarball with only required files for CMake build (using xz for better compression)
+    (cd "$SDK_DIR" && tar -cJf - \
+        AAX_SDK/CMakeLists.txt \
+        AAX_SDK/CMakePresets.json \
+        AAX_SDK/cmake \
+        AAX_SDK/Interfaces \
+        AAX_SDK/Libs/AAXLibrary/CMakeLists.txt \
+        AAX_SDK/Libs/AAXLibrary/source \
+        AAX_SDK/Libs/AAXLibrary/include \
+        AAX_SDK/Extensions/GUI/CMakeLists.txt \
+        2>/dev/null) | base64 $B64_OPTS > "$OUTPUT_DIR/aax_sdk.b64"
+
+    encoded_size=$(wc -c < "$OUTPUT_DIR/aax_sdk.b64")
+    echo "  Original: $original_size -> Encoded: $encoded_size bytes"
+    echo "  Output: $OUTPUT_DIR/aax_sdk.b64"
+
+    # GitHub secrets are limited to 48KB, split if necessary
+    CHUNK_SIZE=45000  # Leave some margin below 48KB
+    if [ "$encoded_size" -gt "$CHUNK_SIZE" ]; then
+        echo "  Splitting into chunks for GitHub secrets (48KB limit)..."
+        split -b $CHUNK_SIZE "$OUTPUT_DIR/aax_sdk.b64" "$OUTPUT_DIR/aax_sdk_part_"
+
+        # Rename to numbered files
+        i=1
+        for part in "$OUTPUT_DIR"/aax_sdk_part_*; do
+            mv "$part" "$OUTPUT_DIR/aax_sdk_part_$i.b64"
+            part_size=$(wc -c < "$OUTPUT_DIR/aax_sdk_part_$i.b64")
+            echo "    Part $i: $part_size bytes"
+            i=$((i + 1))
+        done
+        NUM_PARTS=$((i - 1))
+        echo "  Split into $NUM_PARTS parts"
+    fi
+fi
+
+echo ""
+echo "Done! Add these as GitHub repository secrets:"
+echo "  VST2_SDK_B64 = contents of vst2_sdk.b64"
+if [ -n "$NUM_PARTS" ]; then
+    echo ""
+    echo "  AAX SDK split into $NUM_PARTS secrets (GitHub 48KB limit):"
+    for i in $(seq 1 $NUM_PARTS); do
+        echo "    AAX_SDK_B64_$i = contents of aax_sdk_part_$i.b64"
+    done
+fi
+echo ""
+echo "To verify decoding works:"
+echo "  cat vst2_sdk.b64 | base64 -d | tar -tzf - | head"
+
+# Interactive clipboard helper (macOS only)
+if [ "$1" = "--copy" ] && command -v pbcopy &> /dev/null; then
+    echo ""
+    echo "=== Copying secrets to clipboard ==="
+    echo ""
+
+    read -p "Copy VST2_SDK_B64 to clipboard? [Y/n] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        cat "$OUTPUT_DIR/vst2_sdk.b64" | pbcopy
+        echo "Copied! Paste into GitHub as: VST2_SDK_B64"
+        read -p "Press Enter when ready for next secret..."
+    fi
+
+    if [ -n "$NUM_PARTS" ]; then
+        for i in $(seq 1 $NUM_PARTS); do
+            read -p "Copy AAX_SDK_B64_$i to clipboard? [Y/n] " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+                cat "$OUTPUT_DIR/aax_sdk_part_$i.b64" | pbcopy
+                echo "Copied! Paste into GitHub as: AAX_SDK_B64_$i"
+                if [ $i -lt $NUM_PARTS ]; then
+                    read -p "Press Enter when ready for next secret..."
+                fi
+            fi
+        done
+    fi
+    echo ""
+    echo "All done!"
+elif [ "$1" != "--copy" ]; then
+    echo ""
+    echo "Tip: Run with --copy flag to interactively copy each secret to clipboard:"
+    echo "  $0 --copy"
+fi

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+#  ==============================================================================
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# iPlug2 Test Projects
+# Build all test projects for testing the iPlug2 framework
+
+set(CMAKE_FOLDER "Tests")
+add_subdirectory(IGraphicsTest)
+add_subdirectory(IGraphicsStressTest)
+add_subdirectory(MetaParamTest)

--- a/Tests/IGraphicsStressTest/CMakeLists.txt
+++ b/Tests/IGraphicsStressTest/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+project(IGraphicsStressTest VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    IGraphicsStressTest.cpp
+    IGraphicsStressTest.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+    resources/img/23.svg
+    resources/img/smiley.png
+    resources/img/smiley@2x.png
+)

--- a/Tests/IGraphicsTest/CMakeLists.txt
+++ b/Tests/IGraphicsTest/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.14)
+project(IGraphicsTest VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+# Source files
+set(SOURCES
+  IGraphicsTest.cpp
+  IGraphicsTest.h
+  resources/resource.h
+)
+
+# Apple-specific test controls using Metal
+set(EXTRA_LINK)
+if(APPLE)
+  list(APPEND SOURCES
+    ${IPLUG2_DIR}/IGraphics/Controls/Test/TestMPSControl.mm
+    ${IPLUG2_DIR}/IGraphics/Controls/Test/TestCustomShaderControl.mm
+  )
+  # MetalPerformanceShaders needed for TestMPSControl
+  set(EXTRA_LINK "-framework MetalPerformanceShaders")
+endif()
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    ${SOURCES}
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+    resources/fonts/Montserrat-LightItalic.ttf
+    resources/img/23.svg
+    resources/img/orbs.svg
+    resources/img/smiley.png
+    resources/img/smiley@2x.png
+    resources/img/iplug.png
+    resources/img/iplug@2x.png
+    resources/img/src.png
+    resources/img/src@2x.png
+    resources/img/dst.png
+    resources/img/dst@2x.png
+  LINK iPlug2::Extras::FlexBox ${EXTRA_LINK}
+)
+
+# TestCustomShaderControl needs ShaderTypes.h from resources/shaders
+if(APPLE)
+  target_include_directories(_${PROJECT_NAME}-base INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/resources/shaders)
+endif()

--- a/Tests/MetaParamTest/CMakeLists.txt
+++ b/Tests/MetaParamTest/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(MetaParamTest VERSION 1.0.0)
+
+if(NOT DEFINED IPLUG2_DIR)
+  set(IPLUG2_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "iPlug2 root directory")
+endif()
+
+include(${IPLUG2_DIR}/iPlug2.cmake)
+find_package(iPlug2 REQUIRED)
+
+iplug_add_plugin(${PROJECT_NAME}
+  SOURCES
+    MetaParamTest.cpp
+    MetaParamTest.h
+    resources/resource.h
+  RESOURCES
+    resources/fonts/Roboto-Regular.ttf
+)

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -1,0 +1,62 @@
+#  ==============================================================================
+#  
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  See LICENSE.txt for  more info.
+#
+#  ==============================================================================
+
+# This file should be included in your main CMakeLists.txt file.
+
+if (APPLE)
+  enable_language(OBJC)
+  enable_language(OBJCXX)
+
+  # Universal binary support (Intel + Apple Silicon)
+  option(IPLUG2_UNIVERSAL "Build universal binaries (arm64 + x86_64)" OFF)
+  if(IPLUG2_UNIVERSAL)
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build architectures" FORCE)
+    # For Xcode generator, also set the Xcode-specific attributes
+    set(CMAKE_XCODE_ATTRIBUTE_ARCHS "arm64 x86_64")
+    set(CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH "NO")
+  endif()
+
+  # macOS deployment target
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum macOS version")
+  endif()
+endif()
+
+# Tracer build support - enables TRACER_BUILD preprocessor define for profiling/tracing
+option(IPLUG2_TRACER "Enable tracer build (adds TRACER_BUILD define)" OFF)
+if(IPLUG2_TRACER)
+  add_compile_definitions(TRACER_BUILD)
+endif()
+
+set(IPLUG2_CXX_STANDARD 17)
+
+# Set C++ standard globally to ensure PCH and all files compile with C++17
+set(CMAKE_CXX_STANDARD ${IPLUG2_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Add the iPlug2 cmake module path
+set(IPLUG2_CMAKE_DIR ${IPLUG2_DIR}/Scripts/cmake)
+list(APPEND CMAKE_MODULE_PATH ${IPLUG2_CMAKE_DIR})
+
+# Make sure MSVC uses static linking
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+# Generate folders for generators that support it (Visual Studio, Xcode, etc.)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+# Debug host application for Visual Studio debugging
+set(_default_debug_host "")
+if(WIN32)
+  set(_reaper_path "C:/Program Files/REAPER (x64)/reaper.exe")
+  if(EXISTS "${_reaper_path}")
+    set(_default_debug_host "${_reaper_path}")
+  endif()
+endif()
+set(IPLUG2_DEBUG_HOST "${_default_debug_host}" CACHE FILEPATH "Host application for debugging plugins (e.g., path to REAPER, Ableton, etc.)")
+set(IPLUG2_DEBUG_HOST_ARGS "" CACHE STRING "Command line arguments for the debug host application")


### PR DESCRIPTION
This PR adds AI-generated Cmake support #39 to iPlug2 based on the cmake branch that many have been using for the last years. It now supports all of the targets that iPlug2 can compile, webviews, wams, ios, visionos etc.

Check the new documentation at @Documentation/cmake.md

This is still work in progress,  we might land a different approach at a later stage with more idiomatic modern CMake .

It is designed to be either used from this repository to build the examples, individually, or... all of them. It also has to work via the [IPlug2OOS](https://github.com/iPlug2/iPlug2OOS) repo, where iPlug2 is a submodule