### PR TITLE
BREAKING: OnParamChangeUI() should still be called in headless plug-ins

### DIFF
--- a/IPlug/AUv3/IPlugAUAudioUnit.mm
+++ b/IPlug/AUv3/IPlugAUAudioUnit.mm
@@ -435,18 +435,16 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
     return (AUValue) pPlug->GetParamStringToValue(param.address, [string UTF8String]);
   };
   
-  if (mPlug->HasUI())
-  {
-    mUIUpdateParamObserverToken = [mParameterTree tokenByAddingParameterObserver:^(AUParameterAddress address, AUValue value) {
-                              dispatch_async(dispatch_get_main_queue(), ^{
-                                pPlug->SendParameterValueFromObserver(address, value);
-                              });
-                            }];
+  // even without a UI we need to observe parameter changes to trigger OnParamChangeUI calls
+  mUIUpdateParamObserverToken = [mParameterTree tokenByAddingParameterObserver:^(AUParameterAddress address, AUValue value) {
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                              pPlug->SendParameterValueFromObserver(address, value);
+                            });
+                          }];
     
 //  [self addObserver:self forKeyPath:@"allParameterValues"
 //                  options:NSKeyValueObservingOptionNew
 //                  context:mUIUpdateParamObserverToken];
-  }
     
   self.currentPreset = mPresets.firstObject;
   

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -141,29 +141,27 @@ void IPlugAPIBase::SendParameterValueFromAPI(int paramIdx, double value, bool no
 
 void IPlugAPIBase::OnTimer(Timer& t)
 {
-  if(HasUI())
-  {
 // VST3 ********************************************************************************
 #if defined VST3P_API || defined VST3_API
-    while (mMidiMsgsFromProcessor.ElementsAvailable())
-    {
-      IMidiMsg msg;
-      mMidiMsgsFromProcessor.Pop(msg);
+  while (mMidiMsgsFromProcessor.ElementsAvailable())
+  {
+    IMidiMsg msg;
+    mMidiMsgsFromProcessor.Pop(msg);
 #ifdef VST3P_API // distributed
-      TransmitMidiMsgFromProcessor(msg);
+    TransmitMidiMsgFromProcessor(msg);
 #else
-      SendMidiMsgFromDelegate(msg);
+    SendMidiMsgFromDelegate(msg);
 #endif
-    }
+  }
 
-    while (mSysExDataFromProcessor.ElementsAvailable())
-    {
-      SysExData msg;
-      mSysExDataFromProcessor.Pop(msg);
+  while (mSysExDataFromProcessor.ElementsAvailable())
+  {
+    SysExData msg;
+    mSysExDataFromProcessor.Pop(msg);
 #ifdef VST3P_API // distributed
-      TransmitSysExDataFromProcessor(msg);
+    TransmitSysExDataFromProcessor(msg);
 #else
-      SendSysexMsgFromDelegate({msg.mOffset, msg.mData, msg.mSize});
+    SendSysexMsgFromDelegate({msg.mOffset, msg.mData, msg.mSize});
 #endif
     }
 // !VST3 ******************************************************************************
@@ -189,7 +187,6 @@ void IPlugAPIBase::OnTimer(Timer& t)
       SendSysexMsgFromDelegate({msg.mOffset, msg.mData, msg.mSize});
     }
 #endif
-  }
   
   OnIdle();
 }


### PR DESCRIPTION
marked as BREAKING, although it probably won't affect many people. Be wary of it.


Analysis: With vs Without this Change

  Without the change (old behavior)

  When HasUI() returns false (headless plugins), the OnTimer() pump is completely skipped. This causes several problems:

  1. Parameter change queue never drains

  IPlugAPIBase.cpp:169 (non-VST3 path)
```
  while(mParamChangeFromProcessor.ElementsAvailable())
  {
    ParamTuple p;
    mParamChangeFromProcessor.Pop(p);
    SendParameterValueFromDelegate(p.idx, p.value, false); // triggers OnParamChangeUI()
  }
```
  - When DSP code calls SendParameterValueFromAPI(), values are pushed to mParamChangeFromProcessor
  - Without pumping, this queue fills up indefinitely → memory grows, parameter changes are lost

  2. MIDI messages from processor never forwarded

```
  while (mMidiMsgsFromProcessor.ElementsAvailable())
  {
    IMidiMsg msg;
    mMidiMsgsFromProcessor.Pop(msg);
    SendMidiMsgFromDelegate(msg);
  }
```
  - MIDI output from DSP (e.g., arpeggiators, sequencers) never reaches the host → MIDI output broken

  3. SysEx messages from processor never forwarded

```
  while (mSysExDataFromProcessor.ElementsAvailable())
  {
    SysExData msg;
    mSysExDataFromProcessor.Pop(msg);
    SendSysexMsgFromDelegate({msg.mOffset, msg.mData, msg.mSize});
  }
```

  - SysEx output from DSP never reaches the host → SysEx output broken

  4. AUv3: No parameter observer registered

  - Host automation changes don't trigger OnParamChangeUI() → linked parameters, state updates broken

  With the change (new behavior)

  All pumps run unconditionally:
  - Queues are drained properly (no memory leak)
  - Parameter changes trigger OnParamChangeUI() even in headless plugins
  - MIDI/SysEx output works regardless of UI presence
  - AUv3 parameter observer always registered

  Conclusion

  1. The queues still need draining even without a UI
  2. OnParamChangeUI() may be overridden for non-visual purposes
  3. MIDI/SysEx forwarding to host is independent of UI