### PR TITLE
VST3: mark the preset parameter kIsList as well as kIsProgramChange

### DIFF
--- a/IPlug/VST3/IPlugVST3_Parameter.h
+++ b/IPlug/VST3/IPlugVST3_Parameter.h
@@ -82,7 +82,7 @@ class IPlugVST3PresetParameter : public Steinberg::Vst::Parameter
 {
 public:
   IPlugVST3PresetParameter(int nPresets)
-  : Steinberg::Vst::Parameter(STR16("Preset"), kPresetParam, STR16(""), 0, nPresets - 1, Steinberg::Vst::ParameterInfo::kIsProgramChange)
+  : Steinberg::Vst::Parameter(STR16("Preset"), kPresetParam, STR16(""), 0, nPresets - 1, Steinberg::Vst::ParameterInfo::kIsProgramChange | Steinberg::Vst::ParameterInfo::kIsList)
   {}
   
   Steinberg::Vst::ParamValue toPlain(Steinberg::Vst::ParamValue valueNormalized) const override


### PR DESCRIPTION
Fixes #1399

### Problem

`IPlugVST3PresetParameter` is constructed with `kIsProgramChange` as its only flag:

```cpp
IPlugVST3PresetParameter(int nPresets)
: Steinberg::Vst::Parameter(STR16("Preset"), kPresetParam, STR16(""), 0, nPresets - 1, Steinberg::Vst::ParameterInfo::kIsProgramChange)
```

The VST3 SDK expects a program-change parameter to also declare itself a list parameter, and the SDK validator's "Scan Parameters" test reports the mismatch on every iPlug2 VST3 built with `VST3_PRESET_LIST` and presets:

```
Info:  =>Parameter 000 (id=65537) is kIsProgramChange, but not a kIsList!
```

The parameter already *behaves* as a list — stepCount is `nPresets - 1`, one discrete step per program, fronting the `ProgramListWithPitchNames` the controller registers on the root unit — it just doesn't say so, and every VST3_PRESET_LIST plugin ships with a validator diagnostic it can't fix from plugin code.

### Change

Add `kIsList` to the flags. This changes how the parameter describes itself, not how it behaves; generic host UIs that honour `kIsList` get a stepped control for the preset switcher, which is what it is. Same pattern as `IPlugVST3BypassParameter`, which already declares `kIsList`.

One line.

### Verification

Windows 11, VS 2022 x64, Release, on a CMake-built plugin defining `VST3_PRESET_LIST` with a factory preset, against master (5c2df9dce): before, the SDK validator prints the diagnostic above in "Scan Parameters"; after, the diagnostic is gone and the run is 47 tests passed, 0 failed, same as before.
