### PR TITLE
cmake: compile resources/main.rc into Windows plugin binaries, not just the app

### DIFF
--- a/Scripts/cmake/IPlugPlugin.cmake
+++ b/Scripts/cmake/IPlugPlugin.cmake
@@ -95,19 +95,25 @@ function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resour
     return()
   endif()
 
-  # APP target (uses add_executable, needs .rc on Windows)
+  # On Windows, resources/main.rc is what embeds resources in a binary: fonts,
+  # images and VS_VERSION_INFO. Plugins need it as much as the app does --
+  # IGraphicsWin looks fonts up in the module that asks for them, so a
+  # .vst3/.clap built without the .rc ships without its fonts.
+  # The RESOURCES mechanism (_iplug_add_resources) only covers macOS bundles.
+  set(_rc_sources "")
+  set(_rc_file "${CMAKE_CURRENT_SOURCE_DIR}/resources/main.rc")
+  if(WIN32 AND EXISTS "${_rc_file}")
+    set(_rc_sources "${_rc_file}")
+    # Tell RC compiler where to find resources (fonts, images, etc.)
+    # The .rc file references files like "Roboto-Regular.ttf" without path
+    set_source_files_properties("${_rc_file}" PROPERTIES
+      COMPILE_FLAGS "/I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/fonts\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/img\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources\""
+    )
+  endif()
+
+  # APP target (uses add_executable)
   if("APP" IN_LIST formats)
-    set(_app_sources ${sources})
-    set(_rc_file "${CMAKE_CURRENT_SOURCE_DIR}/resources/main.rc")
-    if(WIN32 AND EXISTS "${_rc_file}")
-      list(APPEND _app_sources "${_rc_file}")
-      # Tell RC compiler where to find resources (fonts, images, etc.)
-      # The .rc file references files like "Roboto-Regular.ttf" without path
-      set_source_files_properties("${_rc_file}" PROPERTIES
-        COMPILE_FLAGS "/I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/fonts\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources/img\" /I\"${CMAKE_CURRENT_SOURCE_DIR}/resources\""
-      )
-    endif()
-    add_executable(${plugin_name}-app ${_app_sources})
+    add_executable(${plugin_name}-app ${sources} ${_rc_sources})
     iplug_add_target(${plugin_name}-app PUBLIC
       LINK iPlug2::APP ${ui_lib} ${base_lib}
     )
@@ -118,7 +124,7 @@ function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resour
 
   # VST2 (conditional on SDK availability - deprecated)
   if("VST2" IN_LIST formats AND IPLUG2_VST2_SUPPORTED)
-    add_library(${plugin_name}-vst2 MODULE ${sources})
+    add_library(${plugin_name}-vst2 MODULE ${sources} ${_rc_sources})
     iplug_add_target(${plugin_name}-vst2 PUBLIC
       LINK iPlug2::VST2 ${ui_lib} ${base_lib}
     )
@@ -129,7 +135,7 @@ function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resour
 
   # VST3 (always available)
   if("VST3" IN_LIST formats)
-    add_library(${plugin_name}-vst3 MODULE ${sources})
+    add_library(${plugin_name}-vst3 MODULE ${sources} ${_rc_sources})
     iplug_add_target(${plugin_name}-vst3 PUBLIC
       LINK iPlug2::VST3 ${ui_lib} ${base_lib}
     )
@@ -140,7 +146,7 @@ function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resour
 
   # CLAP (conditional on SDK availability)
   if("CLAP" IN_LIST formats AND IPLUG2_CLAP_SUPPORTED)
-    add_library(${plugin_name}-clap MODULE ${sources})
+    add_library(${plugin_name}-clap MODULE ${sources} ${_rc_sources})
     iplug_add_target(${plugin_name}-clap PUBLIC
       LINK iPlug2::CLAP ${ui_lib} ${base_lib}
     )
@@ -151,7 +157,7 @@ function(_iplug_create_desktop_targets plugin_name formats sources ui_lib resour
 
   # AAX (conditional on SDK availability)
   if("AAX" IN_LIST formats AND IPLUG2_AAX_SUPPORTED)
-    add_library(${plugin_name}-aax MODULE ${sources})
+    add_library(${plugin_name}-aax MODULE ${sources} ${_rc_sources})
     iplug_add_target(${plugin_name}-aax PUBLIC
       LINK iPlug2::AAX ${ui_lib} ${base_lib}
     )


### PR DESCRIPTION
Fixes #1398

### Problem

`IPlugPlugin.cmake` compiles `resources/main.rc` into the standalone app only — the `.rc` is appended to `_app_sources` inside the `if("APP" IN_LIST formats)` block, and no plugin target gets it. The `RESOURCES` list doesn't cover it either: `_iplug_add_resources()` sets `MACOSX_PACKAGE_LOCATION`, which is a no-op on Windows.

So everything the `.rc` embeds — fonts, images, `VS_VERSION_INFO` — reaches the `.exe` and nothing else. A plugin looks its fonts up in its **own** module (`IGraphicsWin::LoadPlatformFont` → `LocateResource()` → `EnumResourceNamesW(hInstance, "TTF", ...)`), so a `.vst3`/`.clap` built this way ships without its fonts, `LoadFont()` fails behind a `DBGMSG` that Release never prints, and with NanoVG the missing-font assert compiles out — every label, readout and tooltip renders as nothing in every Windows DAW, silently, while the standalone looks perfect.

The hand-maintained Visual Studio projects already do the right thing — the example `.vcxproj`s compile `..\resources\main.rc` into **every** format (vst3/clap/vst2/aax). Only the CMake path leaves plugins without it.

### Change

Hoist the existing APP-only `.rc` block in `_iplug_create_desktop_targets()` above the per-format targets and add `${_rc_sources}` to each Windows target: APP, VST2, VST3, CLAP, AAX. The RC include flags are unchanged, set once on the source file as before. Off Windows `_rc_sources` stays empty, so macOS bundles and their `Resources/` path are untouched.

One file, +22 −16, no behaviour change for the app or for macOS. As a side effect the `VS_VERSION_INFO` block now reaches the binaries users actually install, so a `.vst3`/`.clap` stops reporting a blank version in Explorer's Details tab.

### Verification

Windows 11, VS 2022 x64 (Build Tools), Release, on a CMake-built plugin using a resource font, against master (5c2df9dce) before/after this change:

* Resource enumeration (`EnumResourceTypesW`, `LOAD_LIBRARY_AS_DATAFILE`):
  * before — `.exe`: `TTF/"ROBOTO-REGULAR.TTF"`, `#16` (version), menus, dialogs; `.vst3` and `.clap`: `#24` (RT_MANIFEST) only
  * after — all three binaries carry `TTF/"ROBOTO-REGULAR.TTF"`, `#16`, and the rest of the `.rc` payload
* VST3 SDK validator: 47 tests passed, 0 failed — identical before and after.
* clap-validator 0.3.2: 20 run / 12 passed / 2 failed / 6 skipped — **identical before and after**; the two failures are pre-existing on master and are exactly the defects #1391 (`state-buffered-streams`) and #1392 (`param-conversions-basic`) address.
* The plugin's own framework-free DSP tests: 15/15.
