### PR TITLE
IGraphicsWin: don't gate a file: URL on InternetGetConnectedState

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1687,8 +1687,17 @@ bool IGraphicsWin::OpenURL(const char* url, const char* msgWindowTitle, const ch
   {
     return false;
   }
+  // Connectivity only bears on a NETWORK url. A file: url -- a plugin opening a
+  // manual it extracted next to itself, say -- is on this machine, and gating it
+  // on InternetGetConnectedState meant it silently would not open with no
+  // connection. That API is also unreliable in its own right: VPN-only and some
+  // metered configurations report no connection while http works fine.
+  //
+  // Same split IGraphicsMac and IGraphicsIOS already make on this argument.
+  const bool isNetworkURL = url && strstr(url, "http") != nullptr;
+
   DWORD inetStatus = 0;
-  if (InternetGetConnectedState(&inetStatus, 0))
+  if (!isNetworkURL || InternetGetConnectedState(&inetStatus, 0))
   {
     if (ShellExecuteW(mPlugWnd, L"open", UTF8AsUTF16(url).Get(), 0, 0, SW_SHOWNORMAL) > HINSTANCE(32))
     {


### PR DESCRIPTION
Fixes #1393

### Problem

`IGraphicsWin::OpenURL` asks Windows whether the internet is reachable before handing **any** url to `ShellExecuteW`:

```cpp
DWORD inetStatus = 0;
if (InternetGetConnectedState(&inetStatus, 0))
{
  if (ShellExecuteW(mPlugWnd, L"open", UTF8AsUTF16(url).Get(), 0, 0, SW_SHOWNORMAL) > HINSTANCE(32))
    return true;
}
```

So a plugin opening a *local* document — a manual extracted to the temp directory, say — silently does nothing on a machine with no connection. The caller can't distinguish that from a failed `ShellExecute`, and a HELP button that appears to do nothing just gets clicked again.

`InternetGetConnectedState` is unreliable on its own terms as well: VPN-only and some metered configurations report no connection while http works fine.

### Change

Split network from local before consulting connectivity, so the gate applies only where it's meaningful. This uses the same `strstr(url, "http")` predicate that `IGraphicsMac::OpenURL` and `IGraphicsIOS::OpenURL` already use, so the three platforms agree on what counts as a network url rather than Windows inventing a stricter rule of its own.

One file, +10 −1, no API or behaviour change for http urls.

### Verification

Windows 11, VS 2022 x64, Release. Tested with a plugin whose HELP plaque extracts an embedded guide to the temp directory and opens it through this function: the file is written and the system handler launches. Previously nothing happened when offline.
