### PR TITLE
IPlugCLAP: loop stateSave until the whole chunk is written

### DIFF
--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -411,11 +411,29 @@ bool IPlugCLAP::renderSetMode(clap_plugin_render_mode mode) noexcept
 bool IPlugCLAP::stateSave(const clap_ostream* pStream) noexcept
 {
   IByteChunk chunk;
-  
+
   if (!SerializeState(chunk))
     return false;
-  
-  return pStream->write(pStream, chunk.GetData(), chunk.Size()) == chunk.Size();
+
+  // clap_ostream::write() may perform a short write (like POSIX write()) --
+  // it isn't required to write the whole buffer in one call, so this must
+  // loop until every byte is written rather than checking a single call's
+  // return value against the full size.
+  const uint8_t* pData = chunk.GetData();
+  int64_t remaining = chunk.Size();
+
+  while (remaining > 0)
+  {
+    const int64_t written = pStream->write(pStream, pData, static_cast<uint64_t>(remaining));
+
+    if (written <= 0)
+      return false;
+
+    pData += written;
+    remaining -= written;
+  }
+
+  return true;
 }
 
 bool IPlugCLAP::stateLoad(const clap_istream* pStream) noexcept
@@ -431,7 +449,7 @@ bool IPlugCLAP::stateLoad(const clap_istream* pStream) noexcept
 
   if (bytesRead != 0)
     return false;
-      
+
   bool restoredOK = UnserializeState(chunk, 0) >= 0;
   
   if (restoredOK)


### PR DESCRIPTION
Fixes #1395

### Problem

`IPlugCLAP::stateSave` treats `clap_ostream::write` as if it always writes the whole buffer:

```cpp
return pStream->write(pStream, chunk.GetData(), chunk.Size()) == chunk.Size();
```

Per `clap/stream.h`, `write` returns the number of bytes actually written, and the documented contract is that the caller must keep calling it until everything is written — the same semantics as POSIX `write()`. A host that performs a short write (a pipe-backed or size-capped stream, most likely with a large state chunk) gets truncated state written *and* a `false` return, so the save silently produces an unusable chunk.

`stateLoad` on the other side already loops correctly, so the two directions currently disagree about the contract.

### Change

Loop until every byte is written, bailing on `<= 0`. One file, no API change; for any host whose `write` consumes the whole buffer in one call — which is the common case, and why this hasn't bitten before — behaviour is identical.

### Verification

`clap-validator` catches this directly — its `state-buffered-streams` test caps how many bytes the stream accepts per call, which is exactly the short-write case.

Examples/IPlugInstrument, Windows 11, VS 2022 x64, Release, clap-validator 0.3.2:

**Before** (current `master`):

```
- state-buffered-streams: Performs the same state and parameter
    reproducibility check as in 'state-reproducibility-basic', but this time
    the plugin is only allowed to read a small prime number of bytes at a
    time when reloading and resaving the state.
  FAILED: 'clap_plugin_state::save()' returned false when only allowing the
    plugin to write 23 bytes at a time.
```

**After:** `state-buffered-streams` passes; `20 tests run, 16 passed, 0 failed, 4 skipped`.

VST3 unaffected and still 47/47 in the VST3 SDK validator, as expected — this code path is CLAP-only.
