### PR TITLE
ReaperExt: add WEB_RESOURCES_DIR to iplug_configure_reaperext()

### DIFF
--- a/Examples/IPlugReaperExtensionWebUI/CMakeLists.txt
+++ b/Examples/IPlugReaperExtensionWebUI/CMakeLists.txt
@@ -55,20 +55,10 @@ iplug_add_target(${PROJECT_NAME} PUBLIC
 )
 
 # Configure as REAPER extension (sets up output, deployment, etc.)
-iplug_configure_reaperext(${PROJECT_NAME} ${PROJECT_NAME})
-
-# Deploy the WebView UI next to the extension so Release builds can load index.html at runtime.
-# (In Debug the extension loads directly from the source tree via __FILE__.) The destination
-# subfolder must match SHARED_RESOURCES_SUBPATH in config.h.
-if(IPLUG_DEPLOY_PLUGINS)
-  iplug_get_default_deploy_path(REAPEREXT)
-  if(IPLUG_DEPLOY_PATH_REAPEREXT)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_directory
-        "${PROJECT_DIR}/resources/web"
-        "${IPLUG_DEPLOY_PATH_REAPEREXT}/IPlugReaperExtensionWebUI"
-      COMMENT "Deploying WebView UI to ${IPLUG_DEPLOY_PATH_REAPEREXT}/IPlugReaperExtensionWebUI"
-      VERBATIM
-    )
-  endif()
-endif()
+# WEB_RESOURCES_DIR deploys the WebView UI next to the extension so Release builds can load
+# index.html at runtime. (In Debug the extension loads from the source tree via __FILE__.)
+# The destination subfolder is the project name, which must match SHARED_RESOURCES_SUBPATH
+# in config.h.
+iplug_configure_reaperext(${PROJECT_NAME} ${PROJECT_NAME}
+  WEB_RESOURCES_DIR ${PROJECT_DIR}/resources/web
+)

--- a/Scripts/cmake/ReaperExt.cmake
+++ b/Scripts/cmake/ReaperExt.cmake
@@ -80,7 +80,13 @@ if(NOT TARGET iPlug2::ReaperExt)
 endif()
 
 # Configure a REAPER extension target
+#
+# iplug_configure_reaperext(<target> <project_name>
+#   [WEB_RESOURCES_DIR <dir>]   # deployed to <UserPlugins>/<project_name>/
+# )
 function(iplug_configure_reaperext target project_name)
+  cmake_parse_arguments(REAPEREXT "" "WEB_RESOURCES_DIR" "" ${ARGN})
+
   target_link_libraries(${target} PUBLIC iPlug2::ReaperExt)
 
   # REAPER only loads extensions whose filename starts with "reaper_"
@@ -133,5 +139,37 @@ function(iplug_configure_reaperext target project_name)
   # Auto-deploy to REAPER UserPlugins if enabled
   if(IPLUG_DEPLOY_PLUGINS)
     iplug_deploy_target(${target} REAPEREXT ${reaper_ext_name})
+
+    # An extension is a bare dylib/DLL with no bundle to carry resources, so a WebView
+    # UI has nowhere to live in a release build. Deploy it alongside the extension, in
+    # <UserPlugins>/<project_name>/, which is where GetResourcePath() based lookups
+    # expect it. Keep <project_name> in step with SHARED_RESOURCES_SUBPATH in config.h.
+    if(REAPEREXT_WEB_RESOURCES_DIR)
+      iplug_get_default_deploy_path(REAPEREXT)
+
+      if("${IPLUG_DEPLOY_PATH_REAPEREXT}" STREQUAL "")
+        message(STATUS "[iPlug2] No REAPER UserPlugins path on this platform, skipping web resources")
+      else()
+        # POST_BUILD commands run in the binary dir, so resolve a relative directory
+        # against the caller's source dir rather than looking for it under the build tree.
+        get_filename_component(web_resources_dir "${REAPEREXT_WEB_RESOURCES_DIR}"
+          ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+        if(NOT IS_DIRECTORY "${web_resources_dir}")
+          message(FATAL_ERROR "iplug_configure_reaperext(${target}): WEB_RESOURCES_DIR "
+            "'${REAPEREXT_WEB_RESOURCES_DIR}' does not exist (looked in ${web_resources_dir})")
+        endif()
+
+        set(web_deploy_path "${IPLUG_DEPLOY_PATH_REAPEREXT}/${project_name}")
+        message(STATUS "[iPlug2] Will deploy ${target} web resources to ${web_deploy_path}")
+
+        add_custom_command(TARGET ${target} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${web_resources_dir}" "${web_deploy_path}"
+          COMMENT "[iPlug2] Deploying ${project_name} web resources"
+          VERBATIM
+        )
+      endif()
+    endif()
   endif()
 endfunction()


### PR DESCRIPTION
A REAPER extension is a bare dylib/DLL with no bundle to carry resources, so an extension with a WebView UI has to deploy `resources/web` next to itself for release builds to find `index.html` at runtime.

`IPlugReaperExtensionWebUI` did that with fifteen lines of `add_custom_command` in its own `CMakeLists.txt`. That is boilerplate every WebView extension needs, and it is easy to lose: a project derived from the example by copying the sources builds and runs fine in debug, then shows "file not found" in release, because the missing piece lives in the build file rather than the code. That is exactly how it went missing in a downstream template, which is what prompted this.

This hoists it into `iplug_configure_reaperext()` behind an optional `WEB_RESOURCES_DIR` argument, and converts the example to use it:

```cmake
iplug_configure_reaperext(${PROJECT_NAME} ${PROJECT_NAME}
  WEB_RESOURCES_DIR ${PROJECT_DIR}/resources/web
)
```

The destination is `<UserPlugins>/<project_name>/`, resolved through `iplug_get_default_deploy_path(REAPEREXT)`, so it honours `IPLUG_REAPEREXT_DEPLOY_PATH` overrides and lands correctly on macOS as well as Windows. It has to agree with `SHARED_RESOURCES_SUBPATH` in `config.h`, which also defaults to the project name.

A relative `WEB_RESOURCES_DIR` is resolved against the caller's source dir, since `POST_BUILD` commands run in the binary dir, and a directory that does not exist is reported at configure time rather than at the end of the first build.

## Testing

Windows, VS2022. `Examples/IPlugReaperExtensionWebUI` built Release with `-DIPLUG_REAPEREXT_DEPLOY_PATH=<scratch>` so the deploy could be inspected without touching an installed REAPER. Deployed layout is identical to what the hand-rolled block produced:

```
<deploy>/reaper_IPlugReaperExtensionWebUI.dll
<deploy>/IPlugReaperExtensionWebUI/index.html
<deploy>/IPlugReaperExtensionWebUI/script.js
```

Path handling checked both ways against a downstream project passing a relative directory:

- `WEB_RESOURCES_DIR resources/web` resolves to the source tree and configures clean
- `WEB_RESOURCES_DIR resources/nope` fails configure with `does not exist (looked in ...)`

Not yet exercised on macOS — the path comes from `iplug_get_default_deploy_path(REAPEREXT)`, which already resolves to `~/Library/Application Support/REAPER/UserPlugins` there, but that arm is untested.
