### PR TITLE
Add WASM host controls in dist scripts

### DIFF
--- a/Examples/IPlugChunks/scripts/makedist-wasm.sh
+++ b/Examples/IPlugChunks/scripts/makedist-wasm.sh
@@ -194,6 +194,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugControls/scripts/makedist-wasm.sh
+++ b/Examples/IPlugControls/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html

--- a/Examples/IPlugConvoEngine/scripts/makedist-wasm.sh
+++ b/Examples/IPlugConvoEngine/scripts/makedist-wasm.sh
@@ -232,6 +232,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html

--- a/Examples/IPlugDrumSynth/scripts/makedist-wasm.sh
+++ b/Examples/IPlugDrumSynth/scripts/makedist-wasm.sh
@@ -195,6 +195,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugEffect/scripts/makedist-wasm.sh
+++ b/Examples/IPlugEffect/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html

--- a/Examples/IPlugInstrument/scripts/makedist-wasm.sh
+++ b/Examples/IPlugInstrument/scripts/makedist-wasm.sh
@@ -194,6 +194,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugMidiEffect/scripts/makedist-wasm.sh
+++ b/Examples/IPlugMidiEffect/scripts/makedist-wasm.sh
@@ -194,6 +194,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugResponsiveUI/scripts/makedist-wasm.sh
+++ b/Examples/IPlugResponsiveUI/scripts/makedist-wasm.sh
@@ -195,6 +195,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugSideChain/scripts/makedist-wasm.sh
+++ b/Examples/IPlugSideChain/scripts/makedist-wasm.sh
@@ -195,6 +195,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugSurroundEffect/scripts/makedist-wasm.sh
+++ b/Examples/IPlugSurroundEffect/scripts/makedist-wasm.sh
@@ -195,6 +195,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html

--- a/Examples/IPlugVisualizer/scripts/makedist-wasm.sh
+++ b/Examples/IPlugVisualizer/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html

--- a/Tests/IGraphicsStressTest/scripts/makedist-wasm.sh
+++ b/Tests/IGraphicsStressTest/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html

--- a/Tests/IGraphicsTest/scripts/makedist-wasm.sh
+++ b/Tests/IGraphicsTest/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html

--- a/Tests/MetaParamTest/scripts/makedist-wasm.sh
+++ b/Tests/MetaParamTest/scripts/makedist-wasm.sh
@@ -213,6 +213,9 @@ cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template sc
 sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" scripts/$PROJECT_NAME-processor.js
 sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" scripts/$PROJECT_NAME-processor.js
 
+# Copy shared host controls
+cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js scripts/IPlugWasmHostControls.js
+
 # Copy and process HTML template
 # IMPORTANT: Replace NAME_PLACEHOLDER_LC first (longer match) before NAME_PLACEHOLDER
 cp $IPLUG2_ROOT/IPlug/WEB/TemplateWasm/index.html index.html


### PR DESCRIPTION
## Summary

This updates the Makefile-driven Wasm distribution scripts to stage the shared `IPlugWasmHostControls.js` asset that was externalized from `TemplateWasm/index.html`.

The CMake Wasm dist path already copied this shared host controls file, but the `makedist-wasm.sh` scripts still generated an `index.html` that references `scripts/IPlugWasmHostControls.js` without copying that script into `build-web-wasm/scripts/`.

## Changes

- Copy `IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js` into `build-web-wasm/scripts/` from every example/test `makedist-wasm.sh` path.
- Keep the generated Makefile Wasm payload aligned with the CMake Wasm distribution behavior.

## Validation

- `bash -n` across all modified `makedist-wasm.sh` scripts.
- `git diff --check`.
- `./Examples/IPlugEffect/scripts/makedist-wasm.sh off` completed successfully and produced `scripts/IPlugWasmHostControls.js` in the payload.