### PR TITLE
Add kMusicDeviceMIDIEventListSelect support to AUv2

### DIFF
--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -327,6 +327,12 @@ OSStatus IPlugAU::IPlugAUEntry(ComponentParameters *params, void* pPlug)
     {
       return _this->DoMIDIEvent(_this, GET_COMP_PARAM(UInt32, 3, 4), GET_COMP_PARAM(UInt32, 2, 4), GET_COMP_PARAM(UInt32, 1, 4), GET_COMP_PARAM(UInt32, 0, 4));
     }
+    case kMusicDeviceMIDIEventListSelect:
+    {
+      UInt32 inOffsetSampleFrame = GET_COMP_PARAM(UInt32, 0, 2);
+      const MIDIEventList* inEventList = GET_COMP_PARAM(const MIDIEventList*, 1, 2);
+      return IPlugAU::AUMethodMIDIEventList(_this, inOffsetSampleFrame, inEventList);
+    }
     case kMusicDeviceSysExSelect:
     {
       return _this->DoSysEx(_this, GET_COMP_PARAM(UInt8*, 1, 2), GET_COMP_PARAM(UInt32, 0, 2));
@@ -380,6 +386,7 @@ OSStatus IPlugAU::IPlugAUEntry(ComponentParameters *params, void* pPlug)
         case kAudioUnitAddRenderNotifySelect:
         case kAudioUnitRemoveRenderNotifySelect:
         case kAudioUnitScheduleParametersSelect:
+        case kMusicDeviceMIDIEventListSelect:
           return 1;
         default:
           return 0;
@@ -2220,6 +2227,66 @@ OSStatus IPlugAU::AUMethodReset(void* pSelf, AudioUnitScope scope, AudioUnitElem
 OSStatus IPlugAU::AUMethodMIDIEvent(void* pSelf, UInt32 inStatus, UInt32 inData1, UInt32 inData2, UInt32 inOffsetSampleFrame)
 {
   return DoMIDIEvent(GetPlug(pSelf), inStatus, inData1, inData2, inOffsetSampleFrame);
+}
+
+//static
+OSStatus IPlugAU::AUMethodMIDIEventList(void* pSelf, UInt32 inOffsetSampleFrame, const MIDIEventList* inEventList)
+{
+  IPlugAU* pPlug = GetPlug(pSelf);
+
+  if (!pPlug->DoesMIDIIn())
+    return badComponentSelector;
+
+  if (!inEventList)
+    return noErr;
+
+  // Number of 32-bit words per UMP message type (UMP spec section 2.1.4).
+  // Returns 0 for unrecognised/reserved types so the parse loop bails out
+  // rather than misaligning on an unknown word size.
+  auto UMPWordsForType = [](UInt32 mt) -> UInt32 {
+    switch (mt)
+    {
+      case 0x0: case 0x1: case 0x2: return 1;
+      case 0x3: case 0x4: return 2;
+      case 0x5: return 4;
+      default: return 0;
+    }
+  };
+
+  const MIDIEventPacket* packet = &inEventList->packet[0];
+
+  for (UInt32 i = 0; i < inEventList->numPackets; ++i)
+  {
+    UInt32 pos = 0;
+
+    while (pos < packet->wordCount)
+    {
+      const UInt32 word0 = packet->words[pos];
+      const UInt32 mt = (word0 >> 28) & 0x0F;
+      const UInt32 nWords = UMPWordsForType(mt);
+
+      if (nWords == 0 || pos + nWords > packet->wordCount)
+        break;
+
+      // Type 0x1 (System Real-Time/Common) and 0x2 (MIDI 1.0 Channel Voice)
+      // both carry status/data1/data2 in bits 23:16/15:8/7:0 of word0.
+      // NOTE: all events use the single top-level inOffsetSampleFrame; per-packet
+      // timeStamps are ignored, matching the older kMusicDeviceMIDIEventSelect path.
+      if (mt == 0x1 || mt == 0x2)
+      {
+        UInt32 status = (word0 >> 16) & 0xFF;
+        UInt32 data1  = (word0 >>  8) & 0xFF;
+        UInt32 data2  =  word0        & 0xFF;
+        DoMIDIEvent(pPlug, status, data1, data2, inOffsetSampleFrame);
+      }
+
+      pos += nWords;
+    }
+
+    packet = MIDIEventPacketNext(packet);
+  }
+
+  return noErr;
 }
 
 //static

--- a/IPlug/AUv2/IPlugAU.h
+++ b/IPlug/AUv2/IPlugAU.h
@@ -167,6 +167,7 @@ private:
   static OSStatus AUMethodRender(void* pSelf, AudioUnitRenderActionFlags* pIOActionFlags, const AudioTimeStamp* pInTimeStamp, UInt32 inOutputBusNumber, UInt32 inNumberFrames, AudioBufferList* pIOData);
   static OSStatus AUMethodReset(void* pSelf, AudioUnitScope scope, AudioUnitElement elem);
   static OSStatus AUMethodMIDIEvent(void* pSelf, UInt32 inStatus, UInt32 inData1, UInt32 inData2, UInt32 inOffsetSampleFrame);
+  static OSStatus AUMethodMIDIEventList(void* pSelf, UInt32 inOffsetSampleFrame, const MIDIEventList* inEventList);
   static OSStatus AUMethodSysEx(void* pSelf, const UInt8* pInData, UInt32 inLength);
   
 #pragma mark - Implementation Methods
@@ -273,6 +274,7 @@ public:
       case kAudioUnitResetSelect:                   return (Method)IPlugAU::AUMethodReset;
 
       case kMusicDeviceMIDIEventSelect:             return MIDIIn ? (Method)IPlugAU::AUMethodMIDIEvent : NULL;
+      case kMusicDeviceMIDIEventListSelect:         return MIDIIn ? (Method)IPlugAU::AUMethodMIDIEventList : NULL;
       case kMusicDeviceSysExSelect:                 return MIDIIn ? (Method)IPlugAU::AUMethodSysEx : NULL;
 
       default:


### PR DESCRIPTION
## Summary
- Add `AUMethodMIDIEventList` to handle `MIDIEventList`-based MIDI delivery in AUv2 plugins
- Register the selector in the lookup table, component entry point, and `kComponentCanDoSelect` handler
- Parses UMP packets and forwards MIDI 1.0 Channel Voice messages through the existing `DoMIDIEvent` path

Fixes #1337 — Logic crashes on macOS 15 / Intel (or Rosetta) when it calls `kMusicDeviceMIDIEventListSelect` despite the plugin not previously advertising support.

## Test plan
- [x] AUv2 builds succeed for both effect (IPlugConvoEngine) and instrument (IPlugDrumSynth) targets
- [ ] Test in Logic under Rosetta on macOS 15 / Intel to verify the crash is resolved
- [ ] Verify MIDI input works correctly in AUv2 plugins on Apple Silicon (no regression)