### PR TITLE
IParam: constrain the value before the display-text lookup

### DIFF
--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -271,7 +271,13 @@ void IParam::GetDisplay(double value, bool normalized, WDL_String& str, bool wit
 
   if (withDisplayText)
   {
-    const char* displayText = GetDisplayText(value);
+    // Round to the nearest valid step first (a no-op for non-stepped params):
+    // display texts are keyed to exact stepped values, so an unstepped raw
+    // value (e.g. a host round-tripping an arbitrary double through an enum
+    // param) would otherwise miss the lookup below and fall through to the
+    // numeric formatting further down -- which StringToValue can't parse back
+    // for kTypeEnum/kTypeBool, breaking the ToString/StringToValue round trip.
+    const char* displayText = GetDisplayText(Constrain(value));
 
     if (CStringHasContents(displayText))
     {


### PR DESCRIPTION
Fixes #1396

### Problem

`IParam::GetDisplay` looks up display texts with the raw incoming value:

```cpp
const char* displayText = GetDisplayText(value);
```

and `GetDisplayText` matches on exact equality (`value == pDT->mValue`). But the wrappers call `GetDisplay` with an *arbitrary host-supplied* value, not the parameter's own stepped value:

* `IPlugVST3_Parameter::toString` — `mIPlugParam->GetDisplay(valueNormalized, true, display)`
* `IPlugCLAP::paramsValueToText` — `pParam->GetDisplay(value, isDoubleType, str)`
* `IPlugAU` — `GetParam(pSFV->inParamID)->GetDisplay(*(pSFV->inValue), false, mParamDisplayStr)`

A host asking "what text corresponds to normalized 0.37?" on a 3-value enum gets `FromNormalized` → `0.74`, which matches no display text, so the lookup misses and execution falls through to the numeric formatting at the bottom of the function.

That output is unusable for a stepped param: `StringToValue` refuses to `atof` for `kTypeEnum`/`kTypeBool` (it only maps display texts for those types), so the string this produces cannot be parsed back — the `ToString`/`StringToValue` round trip the hosts rely on is broken for exactly the parameter types display texts exist for.

### Change

Constrain before the lookup:

```cpp
const char* displayText = GetDisplayText(Constrain(value));
```

`Constrain` applies stepping and clipping, so `0.74` becomes `1.0` and matches. It is a no-op for a value that is already valid, and a no-op for non-stepped parameters (no `kFlagStepped`, no rounding). This is also what the value would have become had it gone through `IParam::Set`, so the display now agrees with what setting that value would produce.

### Verification

`clap-validator`'s `param-conversions` test reproduces this on a stock example plugin — Examples/IPlugInstrument, whose `LFO Shape` is an `InitEnum`.

Windows 11, VS 2022 x64, Release, clap-validator 0.3.2:

**Before** (current `master`):

```
- param-conversions: Asserts that value to string and string to value
    conversions are supported for ether all or none of the plugin's
    parameters, and that conversions between values and strings roundtrip
    consistently.
  FAILED: Converting 0.9885933439881882 to a string, back to a value, and
    then back to a string again for parameter 6 ('LFO Shape') results in '1'
    -> 0.0 -> 'Triangle', which is not consistent.
```

The `'1'` there is the numeric fallthrough — the display-text lookup missed, and `StringToValue` then can't parse `'1'` for an enum, so it returns `0.0` and the round trip lands on `'Triangle'`.

**After:** `param-conversions` passes; `20 tests run, 16 passed, 0 failed, 4 skipped`.

Also 47/47 in the VST3 SDK validator, unchanged from before the fix.
