### PR TITLE
cmake: allow AAX_SDK_DIR to be overridden for out-of-source AAX SDK

### DIFF
--- a/Scripts/cmake/AAX.cmake
+++ b/Scripts/cmake/AAX.cmake
@@ -11,8 +11,10 @@
 include(${CMAKE_CURRENT_LIST_DIR}/IPlug.cmake)
 
 if(NOT TARGET iPlug2::AAX)
-  # Define SDK path
-  set(AAX_SDK_DIR ${IPLUG_DEPS_DIR}/AAX_SDK)
+  # Define SDK path (allow override for out-of-source AAX SDK)
+  if(NOT DEFINED AAX_SDK_DIR)
+    set(AAX_SDK_DIR ${IPLUG_DEPS_DIR}/AAX_SDK)
+  endif()
 
   # Check if AAX SDK exists (must have CMakeLists.txt, not just placeholder directory)
   if(NOT EXISTS ${AAX_SDK_DIR}/CMakeLists.txt)


### PR DESCRIPTION
Lets projects point at a custom AAX SDK path instead of the in-tree `Dependencies/IPlug/AAX_SDK` location, by guarding the default `set(AAX_SDK_DIR ...)` with `if(NOT DEFINED ...)`. This is useful when you want to keep your own AAX cmake scripts out-of-source rather than committing them to iPlug2.

Picks up the `AAX_SDK_DIR` portion of #1342 by @pressplay-music. The other half of that PR (configurable `IPLUG2_CXX_STANDARD`) already landed via #1371, which left #1342 conflicting — so this extracts the remaining unique change. Closes #1342.