### PR TITLE
Adapt IGraphicsLiveEdit for WASM targets

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -203,7 +203,7 @@ void IGraphics::RemoveAllControls()
   mCornerResizer = nullptr;
   mPerfDisplay = nullptr;
     
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
   mLiveEdit = nullptr;
 #endif
   
@@ -559,7 +559,7 @@ void IGraphics::ForAllControlsFunc(IControlFunction func)
   if (mPerfDisplay)
     func(mPerfDisplay.get());
   
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
   if (mLiveEdit)
     func(mLiveEdit.get());
 #endif
@@ -1309,7 +1309,7 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
     {
       IControl* pControl = GetControl(c);
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
       if(!mLiveEdit)
       {
 #endif
@@ -1323,7 +1323,7 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
             }
           }
         }
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
       }
       else if (pControl->GetRECT().Contains(x, y) && pControl->GetParent() == nullptr)
       {
@@ -1359,7 +1359,7 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
     pControl = mTextEntryControl.get();
   
   
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
   if (!pControl && mLiveEdit)
     pControl = mLiveEdit.get();
 #endif
@@ -1550,7 +1550,7 @@ void IGraphics::EnableTooltips(bool enable)
 
 void IGraphics::EnableLiveEdit(bool enable)
 {
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
   if (enable)
   {
     if (!mLiveEdit)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1204,6 +1204,9 @@ public:
 
   /**@return \c true if live edit mode is enabled */
   bool LiveEditEnabled() const { return mLiveEdit != nullptr; }
+
+  /** Set a callback for JSON live edit events */
+  void SetLiveEditEventFunc(ILiveEditEventFunc func) { mLiveEditEventFunc = func; }
   
   /** Returns an IRECT that represents the entire UI bounds
    * This is useful for programatically arranging UI elements by slicing up the IRECT using the various IRECT methods
@@ -1808,6 +1811,14 @@ private:
     mMouseOver = nullptr;
     mMouseOverIdx = -1;
   }
+
+  bool HasLiveEditEventFunc() const { return static_cast<bool>(mLiveEditEventFunc); }
+
+  void EmitLiveEditEvent(const char* eventJson) const
+  {
+    if (mLiveEditEventFunc)
+      mLiveEditEventFunc(eventJson);
+  }
   
   WDL_PtrList<IControl> mControls;
   std::unordered_map<int, IControl*> mCtrlTags;
@@ -1865,6 +1876,7 @@ private:
   IKeyHandlerFunc mKeyHandlerFunc = nullptr;
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
+  ILiveEditEventFunc mLiveEditEventFunc = nullptr;
   
 protected:
   IGEditorDelegate* mDelegate;

--- a/IGraphics/IGraphicsLiveEdit.h
+++ b/IGraphics/IGraphicsLiveEdit.h
@@ -15,10 +15,23 @@
  * @copydoc IGraphicsLiveEdit
  */
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
 
 #include "IControl.h"
+#include <cmath>
+#include <cstdio>
 #include <fstream>
+#include <string>
+#include <vector>
+
+#if defined(IPLUG_LIVE_EDIT_CLASS_NAME)
+#include <cstring>
+#include <typeinfo>
+#if defined(__GNUG__) && !defined(_WIN32)
+#include <cxxabi.h>
+#include <cstdlib>
+#endif
+#endif
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
@@ -69,6 +82,7 @@ public:
         GetUI()->AttachControl(new PlaceHolder(mMouseDownRECT));
         mClickedOnControl = GetUI()->NControls() - 1;
         mMouseClickedOnResizeHandle = false;
+        EmitControlAdded(GetUI()->GetControl(mClickedOnControl));
       }
       else if (mod.R)
       {
@@ -95,27 +109,49 @@ public:
       mDragRegion.L = mDragRegion.R = x;
       mDragRegion.T = mDragRegion.B = y;
     }
+
+    EmitSelectionChanged();
   }
   
   void OnMouseUp(float x, float y, const IMouseMod& mod) override
   {
-    if (mMouseClickedOnResizeHandle)
+    // Web popup menus are async, so keep the clicked control index alive
+    // until OnPopupMenuSelection receives either a selection or a cancel.
+    const bool waitingForControlPopup = mod.R && mClickedOnControl > 0;
+
+    if (mClickedOnControl > 0)
     {
       IControl* pControl = GetUI()->GetControl(mClickedOnControl);
       IRECT r = pControl->GetRECT();
-      float w = r.R - r.L;
-      float h = r.B - r.T;
-      
-      if (w < 0.f || h < 0.f)
+
+      if (mMouseClickedOnResizeHandle)
       {
-        pControl->SetRECT(mMouseDownRECT);
-        pControl->SetTargetRECT(mMouseDownTargetRECT);
+        float w = r.R - r.L;
+        float h = r.B - r.T;
+
+        if (w < 0.f || h < 0.f)
+        {
+          pControl->SetRECT(mMouseDownRECT);
+          pControl->SetTargetRECT(mMouseDownTargetRECT);
+          r = pControl->GetRECT();
+        }
+      }
+
+      if (r.L != mMouseDownRECT.L || r.T != mMouseDownRECT.T ||
+          r.R != mMouseDownRECT.R || r.B != mMouseDownRECT.B)
+      {
+        EmitControlChanged(pControl, mMouseDownRECT);
       }
     }
-    mClickedOnControl = -1;
+
+    if (!waitingForControlPopup)
+      mClickedOnControl = -1;
+
     mMouseClickedOnResizeHandle = false;
     GetUI()->SetAllControlsDirty();
-    
+
+    EmitSelectionChanged();
+
     mDragRegion = IRECT();
   }
   
@@ -202,6 +238,11 @@ public:
     {
       if (mSelectedControls.GetSize())
       {
+        std::vector<IControl*> snapshot;
+        snapshot.reserve(mSelectedControls.GetSize());
+        for (int i = 0; i < mSelectedControls.GetSize(); i++)
+          snapshot.push_back(mSelectedControls.Get(i));
+        EmitControlsDeleted(snapshot.data(), static_cast<int>(snapshot.size()));
         for (int i = 0; i < mSelectedControls.GetSize(); i++)
         {
           IControl* pControl = mSelectedControls.Get(i);
@@ -210,7 +251,9 @@ public:
         
         mSelectedControls.Empty();
         GetUI()->SetAllControlsDirty();
-        
+
+        EmitSelectionChanged();
+
         return true;
       }
     }
@@ -220,6 +263,12 @@ public:
   
   void OnPopupMenuSelection(IPopupMenu* pSelectedMenu, int valIdx) override
   {
+    if (!pSelectedMenu)
+    {
+      mClickedOnControl = -1;
+      return;
+    }
+
     if (pSelectedMenu && pSelectedMenu == &mRightClickOutsideControlMenu)
     {
       auto idx = pSelectedMenu->GetChosenItemIdx();
@@ -230,8 +279,11 @@ public:
       switch(idx)
       {
         case 0:
+        {
           GetUI()->AttachControl(new PlaceHolder(b));
+          EmitControlAdded(GetUI()->GetControl(GetUI()->NControls() - 1));
           break;
+        }
         default:
           break;
       }
@@ -244,14 +296,22 @@ public:
       switch (idx)
       {
         case 0:
+        {
+          IControl* pToDelete = mClickedOnControl > 0 ? GetUI()->GetControl(mClickedOnControl) : nullptr;
+          IControl* controls[1] = { pToDelete };
+          if (pToDelete)
+            EmitControlsDeleted(controls, 1);
           mSelectedControls.Empty();
-          GetUI()->RemoveControl(mClickedOnControl);
-          mClickedOnControl = -1;
+          if (mClickedOnControl > 0)
+            GetUI()->RemoveControl(mClickedOnControl);
+          EmitSelectionChanged();
           break;
+        }
         default:
           break;
       }
 
+      mClickedOnControl = -1;
     }
   }
   
@@ -313,6 +373,182 @@ public:
       return input;
   }
 
+  static void AppendJsonString(std::string& out, const char* str)
+  {
+    out.push_back('"');
+
+    if (str)
+    {
+      for (const char* p = str; *p; ++p)
+      {
+        unsigned char c = static_cast<unsigned char>(*p);
+
+        switch (c)
+        {
+          case '\\': out += "\\\\"; break;
+          case '"': out += "\\\""; break;
+          case '\b': out += "\\b"; break;
+          case '\f': out += "\\f"; break;
+          case '\n': out += "\\n"; break;
+          case '\r': out += "\\r"; break;
+          case '\t': out += "\\t"; break;
+          default:
+          {
+            if (c < 0x20)
+            {
+              char esc[8];
+              std::snprintf(esc, sizeof(esc), "\\u%04x", c);
+              out += esc;
+            }
+            else
+            {
+              out.push_back(static_cast<char>(c));
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    out.push_back('"');
+  }
+
+#if defined(IPLUG_LIVE_EDIT_CLASS_NAME)
+  static std::string DemangledClassName(IControl* pControl)
+  {
+    if (!pControl)
+      return "";
+
+    const char* mangled = typeid(*pControl).name();
+#if defined(__GNUG__) && !defined(_WIN32)
+    int status = 0;
+    char* demangled = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
+    const char* name = (status == 0 && demangled) ? demangled : (mangled ? mangled : "");
+#else
+    const char* name = mangled ? mangled : "";
+#endif
+    static const char prefix[] = "iplug::igraphics::";
+    const std::size_t prefixLen = sizeof(prefix) - 1;
+    const char* compact = std::strncmp(name, prefix, prefixLen) == 0 ? name + prefixLen : name;
+    std::string result(compact);
+
+#if defined(__GNUG__) && !defined(_WIN32)
+    if (demangled)
+      std::free(demangled);
+#endif
+
+    return result;
+  }
+#endif
+
+  void AppendControlDescriptor(std::string& out, IControl* pControl)
+  {
+    if (!pControl)
+    {
+      out += "null";
+      return;
+    }
+
+    const IRECT r = pControl->GetRECT();
+    out += "{\"idx\":";
+    out += std::to_string(GetUI()->GetControlIdx(pControl));
+#if defined(IPLUG_LIVE_EDIT_CLASS_NAME)
+    out += ",\"className\":";
+    AppendJsonString(out, DemangledClassName(pControl).c_str());
+#endif
+    out += ",\"tag\":";
+    out += std::to_string(pControl->GetTag());
+    out += ",\"paramIdx\":";
+    out += std::to_string(pControl->GetParamIdx());
+    out += ",\"l\":";
+    out += std::to_string(static_cast<int>(std::round(r.L)));
+    out += ",\"t\":";
+    out += std::to_string(static_cast<int>(std::round(r.T)));
+    out += ",\"r\":";
+    out += std::to_string(static_cast<int>(std::round(r.R)));
+    out += ",\"b\":";
+    out += std::to_string(static_cast<int>(std::round(r.B)));
+    out += "}";
+  }
+
+  static void AppendRect(std::string& out, const IRECT& r)
+  {
+    out += "{\"l\":";
+    out += std::to_string(static_cast<int>(std::round(r.L)));
+    out += ",\"t\":";
+    out += std::to_string(static_cast<int>(std::round(r.T)));
+    out += ",\"r\":";
+    out += std::to_string(static_cast<int>(std::round(r.R)));
+    out += ",\"b\":";
+    out += std::to_string(static_cast<int>(std::round(r.B)));
+    out += "}";
+  }
+
+  void EmitControlChanged(IControl* pControl, const IRECT& previousRECT)
+  {
+    if (!GetUI()->HasLiveEditEventFunc())
+      return;
+
+    std::string json = "{\"type\":\"iplug:live-edit:control-changed\",\"control\":";
+    AppendControlDescriptor(json, pControl);
+    json += ",\"prev\":";
+    AppendRect(json, previousRECT);
+    json += "}";
+    GetUI()->EmitLiveEditEvent(json.c_str());
+  }
+
+  void EmitControlAdded(IControl* pControl)
+  {
+    if (!GetUI()->HasLiveEditEventFunc())
+      return;
+
+    std::string json = "{\"type\":\"iplug:live-edit:control-added\",\"control\":";
+    AppendControlDescriptor(json, pControl);
+    json += "}";
+    GetUI()->EmitLiveEditEvent(json.c_str());
+  }
+
+  void EmitControlsDeleted(IControl* const* controls, int count)
+  {
+    if (!GetUI()->HasLiveEditEventFunc())
+      return;
+
+    if (count <= 0)
+      return;
+
+    std::string json = "{\"type\":\"iplug:live-edit:controls-deleted\",\"deleted\":[";
+
+    for (int i = 0; i < count; i++)
+    {
+      if (i > 0)
+        json += ",";
+
+      AppendControlDescriptor(json, controls[i]);
+    }
+
+    json += "]}";
+    GetUI()->EmitLiveEditEvent(json.c_str());
+  }
+
+  void EmitSelectionChanged()
+  {
+    if (!GetUI()->HasLiveEditEventFunc())
+      return;
+
+    std::string json = "{\"type\":\"iplug:live-edit:selection-changed\",\"selection\":[";
+
+    for (int i = 0; i < mSelectedControls.GetSize(); i++)
+    {
+      if (i > 0)
+        json += ",";
+
+      AppendControlDescriptor(json, mSelectedControls.Get(i));
+    }
+
+    json += "]}";
+    GetUI()->EmitLiveEditEvent(json.c_str());
+  }
+
 private:
   IPopupMenu mRightClickOutsideControlMenu {"Outside Control", {"Add Place Holder"}};
   IPopupMenu mRightClickOnControlMenu{ "On Control", {"Delete Control"} };
@@ -338,4 +574,4 @@ private:
 END_IGRAPHICS_NAMESPACE
 END_IPLUG_NAMESPACE
 
-#endif // !NDEBUG
+#endif // !NDEBUG || IPLUG_LIVE_EDIT

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -53,6 +53,7 @@ using IGestureFunc = std::function<void(IControl*, const IGestureInfo&)>;
 using IPopupFunction = std::function<void(IPopupMenu* pMenu)>;
 using IDisplayTickFunc = std::function<void()>;
 using IUIAppearanceChangedFunc = std::function<void(EUIAppearance appearance)>;
+using ILiveEditEventFunc = std::function<void(const char* eventJson)>;
 using ITouchID = uintptr_t;
 
 /** A click action function that does nothing */

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -468,6 +468,30 @@ EM_JS(void, iplug_popup_menu_close_js, (void* pGraphics), {
   }
 });
 
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
+EM_JS(void, iplug_emit_live_edit_js, (const char* eventJson), {
+  var msg;
+  try {
+    msg = JSON.parse(UTF8ToString(eventJson));
+  } catch (e) {
+    console.error('iPlug live edit: invalid event payload', e);
+    return;
+  }
+
+  try {
+    // Live edit is an opt-in developer channel. The wildcard origin lets
+    // file:// previews and IDE shells host the frame without build-time
+    // origin knowledge; do not enable IPLUG2_WASM_LIVE_EDIT for production.
+    window.postMessage(msg, '*');
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(msg, '*');
+    }
+  } catch (e) {
+    console.warn('iPlug live edit: postMessage failed', e);
+  }
+});
+#endif
+
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
@@ -871,6 +895,12 @@ EMSCRIPTEN_BINDINGS(events) {
 IGraphicsWeb::IGraphicsWeb(IGEditorDelegate& dlg, int w, int h, int fps, float scale, val canvas)
 : IGRAPHICS_DRAW_CLASS(dlg, w, h, fps, scale)
 {
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
+  SetLiveEditEventFunc([](const char* eventJson) {
+    iplug_emit_live_edit_js(eventJson);
+  });
+#endif
+
   val keys = val::global("Object").call<val>("keys", GetPreloadedImages());
 
   DBGMSG("Preloaded %i images\n", keys["length"].as<int>());
@@ -1608,6 +1638,19 @@ void iGraphicsWheelCallback(void* pGraphics, double x, double y, double deltaY, 
   IMouseMod mod(false, false, static_cast<bool>(shift), static_cast<bool>(ctrl), static_cast<bool>(alt));
   pG->OnMouseWheel(x / scale, y / scale, mod, deltaY);
 }
+
+#if !defined(NDEBUG) || defined(IPLUG_LIVE_EDIT)
+EMSCRIPTEN_KEEPALIVE
+int iplug_set_live_edit(void* pGraphics, int enabled)
+{
+  if (!pGraphics)
+    return 0;
+
+  IGraphicsWeb* pG = static_cast<IGraphicsWeb*>(pGraphics);
+  pG->EnableLiveEdit(enabled != 0);
+  return pG->LiveEditEnabled() == (enabled != 0);
+}
+#endif
 
 } // extern "C"
 

--- a/IPlug/WEB/TemplateWasm/index.html
+++ b/IPlug/WEB/TemplateWasm/index.html
@@ -39,6 +39,8 @@
         receivesMidi: pluginElement.receivesMidi,
         sendsMidi: pluginElement.sendsMidi
       }),
+      isLiveEditAvailable: () => pluginElement.isLiveEditAvailable?.() ?? false,
+      setLiveEditEnabled: (enabled) => pluginElement.setLiveEditEnabled?.(enabled) ?? false,
       createController: async ({ audioContext, capabilities }) => {
         const controller = new IPlugWasmController('NAME_PLACEHOLDER');
         await controller.init({
@@ -61,6 +63,7 @@
 
     pluginElement.addEventListener('uiready', (e) => {
       hostControls.setReady(true);
+      hostControls.refreshLiveEditAvailability();
 
       if (!e.detail.module) {
         isHeadless = true;

--- a/IPlug/WEB/TemplateWasm/scripts/IPlugWasmBundle.js.template
+++ b/IPlug/WEB/TemplateWasm/scripts/IPlugWasmBundle.js.template
@@ -732,6 +732,21 @@ window.Module = window.Module || {
       return this._controller;
     }
 
+    setLiveEditEnabled(enabled) {
+      const pGraphics = this._canvas?._iplugGraphics;
+      const setLiveEdit = this._uiModule?._iplug_set_live_edit;
+
+      if (!pGraphics || typeof setLiveEdit !== 'function') {
+        return false;
+      }
+
+      return setLiveEdit(pGraphics, enabled ? 1 : 0) === 1;
+    }
+
+    isLiveEditAvailable() {
+      return !!this._canvas?._iplugGraphics && typeof this._uiModule?._iplug_set_live_edit === 'function';
+    }
+
     // Getters
     get controller() { return this._controller; }
     get module() { return this._uiModule; }

--- a/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js
+++ b/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js
@@ -75,6 +75,7 @@
       <div class="vu-bar-container"><div id="vuOutR" class="vu-bar"></div></div>
     </div>
 
+    <button id="liveEditBtn" class="live-edit-btn hidden" title="Toggle live layout edit" aria-pressed="false">Edit</button>
     <button id="fullscreenBtn" title="Fullscreen">&#9974;</button>
     <div id="pluginParams" class="plugin-params hidden"></div>
   </div>
@@ -130,6 +131,7 @@
       this.midiInTimeout = null;
       this.midiOutTimeout = null;
       this.midiOutUnsubscribe = null;
+      this.liveEditActive = false;
 
       this.installMarkup();
       this.bindDom();
@@ -183,6 +185,7 @@
       this.midiOutSelect = document.getElementById('midiOutSelect');
       this.midiInLed = document.getElementById('midiInLed');
       this.midiOutLed = document.getElementById('midiOutLed');
+      this.liveEditBtn = document.getElementById('liveEditBtn');
     }
 
     bindEvents() {
@@ -204,6 +207,7 @@
         if (this.fileSource) this.fileSource.loop = this.loopCheck.checked;
       });
       this.fullscreenBtn.addEventListener('click', () => this.toggleFullscreen());
+      this.liveEditBtn.addEventListener('click', () => this.toggleLiveEdit());
       this.midiInSelect.addEventListener('change', () => this.connectMidiInput(this.midiInSelect.value));
       this.midiOutSelect.addEventListener('change', () => this.connectMidiOutput(this.midiOutSelect.value));
     }
@@ -216,6 +220,28 @@
       if (!this.status) return;
       this.status.textContent = text || '';
       this.status.classList.toggle('hidden', !this.options.showStatus && !text);
+    }
+
+    refreshLiveEditAvailability() {
+      const available = this.options.isLiveEditAvailable ? Boolean(this.options.isLiveEditAvailable()) : false;
+      this.liveEditBtn.classList.toggle('hidden', !available);
+
+      if (!available && this.liveEditActive) {
+        this.liveEditActive = false;
+        this.liveEditBtn.setAttribute('aria-pressed', 'false');
+        this.liveEditBtn.classList.remove('active');
+      }
+    }
+
+    toggleLiveEdit() {
+      if (!this.options.setLiveEditEnabled) return;
+
+      const next = !this.liveEditActive;
+      if (!this.options.setLiveEditEnabled(next)) return;
+
+      this.liveEditActive = next;
+      this.liveEditBtn.setAttribute('aria-pressed', String(next));
+      this.liveEditBtn.classList.toggle('active', next);
     }
 
     getCapabilities() {

--- a/IPlug/WEB/TemplateWasm/styles/style.css
+++ b/IPlug/WEB/TemplateWasm/styles/style.css
@@ -141,6 +141,21 @@ iplug-NAME_PLACEHOLDER_LC.resizable {
   color: white;
 }
 
+.live-edit-btn {
+  background: #333;
+  color: #aaa;
+}
+
+.live-edit-btn:hover {
+  background: #444;
+  color: white;
+}
+
+.live-edit-btn.active {
+  background: #3b82f6;
+  color: white;
+}
+
 /* Control sections (collapsible groups) */
 .control-section {
   display: flex;

--- a/Scripts/cmake/FindiPlug2.cmake
+++ b/Scripts/cmake/FindiPlug2.cmake
@@ -40,6 +40,8 @@ endif()
 
 # Include WAM/Web/Wasm modules for Emscripten builds
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  option(IPLUG2_WASM_LIVE_EDIT "Enable IGraphics live edit in Wasm builds" OFF)
+
   include(${CMAKE_CURRENT_LIST_DIR}/WAM.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/WEB.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/WAMDist.cmake)

--- a/Scripts/cmake/WASMUI.cmake
+++ b/Scripts/cmake/WASMUI.cmake
@@ -77,6 +77,9 @@ if(NOT TARGET iPlug2::WasmUI)
 
   # UI module exported functions
   set(WASM_UI_EXPORTS "'_malloc','_free','_main','_iplug_fsready','_iplug_syncfs','_iplug_popup_menu_selected'")
+  if(IPLUG2_WASM_LIVE_EDIT)
+    string(APPEND WASM_UI_EXPORTS ",'_iplug_set_live_edit'")
+  endif()
   set(WASM_UI_OPT)
   if(IPLUG2_WASM_UI_OPTIMIZATION)
     set(WASM_UI_OPT "$<$<NOT:$<CONFIG:Debug>>:${IPLUG2_WASM_UI_OPTIMIZATION}>")
@@ -110,6 +113,15 @@ if(NOT TARGET iPlug2::WasmUI)
     # Force-include GLES2 header so GL types are defined before NanoVG
     -include GLES2/gl2.h
   )
+
+  if(IPLUG2_WASM_LIVE_EDIT)
+    target_compile_definitions(iPlug2::WasmUI INTERFACE IPLUG_LIVE_EDIT=1)
+    if(IPLUG2_WASM_UI_OPTIMIZATION STREQUAL "-O0")
+      target_compile_definitions(iPlug2::WasmUI INTERFACE IPLUG_LIVE_EDIT_CLASS_NAME=1)
+    else()
+      target_compile_definitions(iPlug2::WasmUI INTERFACE "$<$<CONFIG:Debug>:IPLUG_LIVE_EDIT_CLASS_NAME=1>")
+    endif()
+  endif()
 
   target_link_libraries(iPlug2::WasmUI INTERFACE iPlug2::IPlug)
 endif()

--- a/Scripts/cmake/WEB.cmake
+++ b/Scripts/cmake/WEB.cmake
@@ -70,6 +70,9 @@ if(NOT TARGET iPlug2::Web)
 
   # Web controller exported functions
   set(WEB_EXPORTS "'_malloc','_free','_main','_iplug_fsready','_iplug_syncfs','_iplug_popup_menu_selected'")
+  if(IPLUG2_WASM_LIVE_EDIT)
+    string(APPEND WEB_EXPORTS ",'_iplug_set_live_edit'")
+  endif()
 
   # Emscripten link flags for Web controller
   # - BINARYEN_ASYNC_COMPILATION=1: Async compilation (can run on main thread)
@@ -96,6 +99,10 @@ if(NOT TARGET iPlug2::Web)
     # Force-include GLES2 header so GL types are defined before NanoVG
     -include GLES2/gl2.h
   )
+
+  if(IPLUG2_WASM_LIVE_EDIT)
+    target_compile_definitions(iPlug2::Web INTERFACE IPLUG_LIVE_EDIT=1)
+  endif()
 
   target_link_libraries(iPlug2::Web INTERFACE iPlug2::IPlug)
 endif()


### PR DESCRIPTION
## Summary

- Allows `IGraphicsLiveEdit` to compile in Release-style Wasm builds when `IPLUG_LIVE_EDIT` is defined.
- Adds a Wasm live-edit bridge that posts JSON events for control changes, additions, deletions, and selection changes.
- Exports `_iplug_set_live_edit` so a host shell can toggle live edit at runtime.
- Adds `IPLUG2_WASM_LIVE_EDIT` CMake opt-in and wires the Wasm template Edit button plus custom-element API.

## Impact

This lets IDE/agent hosts using the WebAssembly UI build observe user layout edits in the browser without pulling in unrelated popup-menu or stale Wasm plumbing from the source commits.

## Validation

- `git diff --check`
- `cmake --build build-wasm/IPlugEffect --target IPlugEffect-wasm-ui`
- configured `/private/tmp/iplug-liveedit-check` with `-DIPLUG2_WASM_LIVE_EDIT=ON`
- `cmake --build /private/tmp/iplug-liveedit-check --target IPlugEffect-wasm-ui`
- `cmake --build /private/tmp/iplug-liveedit-check --target IPlugEffect-wasm-ui-dist`