### PR TITLE
Cmake: allow overriding C++ standard

### DIFF
--- a/Scripts/cmake/IPlug.cmake
+++ b/Scripts/cmake/IPlug.cmake
@@ -12,6 +12,9 @@
 if(NOT DEFINED IPLUG2_CXX_STANDARD)
   set(IPLUG2_CXX_STANDARD 17 CACHE STRING "C++ standard for iPlug2")
 endif()
+if(IPLUG2_CXX_STANDARD LESS 17)
+  message(FATAL_ERROR "iPlug2 requires C++17 or later (IPLUG2_CXX_STANDARD=${IPLUG2_CXX_STANDARD})")
+endif()
 
 # Option to disable deprecation warnings (useful for CI)
 option(IPLUG2_DISABLE_DEPRECATION_WARNINGS "Disable deprecation warnings" ON)

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -33,7 +33,9 @@ if(IPLUG2_TRACER)
   add_compile_definitions(TRACER_BUILD)
 endif()
 
-set(IPLUG2_CXX_STANDARD 17)
+if(NOT DEFINED IPLUG2_CXX_STANDARD)
+  set(IPLUG2_CXX_STANDARD 17 CACHE STRING "C++ standard for iPlug2")
+endif()
 
 # Set C++ standard globally to ensure PCH and all files compile with C++17
 set(CMAKE_CXX_STANDARD ${IPLUG2_CXX_STANDARD})

--- a/iPlug2.cmake
+++ b/iPlug2.cmake
@@ -36,8 +36,11 @@ endif()
 if(NOT DEFINED IPLUG2_CXX_STANDARD)
   set(IPLUG2_CXX_STANDARD 17 CACHE STRING "C++ standard for iPlug2")
 endif()
+if(IPLUG2_CXX_STANDARD LESS 17)
+  message(FATAL_ERROR "iPlug2 requires C++17 or later (IPLUG2_CXX_STANDARD=${IPLUG2_CXX_STANDARD})")
+endif()
 
-# Set C++ standard globally to ensure PCH and all files compile with C++17
+# Set C++ standard globally to ensure PCH and all files compile with the selected C++ standard
 set(CMAKE_CXX_STANDARD ${IPLUG2_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Allows `IPLUG2_CXX_STANDARD` to be overridden by the user instead of being unconditionally forced to 17.

Builds on @svantana's #1367 (fixes #1366):
- Only set `IPLUG2_CXX_STANDARD` to 17 if not already defined, exposing it as a cache variable (consistent with how `CMAKE_OSX_DEPLOYMENT_TARGET` is handled in the same file).
- Added: `FATAL_ERROR` guard if the value is below 17, since iPlug2 relies on C++17 features — fails fast with a clear message instead of cryptic compile errors.
- Updated the stale comment that hardcoded "C++17".

Closes #1366. Supersedes #1367.