### PR TITLE
IGraphicsWin: don't truncate the display scale to int in OpenWindow

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1035,8 +1035,28 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* str, const char* title, E
 void* IGraphicsWin::OpenWindow(void* pParent)
 {
   mParentWnd = (HWND) pParent;
-  int screenScale = GetScaleForHWND(mParentWnd);
-  int x = 0, y = 0, w = WindowWidth() * screenScale, h = WindowHeight() * screenScale;
+  // GetScaleForHWND returns a float, and on Windows the fractional scalings are
+  // the common ones: 125%, 150% and 175% are all offered by the Settings app.
+  // Truncating to int made all three arrive here as 1.0, so the view was created
+  // unscaled and SetScreenScale was told 1.0. Only 100% and 200% survived the cast
+  // intact.
+  //
+  // Nothing stayed wrong: the paint tick in Draw() re-reads the true scale, spots
+  // the disagreement and calls SetScreenScale again, and PlatformResize then grows
+  // the view and its parent to the size they should have had. The end geometry is
+  // the same either way -- measured, not assumed. What the cast cost was a second
+  // pass: SetScreenScale runs OnRescale over every control and DrawResize, and
+  // LayoutUI is called just below here, so all of that happened once at 1.0 and
+  // again at the real scale a frame later.
+  //
+  // The two products below are truncated rather than rounded on purpose:
+  // PlatformResize computes the same WindowWidth() * GetScreenScale() and
+  // truncates, and if these two disagreed it would see a non-zero delta and
+  // resize a window that is already the size it wants.
+  const float screenScale = GetScaleForHWND(mParentWnd);
+  int x = 0, y = 0;
+  int w = static_cast<int>(WindowWidth() * screenScale);
+  int h = static_cast<int>(WindowHeight() * screenScale);
 
   if (mPlugWnd)
   {


### PR DESCRIPTION
Fixes #1394

### Problem

In `IGraphicsWin::OpenWindow`:

```cpp
int screenScale = GetScaleForHWND(mPlugWnd);
```

`GetScaleForHWND` returns a `float`, and Windows offers 125%, 150% and 175% as first-class display scalings — the cast turns all three into `1.0`. The view is created at unscaled size and `SetScreenScale` is told `1.0`. Only 100% and 200% survive.

### Why nothing visibly breaks

This is a redundant-work fix, not a rendering fix, which is presumably why it has gone unnoticed. The paint tick in `Draw()` re-reads the true scale, spots the disagreement and calls `SetScreenScale` again, and `PlatformResize` then grows the view and its parent to the size they should have had. End geometry is identical either way — measured on a 150% display, the standalone's client area is 900x600 for a 600x400 `PLUG_WIDTH`/`PLUG_HEIGHT` both before and after.

What the cast costs is a wasted pass: `SetScreenScale` runs `OnRescale` over every control plus `DrawResize`, and `LayoutUI` is called immediately below, so all of that runs once at `1.0` and again at the real scale a frame later.

### Note on truncation

The two products stay truncated rather than rounded, to match `PlatformResize` — it computes the same `WindowWidth() * GetScreenScale()` and truncates, and if the two disagreed it would see a non-zero delta and resize a window that is already the size it wants.

### Verification

Windows 11, VS 2022 x64, Release, APP/VST3/CLAP: 47/47 in the VST3 SDK validator, 0 failed in clap-validator, and the standalone GUI complete and geometry-unchanged at 150% scaling.
