### PR TITLE
CMake: Improve WASM split build

### DIFF
--- a/Scripts/cmake/WASMDist.cmake
+++ b/Scripts/cmake/WASMDist.cmake
@@ -574,6 +574,13 @@ function(iplug_build_wasm_dsp_dist project_name)
       ${project_name}_wasm_dsp_templates
     COMMENT "Building Wasm DSP distribution for ${project_name}"
   )
+
+  # The UI dist helpers add this target to their DEPENDS when it already
+  # exists; handle the opposite call order (UI dist created first) here so
+  # the co-build wiring is order-independent.
+  if(TARGET ${project_name}-wasm-ui-dist)
+    add_dependencies(${project_name}-wasm-ui-dist ${project_name}-wasm-dsp-dist)
+  endif()
 endfunction()
 
 # ============================================================================
@@ -618,6 +625,9 @@ function(iplug_build_wasm_webview_ui_dist project_name)
   )
   if(TARGET ${project_name}_wasm_webview_resources)
     list(APPEND UI_DEPENDS ${project_name}_wasm_webview_resources)
+  endif()
+  if(TARGET ${project_name}-wasm-dsp-dist)
+    list(APPEND UI_DEPENDS ${project_name}-wasm-dsp-dist)
   endif()
 
   add_custom_target(${project_name}-wasm-ui-dist ALL
@@ -679,6 +689,13 @@ function(iplug_build_wasm_ui_dist project_name)
   endif()
   if(TARGET ${project_name}_wasm_resources)
     list(APPEND UI_DEPENDS ${project_name}_wasm_resources)
+  endif()
+  # The UI bundle loads scripts/<name>-dsp.js at runtime, so make sure the
+  # DSP dist (which stages it plus -processor.js) is co-built whenever the
+  # caller has also asked for WASM_DSP. Without this dependency, building
+  # just `<name>-wasm-ui-dist` produces a staged dir that 404s at audio start.
+  if(TARGET ${project_name}-wasm-dsp-dist)
+    list(APPEND UI_DEPENDS ${project_name}-wasm-dsp-dist)
   endif()
 
   add_custom_target(${project_name}-wasm-ui-dist ALL


### PR DESCRIPTION
The split-DSP/UI Wasm refactor (#1355) created a footgun: building only `<name>-wasm-ui-dist` produces a staged dir that looks complete but 404s at audio start, because the bundle controller fetches `scripts/<name>-dsp.js` (and `<name>-processor.js`) at runtime — files only staged by `<name>-wasm-dsp-dist`. The aggregate `<name>-wasm-dist` and the default `all` target are fine, but anyone targeting the UI dist directly (or via tooling that does) hits this.

Make `iplug_build_wasm_ui_dist` / `iplug_build_wasm_webview_ui_dist` add the dsp-dist target to their `DEPENDS` when it exists, so building the UI dist alone always produces a runnable bundle. Projects without `WASM_DSP` are unaffected (`if(TARGET ...)` guard makes it a no-op).