### PR TITLE
VST3 lock fix: only restartComponent(kLatencyChanged) when latency changes

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -249,10 +249,18 @@ void IPlugVST3::SendParameterValueFromUI(int paramIdx, double normalisedValue)
 void IPlugVST3::SetLatency(int latency)
 {
   // N.B. set the latency even if the handler is not yet set
-  
+
+  // Only notify the host when the latency value actually changes. restartComponent()
+  // is expensive, and issuing kLatencyChanged from inside setProcessing()/OnReset()
+  // (which is where SetLatency is commonly reached, e.g. on deactivate/remove) livelocks
+  // some hosts: they receive a restart request while already inside the processing-state
+  // transition and spin (observed as a hang on plugin removal in Renoise). A no-op latency
+  // update must therefore stay silent. GetLatency() still holds the previous value here.
+  const bool changed = (latency != GetLatency());
+
   IPlugProcessor::SetLatency(latency);
 
-  if (componentHandler)
+  if (changed && componentHandler)
   {
     FUnknownPtr<IComponentHandler> handler(componentHandler);
 


### PR DESCRIPTION
IPlugVST3::SetLatency issued restartComponent(kLatencyChanged) on every call whenever a componentHandler was set, even when the latency value was unchanged. SetLatency is commonly reached from OnReset(), which the VST3 processor invokes synchronously inside setProcessing(). Some hosts (Renoise on Windows) livelock when they receive a restart request while already inside the processing-state transition: a worker thread spins in SwitchToThread and
the host hangs on plugin removal (confirmed via stack: setProcessing ->
OnReset -> SetLatency -> restartComponent -> host spin). VST2 is unaffected (no synchronous latency restart callback).

Guard the notification on an actual change to the latency value, which is also the correct VST3 semantics. On removal the latency is unchanged, so the restart is no longer issued and the hang is gone.