### PR TITLE
IGraphicsWeb: preserve existing canvas id (fix legacy WAM template)

### DIFF
--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -458,11 +458,18 @@ IGraphicsWeb::IGraphicsWeb(IGEditorDelegate& dlg, int w, int h, int fps, float s
   std::string rootNodeType = mRootNode["constructor"]["name"].as<std::string>();
   mInShadowDOM = (rootNodeType == "ShadowRoot");
 
-  // Generate unique canvas ID for this instance (used by emscripten callbacks)
-  char idBuf[64];
-  snprintf(idBuf, sizeof(idBuf), "iplug-canvas-%p", static_cast<void*>(this));
-  mCanvasSelector = std::string("#") + idBuf;
-  mCanvas.set("id", std::string(idBuf));
+  // Use the canvas's existing id if it has one (legacy templates rely on
+  // querying their <canvas id="canvas"> from JS); otherwise synthesize a
+  // per-instance id so multiple instances on a page don't collide.
+  std::string existingId = mCanvas["id"].as<std::string>();
+  if (existingId.empty())
+  {
+    char idBuf[64];
+    snprintf(idBuf, sizeof(idBuf), "iplug-canvas-%p", static_cast<void*>(this));
+    existingId = idBuf;
+    mCanvas.set("id", existingId);
+  }
+  mCanvasSelector = std::string("#") + existingId;
 
   DBGMSG("IGraphicsWeb: Shadow DOM = %s, selector = %s\n", mInShadowDOM ? "true" : "false", mCanvasSelector.c_str());
 


### PR DESCRIPTION
## Summary
- The shadow-DOM commit (5b20fdf48) unconditionally rewrote the canvas's `id` attribute to a per-instance `iplug-canvas-{ptr}` value in `IGraphicsWeb`'s constructor.
- The legacy WAM template (`IPlug/WEB/Template/index.html`) declares `<canvas id="canvas">` and `connectionsDone()` later calls `document.getElementById("canvas")` to centre the WAM div. After IGraphicsWeb constructed, that lookup returned `null` and `makedist-web.sh` builds crashed in `connectionsDone()`.
- Only synthesize a unique id when the canvas doesn't already have one; otherwise reuse the existing id for `mCanvasSelector`. Multi-instance / shadow-DOM use cases (canvas passed in or created without an id) still get a unique id as before.

## Test plan
- [ ] `Examples/IPlugEffect/scripts/makedist-web.sh` produces a working WAM build and `connectionsDone()` no longer errors.
- [ ] Verify a shadow-DOM / web-component instance still gets a unique `iplug-canvas-...` id and emscripten callbacks (mouse, WebGL context) still function.
- [ ] Multiple instances on the same page still resolve to distinct selectors.