### PR TITLE
AUv3: Implement sample accurate MIDI

### DIFF
--- a/IPlug/IPlugProcessor.h
+++ b/IPlug/IPlugProcessor.h
@@ -277,6 +277,8 @@ protected:
   void PassThroughBuffers(PLUG_SAMPLE_DST type, int nFrames);
   void ProcessBuffers(PLUG_SAMPLE_SRC type, int nFrames);
   void ProcessBuffers(PLUG_SAMPLE_DST type, int nFrames);
+  void ProcessBuffers(PLUG_SAMPLE_SRC type, int nFrames, int bufferOffset);
+  void ProcessBuffers(PLUG_SAMPLE_DST type, int nFrames, int bufferOffset);
   void ProcessBuffersAccumulating(int nFrames); // only for VST2 deprecated method single precision
   void ZeroScratchBuffers();
   void SetSampleRate(double sampleRate) { mSampleRate = sampleRate; }


### PR DESCRIPTION
Previously, AUv3 processed all MIDI events before audio processing, meaning events effectively occurred at sample 0 regardless of their actual offset. This could introduce up to one buffer of timing jitter (~5ms at 256 samples/48kHz).

Changes:

Add ProcessBuffers() overloads with buffer offset parameter to IPlugProcessor, allowing processing of audio segments starting at any position within the buffer
Rewrite AUv3 ProcessWithEvents() to split the buffer around MIDI/parameter events, processing audio in segments between events
Handle events at their exact sample positions within the buffer
Remove the incomplete commented-out buffer splitting code
This makes MIDI timing in AUv3 sample-accurate, matching the precision expected by the AUv3 specification where events carry sample-accurate timestamps.

Reference: https://cp3.io/posts/sample-accurate-midi-timing/