### PR TITLE
VST3: Fix pitchbend out - 13 bit quantization

### DIFF
--- a/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
+++ b/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
@@ -178,7 +178,7 @@ void IPlugVST3ProcessorBase::ProcessMidiOut(IPlugQueue<SysExData>& sysExQueue, S
         toAdd.midiCCOut.channel = msg.Channel();
         toAdd.sampleOffset = msg.mOffset;
         toAdd.midiCCOut.controlNumber = ControllerNumbers::kPitchBend;
-        int16 tmp = static_cast<int16> (msg.PitchWheel() * 0x3FFF);
+        int tmp = std::clamp(static_cast<int>((msg.PitchWheel() + 1.0) * 8192.0), 0, 16383);
         toAdd.midiCCOut.value = (tmp & 0x7F);
         toAdd.midiCCOut.value2 = ((tmp >> 7) & 0x7F);
         pOutputEvents->addEvent(toAdd);


### PR DESCRIPTION
Pitch bend output was effectively limited to 13-bit resolution (~8192 steps) instead of the expected 14-bit (16384 steps).
Specifically:

Values above ~8191 would wrap around or behave incorrectly
This occurred even when constructing IMidiMsg correctly and verifying internal values (LSB/MSB reconstruction was accurate)

Line ~181:
int16 tmp = static_cast<int16> (msg.PitchWheel() * 0x3FFF);

Issues:

msg.PitchWheel() returns a normalized value in [-1.0, 1.0]
Multiplying by 0x3FFF produces a signed range [-16383, 16383]
Casting to int16 and then splitting into 7-bit MIDI bytes introduces precision loss and incorrect bit reconstruction
This results in effective 13-bit behavior

Replacing the conversion with a proper normalization to [0, 16383] resolves the issue:
int tmp = static_cast<int>((msg.PitchWheel() + 1.0) * 8192.0);