### PR TITLE
APP: parse the Windows command line with CommandLineToArgvW, not strtok

### DIFF
--- a/IPlug/APP/IPlugAPP_main.cpp
+++ b/IPlug/APP/IPlugAPP_main.cpp
@@ -27,6 +27,9 @@ using namespace iplug;
 #include <shellapi.h>
 
 // Include stb_image_write for PNG saving
+// STBIW_WINDOWS_UTF8 makes it open UTF-8 paths via _wfopen, matching the
+// UTF-8 screenshot path parsed from the wide command line below
+#define STBIW_WINDOWS_UTF8
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "../../Dependencies/IGraphics/STB/stb_image_write.h"
 
@@ -153,26 +156,24 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdPa
 
     IPlugAPPHost* pAppHost = IPlugAPPHost::Create();
 
-    // Parse command line arguments
-    if (lpszCmdParam && lpszCmdParam[0])
+    // Parse command line arguments from the wide command line, so that quoted
+    // arguments (paths with spaces) and non-ASCII characters survive
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argv)
     {
-      char* args = _strdup(lpszCmdParam);
-      char* token = strtok(args, " ");
-      while (token)
+      for (int i = 1; i < argc; i++)
       {
-        if (strcmp(token, "--screenshot") == 0)
+        if (wcscmp(argv[i], L"--screenshot") == 0 && (i + 1) < argc)
         {
-          token = strtok(nullptr, " ");
-          if (token)
-            pAppHost->SetScreenshotPath(token);
+          pAppHost->SetScreenshotPath(UTF16AsUTF8(argv[++i]).Get());
         }
-        else if (strcmp(token, "--no-io") == 0)
+        else if (wcscmp(argv[i], L"--no-io") == 0)
         {
           pAppHost->SetNoIO(true);
         }
-        token = strtok(nullptr, " ");
       }
-      free(args);
+      LocalFree(argv);
     }
 
     // Screenshot mode implies --no-io


### PR DESCRIPTION
Fixes #1400

### Problem

`WinMain` parses the ANSI `lpszCmdParam` by splitting on single spaces with `strtok`. Quoting is never honoured and the ANSI code page mangles anything outside it before parsing begins, so:

```
MyPlug.exe --screenshot "C:\path with spaces\shot.png"
```

exits 0 and writes nothing — the quoted path arrives as `"C:\path`, `with`, `spaces\shot.png"`. Most Windows user-profile paths contain spaces, so the automated-screenshot flow added in #1323 silently fails for them, while the same flag works on macOS through `main()`'s proper `argv`.

### Change

Parse the wide command line: `CommandLineToArgvW(GetCommandLineW(), &argc)` applies standard Windows quoting rules and keeps UTF-16 intact; each argument is matched per-token the way the macOS `main()` already does, and the screenshot path is converted with the existing `UTF16AsUTF8` helper (`shellapi.h` was already included). Also define `STBIW_WINDOWS_UTF8` so `stb_image_write` opens the UTF-8 path via `_wfopen` — without it a non-ASCII path would survive parsing and then fail in ANSI `fopen` instead.

One file, parsing only; `--no-io` and unquoted arguments behave exactly as before.

### Verification

Windows 11, VS 2022 x64, Release, CMake-built iPlug2 app, against master (5c2df9dce):

* before — `--screenshot "…\path with spaces\shot.png"`: exit 0, no file written anywhere; `--screenshot shot.png` (no spaces, cwd-relative): PNG written, confirming only the parsing loses the path.
* after — the spaced, quoted path gets its PNG; a path containing non-ASCII (CJK) characters gets its PNG; the space-free control still works; `--no-io` still parses.
