### PR TITLE
make c++ standard and AAX SDK folder paths configurable by cmake

### DIFF
--- a/Scripts/cmake/AAX.cmake
+++ b/Scripts/cmake/AAX.cmake
@@ -12,7 +12,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
 
 if(NOT TARGET iPlug2::AAX)
   # Define SDK path
-  set(AAX_SDK_DIR ${IPLUG_DEPS_DIR}/AAX_SDK)
+  if(NOT DEFINED AAX_SDK_DIR)
+    set(AAX_SDK_DIR ${IPLUG_DEPS_DIR}/AAX_SDK)
+  endif()
 
   # Check if AAX SDK exists (must have CMakeLists.txt, not just placeholder directory)
   if(NOT EXISTS ${AAX_SDK_DIR}/CMakeLists.txt)

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -1,6 +1,6 @@
 #  ==============================================================================
-#  
-#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
+#
+#  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
 #
 #  See LICENSE.txt for  more info.
 #
@@ -33,7 +33,9 @@ if(IPLUG2_TRACER)
   add_compile_definitions(TRACER_BUILD)
 endif()
 
-set(IPLUG2_CXX_STANDARD 17)
+if(NOT DEFINED IPLUG2_CXX_STANDARD)
+  set(IPLUG2_CXX_STANDARD 17)
+endif()
 
 # Set C++ standard globally to ensure PCH and all files compile with C++17
 set(CMAKE_CXX_STANDARD ${IPLUG2_CXX_STANDARD})


### PR DESCRIPTION
Make the two cmake variables `IPLUG2_CXX_STANDARD` and `AAX_SDK_DIR` configurable.

These changes should be non-breaking for existing cmake configurations. They allow you to set a newer c++ standard (was c++20 in my case) and a custom out-of-source AAX SDK path (which is good because you will want to define your own AAX cmake scripts and not commit them to iplug2).