### PR TITLE
Add optional setting for right click context menus

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -352,6 +352,9 @@ public:
    * @return /c true if double clicks should be mapped to single clicks */
   bool GetMouseDblAsSingleClick() const { return mDblAsSingleClick; }
 
+  /** Get whether right click should present host context menu. Useful to provide custom right-click functionality to multi-parameter controls. */
+  bool GetRightClickContextMenu() const {return mRightClickContextMenu; }
+
   /** Shows or hides the IControl.
    * @param hide Set to \c true to hide the control */
   virtual void Hide(bool hide);
@@ -555,6 +558,7 @@ protected:
   bool mDisabled = false;
   bool mDisablePrompt = true;
   bool mDblAsSingleClick = false;
+  bool mRightClickContextMenu = true;
   bool mMouseOverWhenDisabled = false;
   bool mMouseEventsWhenDisabled = false;
   bool mIgnoreMouse = false;

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1009,6 +1009,7 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
 #if defined AAX_API || !defined IGRAPHICS_NO_CONTEXT_MENU
       int valIdx = pCapturedControl->GetValIdxForPos(x, y);
       int paramIdx = pCapturedControl->GetParamIdx((valIdx > kNoValIdx) ? valIdx : 0);
+      bool rightClickMenu = pCapturedControl->GetRightClickContextMenu();
 #endif
         
 #ifdef AAX_API
@@ -1050,7 +1051,7 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
 #endif
 
 #ifndef IGRAPHICS_NO_CONTEXT_MENU
-      if (mod.R && paramIdx > kNoParameter)
+      if (rightClickMenu && mod.R && paramIdx > kNoParameter)
       {
         ReleaseMouseCapture();
         PopupHostContextMenuForParam(pCapturedControl, paramIdx, x, y);


### PR DESCRIPTION
I've been working a lot with multi-parameter custom controls, which makes parameter manipulation and automatic redraws easier to handle. Without the IGRAPHICS_NO_CONTEXT_MENU macro, right clicking a multi-parameter control currently opens the context menu of the first parameter in the list. Aside from special cases, this behavior could be seen as unintended. Additionally, parameters that cannot be automated still consume the right click message and do not pass it to the OnMouseDown() function.

This PR introduces an IControl member variable mRightClickContextMenu that defaults to true, and an update to IGraphics.cpp for interaction with this variable. If the variable is set to false, the host context menu is ignored and the message is instead sent to OnMouseDown. With this addition, custom implementation of right clicks can be added to OnMouseDown to handle multi parameter cases or implement custom functionality.

The implementation is done as minimally as possible, and only addresses management and use of the bool member var. Non-automatable params still consume the right click, but sending the rc message to the IControl might be the logical next step.

I rarely PR, so let me know if there is anything I can improve on for future contributions.