### PR TITLE
WEB: fix first-load resize loss and WebGL resize flicker

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -116,6 +116,8 @@ void IGraphics::Resize(int w, int h, float scale, bool needsPlatformResize)
   
   if(mLayoutOnResize)
     GetDelegate()->LayoutUI(this);
+
+  PostResize();
 }
 
 void IGraphics::SetLayoutOnResize(bool layoutOnResize)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1244,7 +1244,10 @@ private:
   
   /** Called to update the drawing surface after a resize */
   virtual void DrawResize() {}
-  
+
+  /** Called at the very end of Resize() */
+  virtual void PostResize() {}
+
   /** Draw a region of the graphics (redrawing all contained items)
    * @param bounds The rectangular region to redraw
    * @param scale The current draw scale */

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -834,11 +834,37 @@ void IGraphicsWeb::DrawResize()
   mCanvas["style"].set("width", val(widthPx));
   mCanvas["style"].set("height", val(heightPx));
 
-  // Canvas element width/height attributes are integers (no px)
-  mCanvas.set("width", Width() * GetBackingPixelScale());
-  mCanvas.set("height", Height() * GetBackingPixelScale());
+  // Canvas element width/height attributes are integers (no px).
+  // Assigning these clears the WebGL drawing buffer even when the value
+  // is unchanged, so guard against redundant writes — otherwise every
+  // ResizeObserver tick during a drag causes a visible flash.
+  const int newBufW = Width() * GetBackingPixelScale();
+  const int newBufH = Height() * GetBackingPixelScale();
+  const int curBufW = mCanvas["width"].as<int>();
+  const int curBufH = mCanvas["height"].as<int>();
+  if (newBufW != curBufW || newBufH != curBufH)
+  {
+    mCanvas.set("width", newBufW);
+    mCanvas.set("height", newBufH);
+  }
 
   IGRAPHICS_DRAW_CLASS::DrawResize();
+}
+
+void IGraphicsWeb::PostResize()
+{
+  // Called at the end of IGraphics::Resize(), after OnResize +
+  // SetAllControlsDirty + DrawResize + (optional) LayoutUI have all
+  // run. At this point control layout is final, so it's safe to
+  // repaint synchronously. Without this, the canvas is stuck in a
+  // cleared state (canvas.width/height assignment wiped the default
+  // framebuffer; NanoVG's DrawResize rebuilt an empty FBO) until the
+  // next main-loop RAF tick, which the browser may composite past —
+  // producing a one-frame blank flash on every size change.
+  IRECTList rects;
+  rects.Add(GetBounds());
+  SetAllControlsClean();
+  Draw(rects);
 }
 
 PlatformFontPtr IGraphicsWeb::LoadPlatformFont(const char* fontID, const char* fileNameOrResID)

--- a/IGraphics/Platforms/IGraphicsWeb.h
+++ b/IGraphics/Platforms/IGraphicsWeb.h
@@ -59,6 +59,7 @@ public:
   bool IsInShadowDOM() const { return mInShadowDOM; }
 
   void DrawResize() override;
+  void PostResize() override;
 
   const char* GetPlatformAPIStr() override { return "WEB"; }
 

--- a/IPlug/IPlug_include_in_plug_src.h
+++ b/IPlug/IPlug_include_in_plug_src.h
@@ -277,6 +277,10 @@
   std::unique_ptr<iplug::IPlugWasmUI> gPlug;
   extern void StartMainLoopTimer();
 
+  // Defined in IPlugWasmUI.cpp — replays any parent-window resize that
+  // arrived from JS before `gPlug` existed.
+  extern "C" void IPlugWasmUI_ApplyPendingParentWindowResize();
+
   extern "C"
   {
     EMSCRIPTEN_KEEPALIVE void iplug_syncfs()
@@ -298,6 +302,10 @@
       gPlug = std::unique_ptr<iplug::IPlugWasmUI>(iplug::MakePlug(iplug::InstanceInfo()));
       gPlug->SetHost("www", 0);
       gPlug->OpenWindow(nullptr);
+      // IDBFS sync ran async, so the JS bundle's initial
+      // OnParentWindowResize likely already fired and was buffered.
+      // Apply it now, before the first frame is drawn.
+      IPlugWasmUI_ApplyPendingParentWindowResize();
       iplug_syncfs();
     }
   }

--- a/IPlug/WEB/IPlugWasmUI.cpp
+++ b/IPlug/WEB/IPlugWasmUI.cpp
@@ -99,6 +99,26 @@ void IPlugWasmUI::SendDSPIdleTick()
 // Global instance for Emscripten bindings
 extern std::unique_ptr<iplug::IPlugWasmUI> gPlug;
 
+// Parent-window dims that arrived before `gPlug` was constructed.
+// `iplug_fsready()` runs asynchronously after IDBFS syncs — so on the
+// first page load the JS bundle's initial ResizeObserver callback can
+// fire before `gPlug` exists. Without buffering, that resize is lost
+// and the canvas stays pinned at the plugin's default dimensions until
+// the parent element is resized again. Replayed by
+// `IPlugWasmUI_ApplyPendingParentWindowResize()`.
+static int gPendingParentWindowW = 0;
+static int gPendingParentWindowH = 0;
+
+extern "C" EMSCRIPTEN_KEEPALIVE void IPlugWasmUI_ApplyPendingParentWindowResize()
+{
+  if (gPlug && gPendingParentWindowW > 0 && gPendingParentWindowH > 0)
+  {
+    gPlug->OnParentWindowResize(gPendingParentWindowW, gPendingParentWindowH);
+    gPendingParentWindowW = 0;
+    gPendingParentWindowH = 0;
+  }
+}
+
 // Callback functions called by JavaScript controller when DSP sends messages
 static void _SendParameterValueFromDelegate(int paramIdx, double normalizedValue)
 {
@@ -143,7 +163,16 @@ static void _StartIdleTimer()
 static void _OnParentWindowResize(int width, int height)
 {
   if (gPlug)
+  {
     gPlug->OnParentWindowResize(width, height);
+  }
+  else
+  {
+    // gPlug not constructed yet — stash the dims so
+    // `iplug_fsready()` can replay them once the UI is open.
+    gPendingParentWindowW = width;
+    gPendingParentWindowH = height;
+  }
 }
 
 EMSCRIPTEN_BINDINGS(IPlugWasmUI) {


### PR DESCRIPTION
## Summary

Two independent fixes for the WASM UI target, found while building plugins in a host that embeds the WebGL canvas in a resizable DOM element.

### 1. First-load `OnParentWindowResize` silently dropped (`4cf5c46aa`)

`main()` in the `WASM_UI_API` branch of `IPlug_include_in_plug_src.h` schedules `FS.syncfs(true, ...)` asynchronously and delegates construction of `gPlug` + `OpenWindow()` to `iplug_fsready()`. On first page load IDBFS population takes measurable time, so when the JS bundle's initial `ResizeObserver` callback fires immediately after `onRuntimeInitialized`, `gPlug` is still null and `_OnParentWindowResize` silently drops the call. The canvas stays pinned at the plugin's default dimensions until the user changes the parent size again (e.g. drags a divider). Subsequent page loads work because IDBFS is already warm.

Fix: buffer incoming dims in two statics when `gPlug` is null, and replay them from `iplug_fsready()` right after `OpenWindow(nullptr)` via a new exported helper `IPlugWasmUI_ApplyPendingParentWindowResize()`.

### 2. WebGL canvas flicker on resize (`badf40c05`)

Two contributing causes in `IGraphicsWeb::DrawResize()`:

- Per HTML spec, assigning `canvas.width` / `canvas.height` — **even to the same integer value** — resets the drawing buffer. During a drag `ResizeObserver` can fire with identical rounded-pixel dims frame-to-frame, so every tick wiped the default framebuffer. Added a guard that only writes the attributes when they actually change.
- When the buffer size genuinely changes, the `canvas.width/height` assignment still wipes the default framebuffer **and** `IGraphicsNanoVG::DrawResize()` unconditionally deletes and recreates the main FBO, leaving it empty. The browser compositor can paint a blank frame before the next RAF tick runs `OnMainLoopTimer` → `Draw`.

Fix: added a new `virtual void IGraphics::PostResize() {}` hook called at the very end of `IGraphics::Resize()`, after `OnResize`, `SetAllControlsDirty`, `DrawResize`, and any `LayoutUI`. `IGraphicsWeb` overrides it to do a synchronous full-bounds `Draw()`. Running after `LayoutUI` (rather than from inside `DrawResize`) is important — an earlier version of this patch did the sync draw from inside `DrawResize`, which paints pre-layout positions and then leaks them through when the post-`LayoutUI` main-loop tick overpaints only the moved controls.

`PostResize` is a no-op on all native platforms — they don't have the WebGL clear-on-resize behaviour.

## Scope

- Only `WASM_UI_API` code paths and `IGraphicsWeb`. WAM, VST3, AU, AUv3, CLAP, App, and Mac/Win/Linux native backends are untouched.
- No API changes visible to plugin authors.

## Test plan

- [x] Build a WASM UI plugin (iGraphics-based) and embed the canvas in a resizable DOM element.
- [x] First page load (with empty IDBFS): verify the plugin sizes to the parent immediately instead of staying at default dims.
- [x] Drag a parent divider continuously: verify no black flash on every tick.
- [x] Resize through a layout breakpoint (if the plugin implements `mLayoutOnResize`/responsive `LayoutUI`): verify no stale/double-drawn controls.
- [ ] Smoke test native targets (Mac/Win) to confirm `PostResize()` default no-op doesn't regress anything.