### PR TITLE
Add wasm make dist support for WebView examples

### DIFF
--- a/Examples/IPlugP5js/config/IPlugP5js-wasm.mk
+++ b/Examples/IPlugP5js/config/IPlugP5js-wasm.mk
@@ -1,0 +1,21 @@
+# IPLUG2_ROOT should point to the top level IPLUG2 folder from the project folder
+# By default, that is three directories up from /Examples/IPlugP5js/config
+IPLUG2_ROOT = ../../..
+
+include ../../../common-wasm.mk
+
+SRC += $(PROJECT_ROOT)/IPlugP5js.cpp
+
+# DSP module flags
+WASM_DSP_CFLAGS +=
+
+WASM_DSP_LDFLAGS += -O3 -s ASSERTIONS=0
+
+# WebView UI module flags
+WASM_UI_SRC += $(WEBVIEW_SRC)
+
+WASM_UI_CFLAGS += $(WEBVIEW_CFLAGS)
+
+WASM_UI_LDFLAGS += -O3 -s ASSERTIONS=0
+
+WASM_UI_LDFLAGS += $(NANOVG_LDFLAGS)

--- a/Examples/IPlugP5js/projects/IPlugP5js-wasm-dsp.mk
+++ b/Examples/IPlugP5js/projects/IPlugP5js-wasm-dsp.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugP5js-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugP5js-dsp.js
+
+SRC += $(WASM_DSP_SRC)
+CFLAGS += $(WASM_DSP_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_DSP_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_DSP_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugP5js/projects/IPlugP5js-wasm-ui.mk
+++ b/Examples/IPlugP5js/projects/IPlugP5js-wasm-ui.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugP5js-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugP5js-ui.js
+
+SRC += $(WASM_UI_SRC)
+CFLAGS += $(WASM_UI_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_UI_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_UI_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugP5js/scripts/makedist-wasm.sh
+++ b/Examples/IPlugP5js/scripts/makedist-wasm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export IPLUG_WASM_PROJECT_ROOT="$SCRIPT_DIR/.."
+export IPLUG_WASM_IPLUG2_ROOT="$SCRIPT_DIR/../../.."
+
+exec "$IPLUG_WASM_IPLUG2_ROOT/Scripts/makedist-wasm-webview.sh" "$@"

--- a/Examples/IPlugSvelteUI/config/IPlugSvelteUI-wasm.mk
+++ b/Examples/IPlugSvelteUI/config/IPlugSvelteUI-wasm.mk
@@ -1,0 +1,21 @@
+# IPLUG2_ROOT should point to the top level IPLUG2 folder from the project folder
+# By default, that is three directories up from /Examples/IPlugSvelteUI/config
+IPLUG2_ROOT = ../../..
+
+include ../../../common-wasm.mk
+
+SRC += $(PROJECT_ROOT)/IPlugSvelteUI.cpp
+
+# DSP module flags
+WASM_DSP_CFLAGS +=
+
+WASM_DSP_LDFLAGS += -O3 -s ASSERTIONS=0
+
+# WebView UI module flags
+WASM_UI_SRC += $(WEBVIEW_SRC)
+
+WASM_UI_CFLAGS += $(WEBVIEW_CFLAGS)
+
+WASM_UI_LDFLAGS += -O3 -s ASSERTIONS=0
+
+WASM_UI_LDFLAGS += $(NANOVG_LDFLAGS)

--- a/Examples/IPlugSvelteUI/projects/IPlugSvelteUI-wasm-dsp.mk
+++ b/Examples/IPlugSvelteUI/projects/IPlugSvelteUI-wasm-dsp.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugSvelteUI-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugSvelteUI-dsp.js
+
+SRC += $(WASM_DSP_SRC)
+CFLAGS += $(WASM_DSP_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_DSP_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_DSP_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugSvelteUI/projects/IPlugSvelteUI-wasm-ui.mk
+++ b/Examples/IPlugSvelteUI/projects/IPlugSvelteUI-wasm-ui.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugSvelteUI-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugSvelteUI-ui.js
+
+SRC += $(WASM_UI_SRC)
+CFLAGS += $(WASM_UI_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_UI_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_UI_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugSvelteUI/scripts/makedist-wasm.sh
+++ b/Examples/IPlugSvelteUI/scripts/makedist-wasm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export IPLUG_WASM_PROJECT_ROOT="$SCRIPT_DIR/.."
+export IPLUG_WASM_IPLUG2_ROOT="$SCRIPT_DIR/../../.."
+
+exec "$IPLUG_WASM_IPLUG2_ROOT/Scripts/makedist-wasm-webview.sh" "$@"

--- a/Examples/IPlugWebUI/config/IPlugWebUI-wasm.mk
+++ b/Examples/IPlugWebUI/config/IPlugWebUI-wasm.mk
@@ -1,0 +1,21 @@
+# IPLUG2_ROOT should point to the top level IPLUG2 folder from the project folder
+# By default, that is three directories up from /Examples/IPlugWebUI/config
+IPLUG2_ROOT = ../../..
+
+include ../../../common-wasm.mk
+
+SRC += $(PROJECT_ROOT)/IPlugWebUI.cpp
+
+# DSP module flags
+WASM_DSP_CFLAGS +=
+
+WASM_DSP_LDFLAGS += -O3 -s ASSERTIONS=0
+
+# WebView UI module flags
+WASM_UI_SRC += $(WEBVIEW_SRC)
+
+WASM_UI_CFLAGS += $(WEBVIEW_CFLAGS)
+
+WASM_UI_LDFLAGS += -O3 -s ASSERTIONS=0
+
+WASM_UI_LDFLAGS += $(NANOVG_LDFLAGS)

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-wasm-dsp.mk
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-wasm-dsp.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugWebUI-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugWebUI-dsp.js
+
+SRC += $(WASM_DSP_SRC)
+CFLAGS += $(WASM_DSP_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_DSP_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_DSP_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugWebUI/projects/IPlugWebUI-wasm-ui.mk
+++ b/Examples/IPlugWebUI/projects/IPlugWebUI-wasm-ui.mk
@@ -1,0 +1,12 @@
+include ../config/IPlugWebUI-wasm.mk
+
+TARGET = ../build-web-wasm/scripts/IPlugWebUI-ui.js
+
+SRC += $(WASM_UI_SRC)
+CFLAGS += $(WASM_UI_CFLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(WASM_UI_LDFLAGS) \
+-s EXPORTED_FUNCTIONS=$(WASM_UI_EXPORTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SRC)

--- a/Examples/IPlugWebUI/scripts/makedist-wasm.sh
+++ b/Examples/IPlugWebUI/scripts/makedist-wasm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export IPLUG_WASM_PROJECT_ROOT="$SCRIPT_DIR/.."
+export IPLUG_WASM_IPLUG2_ROOT="$SCRIPT_DIR/../../.."
+
+exec "$IPLUG_WASM_IPLUG2_ROOT/Scripts/makedist-wasm-webview.sh" "$@"

--- a/Scripts/makedist-wasm-webview.sh
+++ b/Scripts/makedist-wasm-webview.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# makedist-wasm-webview.sh builds a WebView UI Web version of an iPlug2
+# project using the split wasm DSP/UI approach. Per-project wrappers set
+# IPLUG_WASM_PROJECT_ROOT and IPLUG_WASM_IPLUG2_ROOT before invoking this file.
+#
+# Arguments:
+# 1st argument : either "on" or "off" - whether to launch emrun after compilation
+# 2nd argument : browser - "chrome", "safari", or "firefox"
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PROJECT_ROOT="${IPLUG_WASM_PROJECT_ROOT:-$SCRIPT_DIR/..}"
+IPLUG2_ROOT="${IPLUG_WASM_IPLUG2_ROOT:-$SCRIPT_DIR/..}"
+PROJECT_ROOT="$( cd "$PROJECT_ROOT" >/dev/null 2>&1 && pwd )"
+IPLUG2_ROOT="$( cd "$IPLUG2_ROOT" >/dev/null 2>&1 && pwd )"
+
+PROJECT_NAME="$( basename "$PROJECT_ROOT" )"
+PROJECT_NAME_LC=$(echo "$PROJECT_NAME" | tr '[:upper:]' '[:lower:]')
+EMRUN_BROWSER=chrome
+LAUNCH_EMRUN=1
+
+cd "$PROJECT_ROOT"
+
+if [ "$1" = "off" ]; then
+  LAUNCH_EMRUN=0
+fi
+
+if [ "$#" -ge 2 ]; then
+  EMRUN_BROWSER=${2}
+fi
+
+# Clean/create build directory.
+if [ -d build-web-wasm/.git ]; then
+  # If there's a git repo, only trash generated folders/files.
+  rm -rf build-web-wasm/scripts build-web-wasm/styles build-web-wasm/web
+  rm -f build-web-wasm/index.html build-web-wasm/serve.py
+else
+  rm -rf build-web-wasm
+  mkdir build-web-wasm
+fi
+
+mkdir -p build-web-wasm/scripts
+mkdir -p build-web-wasm/styles
+mkdir -p build-web-wasm/web
+
+echo "============================================================"
+echo "STAGING WEBVIEW RESOURCES"
+echo "============================================================"
+
+if [ -d resources/web ]; then
+  cp -R resources/web/. build-web-wasm/web/
+else
+  echo "WARNING: resources/web does not exist for $PROJECT_NAME"
+fi
+
+echo ""
+echo "============================================================"
+echo "BUILDING DSP WASM MODULE (AudioWorklet)"
+echo "============================================================"
+
+cd "$PROJECT_ROOT/projects"
+emmake make --makefile "$PROJECT_NAME-wasm-dsp.mk"
+
+# Wrap DSP module for AudioWorklet scope.
+cd "$PROJECT_ROOT/build-web-wasm/scripts"
+if [ -f "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/worklet-scope-shim.js" ]; then
+  cat "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/worklet-scope-shim.js" "$PROJECT_NAME-dsp.js" > "$PROJECT_NAME-dsp.tmp.js"
+else
+  echo "// AudioWorklet scope wrapper for iPlug2 Wasm DSP
+var self = globalThis;
+self.location = self.location || { href: 'https://localhost/' };
+var Module = globalThis.Module = globalThis.Module || {};
+" > "$PROJECT_NAME-dsp.tmp.js"
+  cat "$PROJECT_NAME-dsp.js" >> "$PROJECT_NAME-dsp.tmp.js"
+fi
+mv "$PROJECT_NAME-dsp.tmp.js" "$PROJECT_NAME-dsp.js"
+
+cd "$PROJECT_ROOT/projects"
+
+echo ""
+echo "============================================================"
+echo "BUILDING WEBVIEW UI WASM MODULE"
+echo "============================================================"
+
+emmake make --makefile "$PROJECT_NAME-wasm-ui.mk"
+
+cd "$PROJECT_ROOT/build-web-wasm"
+
+echo ""
+echo "============================================================"
+echo "GENERATING JAVASCRIPT BUNDLE"
+echo "============================================================"
+
+MAXNINPUTS=$(python3 "$IPLUG2_ROOT/Scripts/parse_iostr.py" "$PROJECT_ROOT" inputs)
+MAXNOUTPUTS=$(python3 "$IPLUG2_ROOT/Scripts/parse_iostr.py" "$PROJECT_ROOT" outputs)
+
+IS_INSTRUMENT="false"
+if [ "$MAXNINPUTS" -eq "0" ]; then
+  IS_INSTRUMENT="true"
+fi
+
+HOST_RESIZE="false"
+if grep -q "PLUG_HOST_RESIZE 1" "$PROJECT_ROOT/config.h" 2>/dev/null; then
+  HOST_RESIZE="true"
+fi
+
+DOES_MIDI_IN="false"
+if grep -q "PLUG_DOES_MIDI_IN 1" "$PROJECT_ROOT/config.h" 2>/dev/null; then
+  DOES_MIDI_IN="true"
+fi
+
+DOES_MIDI_OUT="false"
+if grep -q "PLUG_DOES_MIDI_OUT 1" "$PROJECT_ROOT/config.h" 2>/dev/null; then
+  DOES_MIDI_OUT="true"
+fi
+
+PLUG_WIDTH=$(sed -nE 's/^#define[[:space:]]+PLUG_WIDTH[[:space:]]+([0-9]+).*/\1/p' "$PROJECT_ROOT/config.h" | head -n 1)
+PLUG_HEIGHT=$(sed -nE 's/^#define[[:space:]]+PLUG_HEIGHT[[:space:]]+([0-9]+).*/\1/p' "$PROJECT_ROOT/config.h" | head -n 1)
+PLUG_WIDTH=${PLUG_WIDTH:-600}
+PLUG_HEIGHT=${PLUG_HEIGHT:-600}
+
+# Copy and process bundle template.
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmBundle.js.template" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/MAXNINPUTS_PLACEHOLDER/$MAXNINPUTS/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/MAXNOUTPUTS_PLACEHOLDER/$MAXNOUTPUTS/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/IS_INSTRUMENT_PLACEHOLDER/$IS_INSTRUMENT/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/HOST_RESIZE_PLACEHOLDER/$HOST_RESIZE/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/HAS_UI_PLACEHOLDER/true/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/DOES_MIDI_IN_PLACEHOLDER/$DOES_MIDI_IN/g" "scripts/$PROJECT_NAME-bundle.js"
+sed -i.bak "s/DOES_MIDI_OUT_PLACEHOLDER/$DOES_MIDI_OUT/g" "scripts/$PROJECT_NAME-bundle.js"
+
+# Copy and process processor template.
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmProcessor.js.template" "scripts/$PROJECT_NAME-processor.js"
+sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" "scripts/$PROJECT_NAME-processor.js"
+sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" "scripts/$PROJECT_NAME-processor.js"
+
+# Copy shared host controls.
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/scripts/IPlugWasmHostControls.js" scripts/IPlugWasmHostControls.js
+
+# Copy and process WebView HTML template.
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/webview.html" index.html
+sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" index.html
+sed -i.bak "s/NAME_PLACEHOLDER/$PROJECT_NAME/g" index.html
+sed -i.bak "s/MAXNINPUTS_PLACEHOLDER/$MAXNINPUTS/g" index.html
+sed -i.bak "s/MAXNOUTPUTS_PLACEHOLDER/$MAXNOUTPUTS/g" index.html
+sed -i.bak "s/IS_INSTRUMENT_PLACEHOLDER/$IS_INSTRUMENT/g" index.html
+sed -i.bak "s/HOST_RESIZE_PLACEHOLDER/$HOST_RESIZE/g" index.html
+sed -i.bak "s/DOES_MIDI_IN_PLACEHOLDER/$DOES_MIDI_IN/g" index.html
+sed -i.bak "s/DOES_MIDI_OUT_PLACEHOLDER/$DOES_MIDI_OUT/g" index.html
+sed -i.bak "s/PLUG_WIDTH_PLACEHOLDER/$PLUG_WIDTH/g" index.html
+sed -i.bak "s/PLUG_HEIGHT_PLACEHOLDER/$PLUG_HEIGHT/g" index.html
+
+# Copy and process CSS/dev server.
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/styles/style.css" styles/style.css
+sed -i.bak "s/NAME_PLACEHOLDER_LC/$PROJECT_NAME_LC/g" styles/style.css
+cp "$IPLUG2_ROOT/IPlug/WEB/TemplateWasm/serve.py" serve.py
+
+# Clean up backup files.
+rm -f *.bak scripts/*.bak styles/*.bak
+
+echo ""
+echo "============================================================"
+echo "BUILD COMPLETE"
+echo "============================================================"
+echo ""
+echo "Output: build-web-wasm/"
+echo ""
+echo "Payload:"
+find . -maxdepth 3 -mindepth 1 -name .git -type d \! -prune -o \! -name .DS_Store -type f -exec du -hs {} \;
+
+echo ""
+echo "============================================================"
+echo "IMPORTANT: Server Requirements"
+echo "============================================================"
+echo "Your server MUST send these headers for SharedArrayBuffer:"
+echo "  Cross-Origin-Opener-Policy: same-origin"
+echo "  Cross-Origin-Embedder-Policy: require-corp"
+echo ""
+echo "Use the staged dev server or another server configured with those headers:"
+echo "  python3 serve.py 8080"
+echo "============================================================"
+
+if [ "$LAUNCH_EMRUN" -eq 1 ]; then
+  echo ""
+  echo "Launching browser with emrun..."
+  emrun --browser "$EMRUN_BROWSER" --no_emrun_detect index.html
+else
+  echo ""
+  echo "Not launching browser (use 'on' argument to launch)"
+fi

--- a/common-wasm.mk
+++ b/common-wasm.mk
@@ -27,6 +27,8 @@ IGRAPHICS_EXTRAS_PATH = $(IGRAPHICS_PATH)/Extras
 IPLUG_EXTRAS_PATH = $(IPLUG_PATH)/Extras
 IPLUG_SYNTH_PATH = $(IPLUG_EXTRAS_PATH)/Synth
 IPLUG_WEB_PATH = $(IPLUG_PATH)/WEB
+WEBVIEW_PATH = $(IPLUG_EXTRAS_PATH)/WebView
+NLOHMANN_PATH = $(DEPS_PATH)/Extras/nlohmann
 NANOVG_PATH = $(DEPS_PATH)/IGraphics/NanoVG/src
 NANOSVG_PATH = $(DEPS_PATH)/IGraphics/NanoSVG/src
 YOGA_PATH = $(DEPS_PATH)/IGraphics/yoga
@@ -45,6 +47,10 @@ IGRAPHICS_SRC = $(IGRAPHICS_PATH)/IGraphics.cpp \
 	$(CONTROLS_PATH)/*.cpp \
 	$(PLATFORMS_PATH)/IGraphicsWeb.cpp
 
+# WebView source files (WebView UI module only)
+WEBVIEW_SRC = $(WEBVIEW_PATH)/IPlugWebViewEditorDelegate.cpp \
+	$(WEBVIEW_PATH)/IPlugWebView_web.cpp
+
 # Include paths (no WAM SDK needed)
 INCLUDE_PATHS = -I$(PROJECT_ROOT) \
 -I$(WDL_PATH) \
@@ -52,6 +58,8 @@ INCLUDE_PATHS = -I$(PROJECT_ROOT) \
 -I$(IPLUG_PATH) \
 -I$(IPLUG_EXTRAS_PATH) \
 -I$(IPLUG_WEB_PATH) \
+-I$(WEBVIEW_PATH) \
+-I$(NLOHMANN_PATH) \
 -I$(IGRAPHICS_PATH) \
 -I$(DRAWING_PATH) \
 -I$(CONTROLS_PATH) \
@@ -93,6 +101,10 @@ WASM_DSP_CFLAGS = -DWASM_DSP_API \
 # UI module CFLAGS - IGraphics and editor
 WASM_UI_CFLAGS = -DWASM_UI_API \
 -DIPLUG_EDITOR=1
+
+# WebView UI module CFLAGS
+WEBVIEW_CFLAGS = -DWEBVIEW_EDITOR_DELEGATE \
+-DNO_IGRAPHICS
 
 # DSP module exports (minimal - JS calls via emscripten bindings)
 WASM_DSP_EXPORTS = "['_malloc', '_free']"


### PR DESCRIPTION
### Motivation
- Provide makefile-based wasm distribution support for examples that use WebView UIs so they can be built with the existing makefile workflows (matching the CMake WebView/wasm support). 
- Reduce duplication by introducing a shared helper that stages WebView resources, builds split DSP/UI wasm modules, and generates the TemplateWasm bundle and HTML/CSS assets.

### Description
- Added a new shared helper script `Scripts/makedist-wasm-webview.sh` that stages `resources/web`, runs per-project `emmake make` for DSP/UI modules, wraps the DSP output for AudioWorklet, and generates bundle/processor/index assets from the TemplateWasm templates.
- Added per-example make wrappers `Examples/{IPlugWebUI,IPlugSvelteUI,IPlugP5js}/scripts/makedist-wasm.sh` which set `IPLUG_WASM_PROJECT_ROOT`/`IPLUG_WASM_IPLUG2_ROOT` and invoke the shared helper.
- Added per-example wasm config files `Examples/*/config/*-wasm.mk` and project makefiles `Examples/*/projects/*-wasm-{dsp,ui}.mk` to declare targets and wire into the shared `common-wasm.mk` build logic for the split DSP/UI wasm approach.
- Extended `common-wasm.mk` with WebView-specific variables and flags: added `WEBVIEW_SRC`, `WEBVIEW_PATH` and include path entries for `nlohmann`, and a `WEBVIEW_CFLAGS` macro that sets `WEBVIEW_EDITOR_DELEGATE` and `NO_IGRAPHICS` for WebView UI wasm builds.

### Testing
- Ran `bash -n` on the shared helper and per-example wrapper scripts to validate shell syntax and it succeeded.
- Performed dry-run builds (`make --makefile <target> -n`) for DSP and UI makefiles in `Examples/IPlugWebUI`, `Examples/IPlugSvelteUI`, and `Examples/IPlugP5js` to validate generated make rules, and the dry-run outputs were produced successfully.
- Executed a fake-`emmake` smoke test that simulates `emmake` to verify the `makedist-wasm.sh` wrappers stage templates and produce the expected `build-web-wasm` assets without requiring Emscripten, and this smoke test passed.
- Note: a full wasm compilation was not performed because `emmake`/`emcc` (Emscripten toolchain) were not available in this environment, so end-to-end wasm builds were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a59d29b48331809b5e15e016e78b)