### PR TITLE
WASM host-capture bridge for in-iframe UI screenshots

### DIFF
--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -16,11 +16,24 @@
 
 #include "IGraphicsWeb.h"
 
-// Helper to create WebGL context for Shadow DOM (CSS selectors don't work)
+EM_JS(int, iplug_wasm_capture_bridge_enabled, (), {
+  if (typeof window === "undefined") return 0;
+  try {
+    return new URLSearchParams(window.location.search).get("iplugWasmCapture") === "1";
+  } catch (e) {
+    return 0;
+  }
+});
+
+// Helper to create WebGL context for Shadow DOM (CSS selectors don't work).
 EM_JS(int, createWebGLContextForShadowDOM, (), {
   var canvas = Module.canvas;
   if (!canvas) return 0;
-  var attrs = { stencil: true, depth: true, antialias: true, alpha: true };
+  var preserveDrawingBuffer = false;
+  try {
+    preserveDrawingBuffer = new URLSearchParams(window.location.search).get("iplugWasmCapture") === "1";
+  } catch (e) {}
+  var attrs = { stencil: true, depth: true, antialias: true, alpha: true, preserveDrawingBuffer: preserveDrawingBuffer };
   var ctx = canvas.getContext("webgl", attrs) || canvas.getContext("experimental-webgl", attrs);
   if (!ctx) return 0;
   return GL.registerContext(ctx, attrs);
@@ -995,6 +1008,11 @@ void* IGraphicsWeb::OpenWindow(void* pHandle)
   emscripten_webgl_init_context_attributes(&attr);
   attr.stencil = true;
   attr.depth = true;
+  attr.antialias = true;
+  attr.alpha = true;
+  // Capture is URL opt-in because preserveDrawingBuffer can reduce WebGL
+  // presentation throughput in regular production plugin embeds.
+  attr.preserveDrawingBuffer = iplug_wasm_capture_bridge_enabled();
 //  attr.explicitSwapControl = 1;
 
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx;

--- a/IPlug/WEB/TemplateWasm/scripts/IPlugWasmBundle.js.template
+++ b/IPlug/WEB/TemplateWasm/scripts/IPlugWasmBundle.js.template
@@ -30,6 +30,15 @@ window.Module = window.Module || {
   const HAS_UI = HAS_UI_PLACEHOLDER; // false for headless plugins
   const DOES_MIDI_IN = DOES_MIDI_IN_PLACEHOLDER;
   const DOES_MIDI_OUT = DOES_MIDI_OUT_PLACEHOLDER;
+  const getUrlParam = (name) => {
+    try {
+      return new URLSearchParams(window.location.search).get(name);
+    } catch (e) {
+      return null;
+    }
+  };
+  const CAPTURE_BRIDGE_ENABLED = getUrlParam('iplugWasmCapture') === '1';
+  const CAPTURE_BRIDGE_ORIGIN = getUrlParam('iplugWasmCaptureOrigin');
 
   // Embedded CSS for Shadow DOM
   const COMPONENT_CSS = `
@@ -722,5 +731,47 @@ window.Module = window.Module || {
   // Export to global scope
   window.IPlugWasmController = IPlugWasmController;
   window[PLUGIN_NAME + 'Element'] = IPlugWasmElement;
+
+  // Host capture is opt-in for trusted parent origins because it exposes
+  // rendered UI pixels across the iframe boundary.
+  if (CAPTURE_BRIDGE_ENABLED && CAPTURE_BRIDGE_ORIGIN && !window.__iplugWasmCaptureBridgeInstalled) {
+    window.__iplugWasmCaptureBridgeInstalled = true;
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (!msg || msg.type !== 'iplug-wasm:capture') return;
+      if (event.origin !== CAPTURE_BRIDGE_ORIGIN) return;
+      const reply = (payload) => {
+        const target = event.source;
+        if (target && typeof target.postMessage === 'function') {
+          target.postMessage(
+            { type: 'iplug-wasm:capture-response', id: msg.id, ...payload },
+            event.origin,
+          );
+        }
+      };
+      try {
+        const host = document.querySelector(PLUGIN_TAG);
+        if (!host) {
+          reply({ error: 'plugin element not found' });
+          return;
+        }
+        const canvas = host.shadowRoot
+          ? host.shadowRoot.querySelector('canvas')
+          : host.querySelector('canvas');
+        if (!canvas) {
+          reply({ error: 'plugin canvas not found' });
+          return;
+        }
+        const dataUrl = canvas.toDataURL('image/png');
+        if (!dataUrl || dataUrl === 'data:,') {
+          reply({ error: 'empty framebuffer; canvas may not have rendered yet' });
+          return;
+        }
+        reply({ dataUrl });
+      } catch (e) {
+        reply({ error: String(e && e.message ? e.message : e) });
+      }
+    });
+  }
 
 })();


### PR DESCRIPTION
## Summary
- Enables host pages such as IDE previews, JIT debuggers, and dev shells to capture the rendered Wasm plugin UI from an iframe when capture is explicitly enabled.
- Makes WebGL framebuffer preservation runtime opt-in with `?iplugWasmCapture=1`, avoiding the `preserveDrawingBuffer` cost for normal production embeds.
- Adds a `postMessage` request/response bridge for `iplug-wasm:capture` requests, but only installs it when `iplugWasmCaptureOrigin` is provided.
- Validates incoming capture requests against `iplugWasmCaptureOrigin` before reading the canvas, then replies directly to the requesting origin.
- Looks up the plugin canvas inside the plugin element/shadow DOM only, avoiding accidental capture of unrelated page canvases.

## Why
A parent host page often cannot inspect the iframe DOM directly because the Wasm preview iframe may be served from a different origin. The bridge keeps that capture flow explicit and origin-scoped while still allowing trusted tooling to request a PNG data URL of the rendered plugin UI.

## Usage
Embed the iframe with both query parameters, for example:

```text
?iplugWasmCapture=1&iplugWasmCaptureOrigin=https%3A%2F%2Flocalhost%3A3000
```

The parent can then post `{ type: 'iplug-wasm:capture', id }` and receive `{ type: 'iplug-wasm:capture-response', id, dataUrl | error }`.

## Validation
- `git diff --check`
- Parsed `IPlugWasmBundle.js.template` with representative placeholder substitutions via Node `vm.Script`.
- Full Wasm build not run in this environment.